### PR TITLE
Sync vec3 changes to cross product from first book to all vec3.h files

### DIFF
--- a/src/TheNextWeek/vec3.h
+++ b/src/TheNextWeek/vec3.h
@@ -98,9 +98,9 @@ inline float dot(const vec3 &v1, const vec3 &v2) {
 }
 
 inline vec3 cross(const vec3 &v1, const vec3 &v2) {
-    return vec3( (v1.e[1]*v2.e[2] - v1.e[2]*v2.e[1]),
-                (-(v1.e[0]*v2.e[2] - v1.e[2]*v2.e[0])),
-                (v1.e[0]*v2.e[1] - v1.e[1]*v2.e[0]));
+    return vec3(v1.e[1]*v2.e[2] - v1.e[2]*v2.e[1],
+                v1.e[2]*v2.e[0] - v1.e[0]*v2.e[2],
+                v1.e[0]*v2.e[1] - v1.e[1]*v2.e[0]);
 }
 
 

--- a/src/TheNextWeek/vec3.h
+++ b/src/TheNextWeek/vec3.h
@@ -103,7 +103,6 @@ inline vec3 cross(const vec3 &v1, const vec3 &v2) {
                 v1.e[0]*v2.e[1] - v1.e[1]*v2.e[0]);
 }
 
-
 inline vec3& vec3::operator+=(const vec3 &v){
     e[0]  += v.e[0];
     e[1]  += v.e[1];

--- a/src/TheRestOfYourLife/vec3.h
+++ b/src/TheRestOfYourLife/vec3.h
@@ -99,11 +99,10 @@ inline float dot(const vec3 &v1, const vec3 &v2) {
 }
 
 inline vec3 cross(const vec3 &v1, const vec3 &v2) {
-    return vec3( (v1.e[1]*v2.e[2] - v1.e[2]*v2.e[1]),
-                (-(v1.e[0]*v2.e[2] - v1.e[2]*v2.e[0])),
-                (v1.e[0]*v2.e[1] - v1.e[1]*v2.e[0]));
+    return vec3(v1.e[1]*v2.e[2] - v1.e[2]*v2.e[1],
+                v1.e[2]*v2.e[0] - v1.e[0]*v2.e[2],
+                v1.e[0]*v2.e[1] - v1.e[1]*v2.e[0]);
 }
-
 
 inline vec3& vec3::operator+=(const vec3 &v){
     e[0]  += v.e[0];


### PR DESCRIPTION
Addresses: https://github.com/RayTracing/raytracing.github.io/issues/69

Note that I have kept changes to just addressing the small difference in computation (how the minor sign is multiplied in the second component). There are still formatting differences in the rest of vec3.h when comparing the first book with the other books. I think it's better to address formatting at a later point and in a different pull request. 