### PR TITLE
Consistent use of random_double() instead of drand48() in all books and src code

### DIFF
--- a/TheNextWeek/book/ch01.md.html
+++ b/TheNextWeek/book/ch01.md.html
@@ -86,7 +86,7 @@ to camera because for now it is not allowed to move; it just sends out rays over
             ray get_ray(float s, float t) {
                 vec3 rd = lens_radius*random_in_unit_disk();
                 vec3 offset = u * rd.x() + v * rd.y();
-                float time = time0 + drand48()*(time1-time0);
+                float time = time0 + random_double()*(time1-time0);
                 return ray(
                     origin + offset,
                     lower_left_corner + s*horizontal + t*vertical - origin - offset,
@@ -187,7 +187,7 @@ Be sure that in the materials you have the scattered rays be at the time of the 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If we take the example diffuse spheres from scene at the end of the last book and make them move
-from their centers at `time==0`, to `center + vec3(0, 0.5*drand48(), 0)` at `time==1`, with the
+from their centers at `time==0`, to `center + vec3(0, 0.5*random_double(), 0)` at `time==1`, with the
 camera aperture open over that frame.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -198,18 +198,18 @@ camera aperture open over that frame.
         int i = 1;
         for (int a = -10; a < 10; a++) {
             for (int b = -10; b < 10; b++) {
-                float choose_mat = drand48();
-                vec3 center(a+0.9*drand48(),0.2,b+0.9*drand48());
+                float choose_mat = random_double();
+                vec3 center(a+0.9*random_double(),0.2,b+0.9*random_double());
                 if ((center-vec3(4,0.2,0)).length() > 0.9) {
                     if (choose_mat < 0.8) {  // diffuse
                         list[i++] = new moving_sphere(
                             center,
-                            center+vec3(0, 0.5*drand48(), 0),
+                            center+vec3(0, 0.5*random_double(), 0),
                             0.0, 1.0, 0.2,
                             new lambertian(
-                                vec3(drand48()*drand48(),
-                                     drand48()*drand48(),
-                                     drand48()*drand48())
+                                vec3(random_double()*random_double(),
+                                     random_double()*random_double(),
+                                     random_double()*random_double())
                             )
                         );
                     }
@@ -217,10 +217,10 @@ camera aperture open over that frame.
                         list[i++] = new sphere(
                             center, 0.2,
                             new metal(
-                                vec3(0.5*(1 + drand48()),
-                                     0.5*(1 + drand48()),
-                                     0.5*(1 + drand48())),
-                                0.5*drand48()
+                                vec3(0.5*(1 + random_double()),
+                                     0.5*(1 + random_double()),
+                                     0.5*(1 + random_double())),
+                                0.5*random_double()
                             )
                         );
                     }

--- a/TheNextWeek/book/ch02.md.html
+++ b/TheNextWeek/book/ch02.md.html
@@ -375,7 +375,7 @@ This yields:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     bvh_node::bvh_node(hitable **l, int n, float time0, float time1) {
-        int axis = int(3*drand48());
+        int axis = int(3*random_double());
         if (axis == 0)
            qsort(l, n, sizeof(hitable *), box_x_compare);
         else if (axis == 1)

--- a/TheNextWeek/book/ch04.md.html
+++ b/TheNextWeek/book/ch04.md.html
@@ -51,13 +51,13 @@ code to make it all happen:
     static vec3* perlin_generate() {
         float * p = new float[256];
         for (int i = 0; i < 256; ++i)
-            p[i] = drand48();
+            p[i] = random_double();
         return p;
     }
 
     void permute(int *p, int n) {
         for (int i = n-1; i > 0; i--) {
-            int target = int(drand48()*(i+1));
+            int target = int(random_double()*(i+1));
             int tmp = p[i];
             p[i] = p[target];
             p[target] = tmp;
@@ -229,7 +229,7 @@ exactly uniform:
     static vec3* perlin_generate() {
         vec3 * p = new vec3[256];
         for ( int i = 0; i < 256; ++i )
-            p[i] = unit_vector(vec3(-1 + 2*drand48(), -1 + 2*drand48(), -1 + 2*drand48()));
+            p[i] = unit_vector(vec3(-1 + 2*random_double(), -1 + 2*random_double(), -1 + 2*random_double()));
         return p;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/TheNextWeek/book/ch08.md.html
+++ b/TheNextWeek/book/ch08.md.html
@@ -80,7 +80,7 @@ And the hit function is:
 
         // Print occasional samples when debugging. To enable, set enableDebug true.
         const enableDebug = false;
-        bool debugging = enableDebug && drand48() < 0.00001;
+        bool debugging = enableDebug && random_double() < 0.00001;
 
         hit_record rec1, rec2;
 
@@ -98,7 +98,7 @@ And the hit function is:
                     rec1.t = 0;
 
                 float distance_inside_boundary = (rec2.t - rec1.t)*r.direction().length();
-                float hit_distance = -(1/density) * log(drand48());
+                float hit_distance = -(1/density) * log(random_double());
 
                 if (hit_distance < distance_inside_boundary) {
 

--- a/TheNextWeek/book/ch09.md.html
+++ b/TheNextWeek/book/ch09.md.html
@@ -29,7 +29,7 @@ why we get caustics and subsurface for free. It’s a double-edged design decisi
                 float z0 = -1000 + j*w;
                 float y0 = 0;
                 float x1 = x0 + w;
-                float y1 = 100*(drand48()+0.01);
+                float y1 = 100*(random_double()+0.01);
                 float z1 = z0 + w;
                 boxlist[b++] = new box(vec3(x0,y0,z0), vec3(x1,y1,z1), ground);
             }
@@ -60,7 +60,7 @@ why we get caustics and subsurface for free. It’s a double-edged design decisi
         int ns = 1000;
         for (int j = 0; j < ns; j++) {
             boxlist2[j] = new sphere(
-                vec3(165*drand48(), 165*drand48(), 165*drand48()), 10, white);
+                vec3(165*random_double(), 165*random_double(), 165*random_double()), 10, white);
         }
         list[l++] =   new translate(new rotate_y(
             new bvh_node(boxlist2,ns, 0.0, 1.0), 15), vec3(-100,270,395));

--- a/TheNextWeek/src/bvh.h
+++ b/TheNextWeek/src/bvh.h
@@ -13,6 +13,7 @@
 #define BVHH
 
 #include "hitable.h"
+#include "random.h"
 
 class bvh_node : public hitable  {
     public:
@@ -97,7 +98,7 @@ int box_z_compare (const void * a, const void * b)
 
 
 bvh_node::bvh_node(hitable **l, int n, float time0, float time1) {
-    int axis = int(3*drand48());
+    int axis = int(3*random_double());
     if (axis == 0)
        qsort(l, n, sizeof(hitable *), box_x_compare);
     else if (axis == 1)

--- a/TheNextWeek/src/camera.h
+++ b/TheNextWeek/src/camera.h
@@ -11,12 +11,14 @@
 
 #ifndef CAMERAH
 #define CAMERAH
+
+#include "random.h"
 #include "ray.h"
 
 vec3 random_in_unit_disk() {
     vec3 p;
     do {
-        p = 2.0*vec3(drand48(),drand48(),0) - vec3(1,1,0);
+        p = 2.0*vec3(random_double(),random_double(),0) - vec3(1,1,0);
     } while (dot(p,p) >= 1.0);
     return p;
 }
@@ -44,7 +46,7 @@ class camera {
         ray get_ray(float s, float t) {
             vec3 rd = lens_radius*random_in_unit_disk();
             vec3 offset = u * rd.x() + v * rd.y();
-            float time = time0 + drand48()*(time1-time0);
+            float time = time0 + random_double()*(time1-time0);
             return ray(origin + offset, lower_left_corner + s*horizontal + t*vertical - origin - offset, time); 
         }
 

--- a/TheNextWeek/src/constant_medium.h
+++ b/TheNextWeek/src/constant_medium.h
@@ -12,6 +12,7 @@
 //==================================================================================================
 
 #include "hitable.h"
+#include "random.h"
 #include <float.h>
 
 
@@ -34,7 +35,7 @@ bool constant_medium::hit(const ray& r, float t_min, float t_max, hit_record& re
 
     // Print occasional samples when debugging. To enable, set enableDebug true.
     const bool enableDebug = false;
-    bool debugging = enableDebug && drand48() < 0.00001;
+    bool debugging = enableDebug && random_double() < 0.00001;
 
     hit_record rec1, rec2;
 
@@ -52,7 +53,7 @@ bool constant_medium::hit(const ray& r, float t_min, float t_max, hit_record& re
                 rec1.t = 0;
 
             float distance_inside_boundary = (rec2.t - rec1.t) * r.direction().length();
-            float hit_distance = -(1/density) * log(drand48());
+            float hit_distance = -(1/density) * log(random_double());
 
             if (hit_distance < distance_inside_boundary) {
 

--- a/TheNextWeek/src/main.cc
+++ b/TheNextWeek/src/main.cc
@@ -22,6 +22,7 @@
 #include "aarect.h"
 #include "constant_medium.h"
 #include "texture.h"
+#include "random.h"
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
@@ -74,7 +75,7 @@ hitable *final() {
             float z0 = -1000 + j*w;
             float y0 = 0;
             float x1 = x0 + w;
-            float y1 = 100*(drand48()+0.01);
+            float y1 = 100*(random_double()+0.01);
             float z1 = z0 + w;
             boxlist[b++] = new box(vec3(x0,y0,z0), vec3(x1,y1,z1), ground);
         }
@@ -100,7 +101,7 @@ hitable *final() {
     list[l++] =  new sphere(vec3(220,280, 300), 80, new lambertian( pertext ));
     int ns = 1000;
     for (int j = 0; j < ns; j++) {
-        boxlist2[j] = new sphere(vec3(165*drand48(), 165*drand48(), 165*drand48()), 10, white);
+        boxlist2[j] = new sphere(vec3(165*random_double(), 165*random_double(), 165*random_double()), 10, white);
     }
     list[l++] =   new translate(new rotate_y(new bvh_node(boxlist2,ns, 0.0, 1.0), 15), vec3(-100,270,395));
     return new hitable_list(list,l);
@@ -133,7 +134,7 @@ hitable *cornell_final() {
     list[i++] = new sphere(vec3(120, 50, 205), 50, new lambertian(pertext));
     int ns = 10000;
     for (int j = 0; j < ns; j++) {
-        boxlist[j] = new sphere(vec3(165*drand48(), 330*drand48(), 165*drand48()), 10, white);
+        boxlist[j] = new sphere(vec3(165*random_double(), 330*random_double(), 165*random_double()), 10, white);
     }
     list[i++] =   new translate(new rotate_y(new bvh_node(boxlist,ns, 0.0, 1.0), 15), vec3(265,0,295));
     */
@@ -227,15 +228,15 @@ hitable *random_scene() {
     int i = 1;
     for (int a = -10; a < 10; a++) {
         for (int b = -10; b < 10; b++) {
-            float choose_mat = drand48();
-            vec3 center(a+0.9*drand48(),0.2,b+0.9*drand48()); 
+            float choose_mat = random_double();
+            vec3 center(a+0.9*random_double(),0.2,b+0.9*random_double()); 
             if ((center-vec3(4,0.2,0)).length() > 0.9) { 
                 if (choose_mat < 0.8) {  // diffuse
-                    list[i++] = new moving_sphere(center, center+vec3(0,0.5*drand48(), 0), 0.0, 1.0, 0.2, new lambertian(new constant_texture(vec3(drand48()*drand48(), drand48()*drand48(), drand48()*drand48()))));
+                    list[i++] = new moving_sphere(center, center+vec3(0,0.5*random_double(), 0), 0.0, 1.0, 0.2, new lambertian(new constant_texture(vec3(random_double()*random_double(), random_double()*random_double(), random_double()*random_double()))));
                 }
                 else if (choose_mat < 0.95) { // metal
                     list[i++] = new sphere(center, 0.2,
-                            new metal(vec3(0.5*(1 + drand48()), 0.5*(1 + drand48()), 0.5*(1 + drand48())),  0.5*drand48()));
+                            new metal(vec3(0.5*(1 + random_double()), 0.5*(1 + random_double()), 0.5*(1 + random_double())),  0.5*random_double()));
                 }
                 else {  // glass
                     list[i++] = new sphere(center, 0.2, new dielectric(1.5));
@@ -285,8 +286,8 @@ int main() {
         for (int i = 0; i < nx; i++) {
             vec3 col(0, 0, 0);
             for (int s=0; s < ns; s++) {
-                float u = float(i+drand48())/ float(nx);
-                float v = float(j+drand48())/ float(ny);
+                float u = float(i+random_double())/ float(nx);
+                float v = float(j+random_double())/ float(ny);
                 ray r = cam.get_ray(u, v);
                 vec3 p = r.point_at_parameter(2.0);
                 col += color(r, world,0);

--- a/TheNextWeek/src/material.h
+++ b/TheNextWeek/src/material.h
@@ -17,6 +17,7 @@ struct hit_record;
 #include "ray.h"
 #include "hitable.h"
 #include "texture.h"
+#include "random.h"
 
 
 float schlick(float cosine, float ref_idx) {
@@ -46,7 +47,7 @@ vec3 reflect(const vec3& v, const vec3& n) {
 vec3 random_in_unit_sphere() {
     vec3 p;
     do {
-        p = 2.0*vec3(drand48(),drand48(),drand48()) - vec3(1,1,1);
+        p = 2.0*vec3(random_double(),random_double(),random_double()) - vec3(1,1,1);
     } while (dot(p,p) >= 1.0);
     return p;
 }
@@ -133,7 +134,7 @@ class dielectric : public material {
                 scattered = ray(rec.p, reflected, r_in.time());
                 reflect_prob = 1.0;
              }
-             if (drand48() < reflect_prob) {
+             if (random_double() < reflect_prob) {
                 scattered = ray(rec.p, reflected, r_in.time());
              }
              else {

--- a/TheNextWeek/src/perlin.h
+++ b/TheNextWeek/src/perlin.h
@@ -13,7 +13,7 @@
 #define PERLINH
 
 #include "vec3.h"
-
+#include "random.h"
 
 inline float perlin_interp(vec3 c[2][2][2], float u, float v, float w) {
     float uu = u*u*(3-2*u);
@@ -67,13 +67,13 @@ class perlin {
 static vec3* perlin_generate() {
     vec3 * p = new vec3[256];
     for ( int i = 0; i < 256; ++i )
-        p[i] = unit_vector(vec3(-1 + 2*drand48(), -1 + 2*drand48(), -1 + 2*drand48()));
+        p[i] = unit_vector(vec3(-1 + 2*random_double(), -1 + 2*random_double(), -1 + 2*random_double()));
     return p;
 }
 
 void permute(int *p, int n) {
     for (int i = n-1; i > 0; i--) {
-        int target = int(drand48()*(i+1));
+        int target = int(random_double()*(i+1));
         int tmp = p[i];
         p[i] = p[target];
         p[target] = tmp;

--- a/TheNextWeek/src/random.h
+++ b/TheNextWeek/src/random.h
@@ -1,0 +1,10 @@
+#ifndef RANDOMH
+#define RANDOMH
+
+#include <cstdlib>
+
+double random_double() {
+    return rand() / (RAND_MAX + 1.0);
+}
+
+#endif

--- a/TheRestOfYourLife/book/ch01.md.html
+++ b/TheRestOfYourLife/book/ch01.md.html
@@ -32,13 +32,14 @@ centered at the origin:
     #include <math.h>
     #include <stdlib.h>
     #include <iostream>
+    #include "random.h"
 
     int main() {
         int N = 1000;
         int inside_circle = 0;
         for (int i = 0; i < nx; i++) {
-            float x = 2*drand48() - 1;
-            float y = 2*drand48() - 1;
+            float x = 2*random_double() - 1;
+            float y = 2*random_double() - 1;
             if(x*x + y*y < 1)
                 inside_circle++;
         }
@@ -54,14 +55,15 @@ If we change the program to run forever and just print out a running estimate:
     #include <math.h>
     #include <stdlib.h>
     #include <iostream>
+    #include "random.h"
 
     int main() {
         int inside_circle = 0;
         int runs = 0;
         while (true) {
             runs++;
-            float x = 2*drand48() - 1;
-            float y = 2*drand48() - 1;
+            float x = 2*random_double() - 1;
+            float y = 2*random_double() - 1;
             if(x*x + y*y < 1)
                 inside_circle++;
 
@@ -84,6 +86,7 @@ because we need to know the grid. Let’s take a hundred million and try it both
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #include <iostream>
+    #include "random.h"
 
     int main() {
         int inside_circle = 0;
@@ -91,12 +94,12 @@ because we need to know the grid. Let’s take a hundred million and try it both
         int sqrt_N = 10000;
         for (int i = 0; i < sqrt_N; i++) {
             for (int j = 0; j < sqrt_N; j++) {
-                float x = 2*drand48() - 1;
-                float y = 2*drand48() - 1;
+                float x = 2*random_double() - 1;
+                float y = 2*random_double() - 1;
                 if (x*x + y*y < 1)
                     inside_circle++;
-                x = 2*((i + drand48()) / sqrt_N) - 1;
-                y = 2*((j + drand48()) / sqrt_N) - 1;
+                x = 2*((i + random_double()) / sqrt_N) - 1;
+                y = 2*((j + random_double()) / sqrt_N) - 1;
                 if (x*x + y*y < 1)
                     inside_circle_stratified++;
             }

--- a/TheRestOfYourLife/book/ch02.md.html
+++ b/TheRestOfYourLife/book/ch02.md.html
@@ -32,7 +32,7 @@ This suggests a MC approach:
         int N = 1000000;
         float sum;
         for (int i = 0; i < N; i++) {
-            float x = 2*drand48();
+            float x = 2*random_double();
             sum += x*x;
         }
         std::cout << "I =" << 2*sum/N << "\n";
@@ -106,7 +106,7 @@ So $p(r) = r/2$.
 How do we generate a random number with that pdf $p(r)$? For that we will need some more machinery.
 Don’t worry this doesn’t go on forever!
 
-Given a random number from `d = drand48()` that is uniform and between 0 and 1, we should be able
+Given a random number from `d = random_double()` that is uniform and between 0 and 1, we should be able
 to find some function $f(d)$ that gives us what we want. Suppose $e = f(d) = d^2$. That is no
 longer a uniform _pdf_ . The _pdf_ of $e$ will be bigger near 0 than it is near 1 (squaring a
 number between 0 and 1 makes it smaller). To take this general observation to a function, we need
@@ -128,7 +128,7 @@ function arguments in a program. If we evaluate $P$ at $x = 0.5$ , we get:
 
 This says _the probability that a random variable with our pdf is less than one is 25%_ . This
 gives rise to a clever observation that underlies many methods to generate non-uniform random
-numbers. We want a function `f()` that when we call it as `f(drand48())` we get a return value with
+numbers. We want a function `f()` that when we call it as `f(random_double())` we get a return value with
 a pdf $\frac{x^2}{4}$ . We don’t know what that is, but we do know that 25% of what it returns
 should be less than 1, and 75% should be above one. If $f()$ is increasing, then we would expect
 $f(0.25) = 1.0$. This can be generalized to figure out $f()$ for every possible input:
@@ -143,7 +143,7 @@ The -1 means “inverse function”. Ugly notation, but standard. For our purpos
 if we have pdf $p()$ and its cumulative distribution function $P()$ , then if we do this to a random
 number we’ll get what we want:
 
-  $$ e = P^-1 (drand48()) $$
+  $$ e = P^-1 (random_double()) $$
 
 For our _pdf_ $p(x) = x/2$ , and corresponding $P(x)$ , we need to compute the inverse of $P$. If
 we have
@@ -156,9 +156,9 @@ we get the inverse by solving for $x$ in terms of $y$:
 
 Thus our random number with density $p$ we get by:
 
-  $$ e = \sqrt{4*drand48()} $$
+  $$ e = \sqrt{4*random_double()} $$
 
-Note that does range 0 to 2 as hoped, and if we send in $1/4$ for `drand48()` we get 1 as desired.
+Note that does range 0 to 2 as hoped, and if we send in $1/4$ for `random_double()` we get 1 as desired.
 
 We can now sample our old integral
 
@@ -172,6 +172,7 @@ weighting function should be proportional to $1/pdf$ . In fact it is exactly $1/
     #include <math.h>
     #include <stdlib.h>
     #include <iostream>
+    #include "random.h"
 
     inline float pdf(float x) {
         return 0.5*x;
@@ -183,7 +184,7 @@ weighting function should be proportional to $1/pdf$ . In fact it is exactly $1/
         int N = 1000000;
         float sum;
         for (int i = 0; i < N; i++) {
-            float x = sqrt(4*drand48());
+            float x = sqrt(4*random_double());
             sum += x*x / pdf(x);
         }
         std::cout << "I =" << sum/N << "\n";
@@ -195,12 +196,13 @@ convergence. This is why using a carefully chosen non-uniform pdf is usually cal
 sampling_.
 
 If we take that same code with uniform samples so the pdf = $1/2$ over the range [0,2] we can use
-the machinery to get `x = 2*drand48()` and the code is:
+the machinery to get `x = 2*random_double()` and the code is:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #include <math.h>
     #include <stdlib.h>
     #include <iostream>
+    #include "random.h"
 
     inline float pdf(float x) {
         return 0.5;
@@ -212,7 +214,7 @@ the machinery to get `x = 2*drand48()` and the code is:
         int N = 1000000;
         float sum;
         for (int i = 0; i < N; i++) {
-            float x = 2*drand48();
+            float x = 2*random_double();
             sum += x*x / pdf(x);
         }
         std::cout << "I =" << sum/N << "\n";
@@ -241,6 +243,7 @@ sample we get:
     #include <math.h>
     #include <stdlib.h>
     #include <iostream>
+    #include "random.h"
 
     inline float pdf(float x) {
         return 3*x*x/8;
@@ -252,7 +255,7 @@ sample we get:
         int N = 1;
         float sum;
         for (int i = 0; i < N; i++) {
-            float x = pow(8*drand48(), 1./3.);
+            float x = pow(8*random_double(), 1./3.);
             sum += x*x / pdf(x);
         }
         std::cout << "I =" << sum/N << "\n";

--- a/TheRestOfYourLife/book/ch03.md.html
+++ b/TheRestOfYourLife/book/ch03.md.html
@@ -26,7 +26,7 @@ uniform random samples in a unit sphere:
     vec3 random_in_unit_sphere() {
         vec3 p;
         do {
-            p = 2.0*vec3(drand48(),drand48(),drand48()) - vec3(1,1,1);
+            p = 2.0*vec3(random_double(),random_double(),random_double()) - vec3(1,1,1);
         } while (dot(p,p) >= 1.0);
         return p;
     }
@@ -38,7 +38,7 @@ To get points on a unit sphere we can just normalize the vector to those points:
     vec3 random_on_unit_sphere() {
         vec3 p;
         do {
-            p = 2.0*vec3(drand48(),drand48(),drand48()) - vec3(1,1,1);
+            p = 2.0*vec3(random_double(),random_double(),random_double()) - vec3(1,1,1);
         } while (dot(p,p) >= 1.0);
         return unit_vector(p);
     }

--- a/TheRestOfYourLife/book/ch06.md.html
+++ b/TheRestOfYourLife/book/ch06.md.html
@@ -74,8 +74,8 @@ We can output some of these:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     int main() {
         for (int i = 0; i < 200; i++) {
-            float r1 = drand48();
-            float r2 = drand48();
+            float r1 = random_double();
+            float r2 = random_double();
             float x = cos(2*M_PI*r1)*2*sqrt(r2*(1-r2));
             float y = sin(2*M_PI*r1)*2*sqrt(r2*(1-r2));
             float z = 1 - r2;
@@ -111,8 +111,8 @@ which is $\cos^3 / (1/(2 \pi))$, and we can test this:
         int N = 1000000;
         float sum = 0.0;
         for (int i = 0; i < N; i++) {
-            float r1 = drand48();
-            float r2 = drand48();
+            float r1 = random_double();
+            float r2 = random_double();
             float x = cos(2*M_PI*r1)*2*sqrt(r2*(1-r2));
             float y = sin(2*M_PI*r1)*2*sqrt(r2*(1-r2));
             float z = 1 - r2;
@@ -141,8 +141,8 @@ Let’s also start generating them as random vectors:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     inline vec3 random_cosine_direction() {
-        float r1 = drand48();
-        float r2 = drand48();
+        float r1 = random_double();
+        float r2 = random_double();
         float z = sqrt(1-r2);
         float phi = 2*M_PI*r1;
         float x = cos(phi)*sqrt(r2);

--- a/TheRestOfYourLife/book/ch08.md.html
+++ b/TheRestOfYourLife/book/ch08.md.html
@@ -52,9 +52,9 @@ math and get the concept, we can add it (see the highlighted region):
             float pdf;
             vec3 albedo;
             if (depth < 50 && rec.mat_ptr->scatter(r, rec, albedo, scattered, pdf)) {
-                vec3 on_light = vec3(213 + drand48()*(343-213),
+                vec3 on_light = vec3(213 + random_double()*(343-213),
                                      554,
-                                     227 + drand48()*(332-227));
+                                     227 + random_double()*(332-227));
                 vec3 to_light = on_light - rec.p;
                 float distance_squared = to_light.squared_length();
                 to_light.make_unit_vector();

--- a/TheRestOfYourLife/book/ch09.md.html
+++ b/TheRestOfYourLife/book/ch09.md.html
@@ -22,7 +22,7 @@ How would we instrument our code to do that? There is a very important detail th
 quite as easy as one might expect. Choosing the random direction is simple:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    if (drand48() < 0.5)
+    if (random_double() < 0.5)
         Pick direction according to pdf_reflection
     else
         Pick direction according to pdf_light
@@ -166,8 +166,8 @@ And we change `xz_rect` to implement those functions:
                     return 0;
             }
             virtual vec3 random(const vec3& o) const {
-                vec3 random_point = vec3(x0 + drand48()*(x1-x0), k,
-                    z0 + drand48()*(z1-z0));
+                vec3 random_point = vec3(x0 + random_double()*(x1-x0), k,
+                    z0 + random_double()*(z1-z0));
                 return random_point - o;
             }
             material  *mp;
@@ -219,7 +219,7 @@ class is straightforward:
                 return 0.5 * p[0]->value(direction) + 0.5 *p[1]->value(direction);
             }
             virtual vec3 generate() const {
-                if (drand48() < 0.5)
+                if (random_double() < 0.5)
                     return p[0]->generate();
                 else
                     return p[1]->generate();

--- a/TheRestOfYourLife/book/ch11.md.html
+++ b/TheRestOfYourLife/book/ch11.md.html
@@ -275,8 +275,8 @@ With the utility function:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     inline vec3 random_to_sphere(float radius, float distance_squared) {
-        float r1 = drand48();
-        float r2 = drand48();
+        float r1 = random_double();
+        float r2 = random_double();
         float z = 1 + r2*(sqrt(1-radius*radius/distance_squared) - 1);
         float phi = 2*M_PI*r1;
         float x = cos(phi)*sqrt(1-z*z);
@@ -295,8 +295,8 @@ We can first try just sampling the sphere rather than the light:
         for (int i = 0; i < nx; i++) {
             vec3 col(0, 0, 0);
             for (int s=0; s < ns; s++) {
-                float u = float(i+drand48())/ float(nx);
-                float v = float(j+drand48())/ float(ny);
+                float u = float(i+random_double())/ float(nx);
+                float v = float(j+random_double())/ float(ny);
                 ray r = cam->get_ray(u, v);
                 vec3 p = r.point_at_parameter(2.0);
                 col += color(r, world, glass_sphere, 0);
@@ -324,7 +324,7 @@ think both tactics would work fine, but I will go with instrumenting `hitable_li
     }
 
     vec3 hitable_list::random(const vec3& o) const {
-        int index = int(drand48() * list_size);
+        int index = int(random_double() * list_size);
         return list[ index ]->random(o);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -343,8 +343,8 @@ We assemble a list to pass in to `color`.
         for (int i = 0; i < nx; i++) {
             vec3 col(0, 0, 0);
             for (int s=0; s < ns; s++) {
-                float u = float(i+drand48())/ float(nx);
-                float v = float(j+drand48())/ float(ny);
+                float u = float(i+random_double())/ float(nx);
+                float v = float(j+random_double())/ float(ny);
                 ray r = cam->get_ray(u, v);
                 vec3 p = r.point_at_parameter(2.0);
                 col += color(r, world, &hlist, 0);
@@ -386,8 +386,8 @@ And we can insert that in the main loop:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     for (int s=0; s < ns; s++) {
-        float u = float(i+drand48())/ float(nx);
-        float v = float(j+drand48())/ float(ny);
+        float u = float(i+random_double())/ float(nx);
+        float v = float(j+random_double())/ float(ny);
         ray r = cam->get_ray(u, v);
         vec3 p = r.point_at_parameter(2.0);
         col += de_nan(color(r, world, &hlist, 0));

--- a/TheRestOfYourLife/src/aarect.h
+++ b/TheRestOfYourLife/src/aarect.h
@@ -12,6 +12,7 @@
 #ifndef AARECTH
 #define AARECTH
 
+#include "random.h"
 #include "hitable.h"
 
 class xy_rect: public hitable  {
@@ -47,7 +48,7 @@ class xz_rect: public hitable  {
                 return 0;
         }
         virtual vec3 random(const vec3& o) const { 
-            vec3 random_point = vec3(x0 + drand48()*(x1-x0), k,  z0 + drand48()*(z1-z0)); 
+            vec3 random_point = vec3(x0 + random_double()*(x1-x0), k,  z0 + random_double()*(z1-z0)); 
             return random_point - o;
         }
         material  *mp;

--- a/TheRestOfYourLife/src/camera.h
+++ b/TheRestOfYourLife/src/camera.h
@@ -11,12 +11,14 @@
 
 #ifndef CAMERAH
 #define CAMERAH
+
+#include "random.h"
 #include "ray.h"
 
 vec3 random_in_unit_disk() {
     vec3 p;
     do {
-        p = 2.0*vec3(drand48(),drand48(),0) - vec3(1,1,0);
+        p = 2.0*vec3(random_double(),random_double(),0) - vec3(1,1,0);
     } while (dot(p,p) >= 1.0);
     return p;
 }
@@ -44,7 +46,7 @@ class camera {
         ray get_ray(float s, float t) {
             vec3 rd = lens_radius*random_in_unit_disk();
             vec3 offset = u * rd.x() + v * rd.y();
-            float time = time0 + drand48()*(time1-time0);
+            float time = time0 + random_double()*(time1-time0);
             return ray(origin + offset, lower_left_corner + s*horizontal + t*vertical - origin - offset, time);
         }
 

--- a/TheRestOfYourLife/src/constant_medium.h
+++ b/TheRestOfYourLife/src/constant_medium.h
@@ -13,6 +13,7 @@
 #define CMEDH
 
 #include "hitable.h"
+#include "random.h"
 #include <float.h>
 
 class constant_medium : public hitable  {
@@ -27,7 +28,7 @@ class constant_medium : public hitable  {
 };
 
 bool constant_medium::hit(const ray& r, float t_min, float t_max, hit_record& rec) const {
-    bool db = (drand48() < 0.00001);
+    bool db = (random_double() < 0.00001);
     db = false;
     hit_record rec1, rec2;
     if (boundary->hit(r, -FLT_MAX, FLT_MAX, rec1)) { 
@@ -42,7 +43,7 @@ bool constant_medium::hit(const ray& r, float t_min, float t_max, hit_record& re
             if (rec1.t < 0)
                 rec1.t = 0;
             float distance_inside_boundary = (rec2.t - rec1.t)*r.direction().length();
-            float hit_distance = -(1/density)*log(drand48()); 
+            float hit_distance = -(1/density)*log(random_double()); 
             if (hit_distance < distance_inside_boundary) {
             if (db) std::cerr << "hit_distance = " <<  hit_distance << "\n";
                 rec.t = rec1.t + hit_distance / r.direction().length(); 

--- a/TheRestOfYourLife/src/coscubed.cc
+++ b/TheRestOfYourLife/src/coscubed.cc
@@ -12,13 +12,14 @@
 #include <iostream>
 #include <math.h>
 
+#include "random.h"
 
 int main() {
     int N = 1000000;
     float sum = 0.0;
     for (int i = 0; i < N; i++) {
-        float r1 = drand48();
-        float r2 = drand48();
+        float r1 = random_double();
+        float r2 = random_double();
         float x = cos(2*M_PI*r1)*2*sqrt(r2*(1-r2));
         float y = sin(2*M_PI*r1)*2*sqrt(r2*(1-r2));
         float z = 1 - r2;

--- a/TheRestOfYourLife/src/cosine_density.cc
+++ b/TheRestOfYourLife/src/cosine_density.cc
@@ -9,6 +9,7 @@
 // with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==================================================================================================
 
+#include "random.h"
 #include "vec3.h"
 
 #include <iostream>
@@ -16,8 +17,8 @@
 
 
 inline vec3 random_cosine_direction() {
-    float r1 = drand48();
-    float r2 = drand48();
+    float r1 = random_double();
+    float r2 = random_double();
     float z = sqrt(1-r2);
     float phi = 2*M_PI*r1;
     float x = cos(phi)*sqrt(r2);

--- a/TheRestOfYourLife/src/foomaterial.h
+++ b/TheRestOfYourLife/src/foomaterial.h
@@ -17,6 +17,7 @@ struct hit_record;
 #include "ray.h"
 #include "hitable.h"
 #include "texture.h"
+#include "random.h"
 
 
 float schlick(float cosine, float ref_idx) {
@@ -46,7 +47,7 @@ vec3 reflect(const vec3& v, const vec3& n) {
 vec3 random_in_unit_sphere() {
     vec3 p;
     do {
-        p = 2.0*vec3(drand48(),drand48(),drand48()) - vec3(1,1,1);
+        p = 2.0*vec3(random_double(),random_double(),random_double()) - vec3(1,1,1);
     } while (dot(p,p) >= 1.0);
     return p;
 }
@@ -144,7 +145,7 @@ class dielectric : public material {
                 scattered = ray(rec.p, reflected);
                 reflect_prob = 1.0;
              }
-             if (drand48() < reflect_prob) {
+             if (random_double() < reflect_prob) {
                 scattered = ray(rec.p, reflected);
              }
              else {

--- a/TheRestOfYourLife/src/hitable_list.h
+++ b/TheRestOfYourLife/src/hitable_list.h
@@ -13,6 +13,7 @@
 #define HITABLELISTH
 
 #include "hitable.h"
+#include "random.h"
 
 class hitable_list: public hitable  {
     public:
@@ -36,7 +37,7 @@ float hitable_list::pdf_value(const vec3& o, const vec3& v) const {
 }
 
 vec3 hitable_list::random(const vec3& o) const {
-        int index = int(drand48() * list_size);
+        int index = int(random_double() * list_size);
         return list[ index ]->random(o);
 }
 

--- a/TheRestOfYourLife/src/main.cc
+++ b/TheRestOfYourLife/src/main.cc
@@ -26,6 +26,7 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 #include "pdf.h"
+#include "random.h"
 
 inline vec3 de_nan(const vec3& c) {
     vec3 temp = c;
@@ -109,8 +110,8 @@ int main() {
         for (int i = 0; i < nx; i++) {
             vec3 col(0, 0, 0);
             for (int s=0; s < ns; s++) {
-                float u = float(i+drand48())/ float(nx);
-                float v = float(j+drand48())/ float(ny);
+                float u = float(i+random_double())/ float(nx);
+                float v = float(j+random_double())/ float(ny);
                 ray r = cam->get_ray(u, v);
                 vec3 p = r.point_at_parameter(2.0);
                 col += de_nan(color(r, world, &hlist, 0));

--- a/TheRestOfYourLife/src/material.h
+++ b/TheRestOfYourLife/src/material.h
@@ -19,6 +19,7 @@ struct hit_record;
 #include "texture.h"
 #include "onb.h"
 #include "pdf.h"
+#include "random.h"
 
 
 
@@ -92,7 +93,7 @@ class dielectric : public material {
              else {
                 reflect_prob = 1.0;
              }
-             if (drand48() < reflect_prob) {
+             if (random_double() < reflect_prob) {
                 srec.specular_ray = ray(hrec.p, reflected);
              }
              else {
@@ -211,7 +212,7 @@ class dielectric : public material {
                 scattered = ray(rec.p, reflected);
                 reflect_prob = 1.0;
              }
-             if (drand48() < reflect_prob) {
+             if (random_double() < reflect_prob) {
                 scattered = ray(rec.p, reflected);
              }
              else {

--- a/TheRestOfYourLife/src/msc.h
+++ b/TheRestOfYourLife/src/msc.h
@@ -2,12 +2,3 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
 #define MAXFLOAT FLT_MAX
-
-#include <random>
-static double drand48()
-{
-	static std::random_device seed_gen;
-	static std::mt19937 engine(seed_gen());
-	static std::uniform_real_distribution<> dist(0.0, 1.0);
-	return dist(engine);
-}

--- a/TheRestOfYourLife/src/pdf.h
+++ b/TheRestOfYourLife/src/pdf.h
@@ -12,11 +12,12 @@
 #ifndef PDFH
 #define PDFH
 #include "onb.h"
+#include "random.h"
 
 
 inline vec3 random_cosine_direction() {
-    float r1 = drand48();
-    float r2 = drand48();
+    float r1 = random_double();
+    float r2 = random_double();
     float z = sqrt(1-r2);
     float phi = 2*M_PI*r1;
     float x = cos(phi)*sqrt(r2);
@@ -25,8 +26,8 @@ inline vec3 random_cosine_direction() {
 }
 
 inline vec3 random_to_sphere(float radius, float distance_squared) {
-    float r1 = drand48();
-    float r2 = drand48();
+    float r1 = random_double();
+    float r2 = random_double();
     float z = 1 + r2*(sqrt(1-radius*radius/distance_squared) - 1);
     float phi = 2*M_PI*r1;
     float x = cos(phi)*sqrt(1-z*z);
@@ -38,7 +39,7 @@ inline vec3 random_to_sphere(float radius, float distance_squared) {
 vec3 random_in_unit_sphere() {
     vec3 p;
     do {
-        p = 2.0*vec3(drand48(),drand48(),drand48()) - vec3(1,1,1);
+        p = 2.0*vec3(random_double(),random_double(),random_double()) - vec3(1,1,1);
     } while (dot(p,p) >= 1.0);
     return p;
 }
@@ -89,7 +90,7 @@ class mixture_pdf : public pdf {
             return 0.5 * p[0]->value(direction) + 0.5 *p[1]->value(direction);
         }
         virtual vec3 generate() const {
-            if (drand48() < 0.5)
+            if (random_double() < 0.5)
                 return p[0]->generate();
             else
                 return p[1]->generate();

--- a/TheRestOfYourLife/src/perlin.h
+++ b/TheRestOfYourLife/src/perlin.h
@@ -13,6 +13,7 @@
 #define PERLINH
 
 #include "vec3.h"
+#include "random.h"
 
 
 inline float perlin_interp(vec3 c[2][2][2], float u, float v, float w) {
@@ -67,13 +68,13 @@ class perlin {
 static vec3* perlin_generate() {
     vec3 * p = new vec3[256];
     for ( int i = 0; i < 256; ++i )
-        p[i] = unit_vector(vec3(-1 + 2*drand48(), -1 + 2*drand48(), -1 + 2*drand48()));
+        p[i] = unit_vector(vec3(-1 + 2*random_double(), -1 + 2*random_double(), -1 + 2*random_double()));
     return p;
 }
 
 void permute(int *p, int n) {
     for (int i = n-1; i > 0; i--) {
-        int target = int(drand48()*(i+1));
+        int target = int(random_double()*(i+1));
         int tmp = p[i];
         p[i] = p[target];
         p[target] = tmp;

--- a/TheRestOfYourLife/src/pi.cc
+++ b/TheRestOfYourLife/src/pi.cc
@@ -12,6 +12,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include <iostream>
+#include "random.h"
 
 int main() {
     int inside_circle = 0;
@@ -19,12 +20,12 @@ int main() {
     int sqrt_N = 30000;
     for (int i = 0; i < sqrt_N; i++) {
         for (int j = 0; j < sqrt_N; j++) {
-            float x = 2*drand48() - 1;
-            float y = 2*drand48() - 1;
+            float x = 2*random_double() - 1;
+            float y = 2*random_double() - 1;
             if (x*x + y*y < 1)
                 inside_circle++;
-            x = 2*((i + drand48()) / sqrt_N) - 1;
-            y = 2*((j + drand48()) / sqrt_N) - 1;
+            x = 2*((i + random_double()) / sqrt_N) - 1;
+            y = 2*((j + random_double()) / sqrt_N) - 1;
             if (x*x + y*y < 1)
                 inside_circle_stratified++;
         }

--- a/TheRestOfYourLife/src/random.h
+++ b/TheRestOfYourLife/src/random.h
@@ -1,0 +1,10 @@
+#ifndef RANDOMH
+#define RANDOMH
+
+#include <cstdlib>
+
+double random_double() {
+    return rand() / (RAND_MAX + 1.0);
+}
+
+#endif

--- a/TheRestOfYourLife/src/sphereimp.cc
+++ b/TheRestOfYourLife/src/sphereimp.cc
@@ -13,11 +13,12 @@
 #include <stdlib.h>
 #include <iostream>
 #include "vec3.h"
+#include "random.h"
 
 vec3 random_on_unit_sphere() {
     vec3 p;
     do {
-        p = 2.0*vec3(drand48(),drand48(),drand48()) - vec3(1,1,1);
+        p = 2.0*vec3(random_double(),random_double(),random_double()) - vec3(1,1,1);
     } while (dot(p,p) >= 1.0);
     return unit_vector(p);
 }

--- a/TheRestOfYourLife/src/sphereplot.cc
+++ b/TheRestOfYourLife/src/sphereplot.cc
@@ -11,12 +11,13 @@
 
 #include <iostream>
 #include <math.h>
+#include "random.h"
 
 
 int main() {
     for (int i = 0; i < 2000; i++) {
-        float r1 = drand48();
-        float r2 = drand48();
+        float r1 = random_double();
+        float r2 = random_double();
         float x = cos(2*M_PI*r1)*2*sqrt(r2*(1-r2));
         float y = sin(2*M_PI*r1)*2*sqrt(r2*(1-r2));
         float z = 1 - 2*r2;

--- a/TheRestOfYourLife/src/x2.cc
+++ b/TheRestOfYourLife/src/x2.cc
@@ -12,6 +12,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include <iostream>
+#include "random.h"
 
 int main() {
     int inside_circle = 0;
@@ -19,7 +20,7 @@ int main() {
     int N = 1000000;
     float sum;
     for (int i = 0; i < N; i++) {
-            float x = 2*drand48();
+            float x = 2*random_double();
             sum += x*x;
     }
     std::cout << "I =" << 2*sum/N << "\n";

--- a/TheRestOfYourLife/src/x2imp.cc
+++ b/TheRestOfYourLife/src/x2imp.cc
@@ -12,6 +12,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include <iostream>
+#include "random.h"
 
 inline float pdf(float x) {
     return  3*x*x/8;
@@ -23,7 +24,7 @@ int main() {
     int N = 1;
     float sum;
     for (int i = 0; i < N; i++) {
-            float x = pow(8*drand48(), 1./3.);
+            float x = pow(8*random_double(), 1./3.);
             sum += x*x / pdf(x);
     }
     std::cout << "I =" << sum/N << "\n";


### PR DESCRIPTION
Changes all uses of `drand48()` to custom `random_double()`, which is currently implemented using `rand()`, in all books and src code. 

I have tested this on macOS by compiling and running all main functions in each project (including stuff like sphereimp.cc) and verifying the output. For main functions that render images, I have compared output images. Everything looks reasonable.

Addresses: https://github.com/RayTracing/raytracing.github.io/issues/70

(Note that we are considering changing the underlying RNG from rand() to the Mersenne twister implementation from `<random>` in the future. This is not yet addressed here.)