### PR TITLE
Add missing headers in constant_medium.h in second book src code

### DIFF
--- a/src/TheNextWeek/constant_medium.h
+++ b/src/TheNextWeek/constant_medium.h
@@ -12,7 +12,9 @@
 //==================================================================================================
 
 #include "hitable.h"
+#include "material.h"
 #include "random.h"
+#include "texture.h"
 
 #include <float.h>
 


### PR DESCRIPTION
Both `texture` and `isotropic` are types that are used but not included in constant_medium.h. The required includes are added here.

I checked and it seems books changes are not required (the corresponding code parts in the book omit all includes). 

Addresses: https://github.com/RayTracing/raytracing.github.io/issues/174