### PR TITLE
src/*/README.md: Edit tweaks

### DIFF
--- a/src/InOneWeekend/README.md
+++ b/src/InOneWeekend/README.md
@@ -3,34 +3,46 @@ Ray Tracing in One Weekend - Source
 
 Content
 --------
-This folder ([InOneWeekend][]) contains the finished code of the [_Ray Tracing in One Weekend_][] book.
+This folder contains the finished code for _Ray Tracing in One Weekend_ ([local][] / [online][]).
+
 
 Intent
 -------
-This folder is not meant to act as it's own tutorial. The source presented here is provided so that you can compare your work when going along with the book. We strongly recommend reading and following along with the book if you want to understand the source.
+This folder is not meant to act as its own tutorial. The source presented here is provided so you
+can compare your work when progressing through the book. We strongly recommend reading and following
+along with the book to understand the source.
+
 
 Programming Language
 ---------------------
-This book is written in c++ with some modern features of c++11. The code as written is designed to be readable by the largest collection of potential programmers. The code is not meant to illustrate idealized c++ code.
+This book is written in C++, and uses some modern features of C++11. The language and features were
+chosen to be broadly understood by the largest collection of programmers. It is not meant to
+represent ideal C++ code.
+
 
 Building
 ---------
-No mechanism for building is included with this project.
+As the source is intended for illustration & comparison only, it does not include any mechanism for
+building a final program. As far as possible, the code is privately tested on multiple platforms to
+ensure that it is generally usable on any OS (primarily Windows, OSX, and Linux), compiler, or build
+environment.
 
-The _Ray Tracing in One Weekend_ series has a long history of being written in other programming languages ([Implementations in Other Languages][]) and across all three primary operating systems.
+It is therefore necessary for you to create your own build tooling. However, the source begins as a
+single main file, and uses only a small collection of additional header files.
 
-It is necessary for you to create your own build tooling. However, the source begins as a single main file and builds to only a small collection of additional header files.
+The _Ray Tracing in One Weekend_ series has a long history of implementations in other programming
+languages (see [_Implementations in Other Languages_][implementations]), and across all three
+primary operating systems. Feel free to add your own implementation to the list!
 
-The c++ code as written should compile across all three platforms (Win, OSX, Linux).
 
 Corrections & Contributions
 ----------------------------
 If you spot errors, have suggested corrections, or would like to help out with the project, please
-review the [CONTRIBUTING][] document for the most effective way to proceed.
+review the [CONTRIBUTING][] guidelines for the most effective way to proceed.
 
 
 
-[InOneWeekend]:                         https://github.com/RayTracing/raytracing.github.io/tree/master/src/InOneWeekend
-[_Ray Tracing in One Weekend_]:         https://github.com/RayTracing/raytracing.github.io/tree/master/books/RayTracingInOneWeekend.html
-[Implementations in Other Languages]:   https://github.com/RayTracing/InOneWeekend/wiki/Implementations-in-Other-Languages
-[CONTRIBUTING]:                         ../../CONTRIBUTING.md
+[online]:          https://raytracing.github.com/books/RayTracingInOneWeekend.html
+[local]:           ../../books/RayTracingInOneWeekend.html
+[implementations]: https://github.com/RayTracing/raytracing.github.io/wiki/Implementations-in-Other-Languages
+[CONTRIBUTING]:    ../../CONTRIBUTING.md

--- a/src/TheNextWeek/README.md
+++ b/src/TheNextWeek/README.md
@@ -3,37 +3,52 @@ Ray Tracing: The Next Week - Source
 
 Content
 --------
-This folder ([TheNextWeek][]) contains the finished code of the [_Ray Tracing: The Next Week_][] book.
+This folder contains the finished code for _Ray Tracing: The Next Week_ ([local][] / [online][]).
 
-Every chapter of [_Ray Tracing: The Next Week_][] acts as it's own mini tutorial, and each chapter is largely independent of other chapters. Every chapter ends with an example render, and in the source, the [main.cc][] contains a render function specific to each chapter. The source presented here represents the simplest superset of the code from all chapters.
+Every chapter of the book acts as its own mini tutorial, and each chapter is largely independent of
+other chapters. Every chapter ends with an example render, and in the source, [main.cc][] contains a
+render function specific to each chapter. The source presented here represents the simplest superset
+of the code from all chapters.
+
 
 Intent
 -------
-This folder is not meant to act as it's own tutorial. The source presented here is provided so that you can compare your work when going along with the book. We strongly recommend reading and following along with the book if you want to understand the source.
+This folder is not meant to act as its own tutorial. The source presented here is provided so you
+can compare your work when progressing through the book. We strongly recommend reading and following
+along with the book to understand the source.
+
 
 Programming Language
 ---------------------
-This book is written in c++ with some modern features of c++11. The code as written is designed to be readable by the largest collection of potential programmers. The code is not meant to illustrate idealized c++ code.
+This book is written in C++, and uses some modern features of C++11. The language and features were
+chosen to be broadly understood by the largest collection of programmers. It is not meant to
+represent ideal C++ code.
+
 
 Building
 ---------
-No mechanism for building is included with this project.
+As the source is intended for illustration & comparison only, it does not include any mechanism for
+building a final program. As far as possible, the code is privately tested on multiple platforms to
+ensure that it is generally usable on any OS (primarily Windows, OSX, and Linux), compiler, or build
+environment.
 
-The _Ray Tracing in One Weekend_ series has a long history of being written in other programming languages ([Implementations in Other Languages][]) and across all three primary operating systems.
+It is therefore necessary for you to create your own build tooling. However, the source begins as a
+single main file, and uses only a small collection of additional header files.
 
-It is necessary for you to create your own build tooling. However, the source begins as a single main file and builds to only a small collection of additional header files.
+The _Ray Tracing in One Weekend_ series has a long history of implementations in other programming
+languages (see [_Implementations in Other Languages_][implementations]), and across all three
+primary operating systems. Feel free to add your own implementation to the list!
 
-The c++ code as written should compile across all three platforms (Win, OSX, Linux).
 
 Corrections & Contributions
 ----------------------------
 If you spot errors, have suggested corrections, or would like to help out with the project, please
-review the [CONTRIBUTING][] document for the most effective way to proceed.
+review the [CONTRIBUTING][] guidelines for the most effective way to proceed.
 
 
 
-[TheNextWeek]:                         https://github.com/RayTracing/raytracing.github.io/tree/master/src/TheNextWeek
-[_Ray Tracing: The Next Week_]:         https://github.com/RayTracing/raytracing.github.io/tree/master/books/RayTracingTheNextWeek.html
-[main.cc]:                              https://github.com/RayTracing/raytracing.github.io/tree/master/src/TheNextWeek/main.cc
-[Implementations in Other Languages]:   https://github.com/RayTracing/InOneWeekend/wiki/Implementations-in-Other-Languages
-[CONTRIBUTING]:                         ../../CONTRIBUTING.md
+[online]:          https://raytracing.github.com/books/RayTracingTheNextWeek.html
+[local]:           ../../books/RayTracingTheNextWeek.html
+[main.cc]:         ./main.cc
+[implementations]: https://github.com/RayTracing/raytracing.github.io/wiki/Implementations-in-Other-Languages
+[CONTRIBUTING]:    ../../CONTRIBUTING.md

--- a/src/TheRestOfYourLife/README.md
+++ b/src/TheRestOfYourLife/README.md
@@ -3,34 +3,47 @@ Ray Tracing: The Rest Of Your Life - Source
 
 Content
 --------
-This folder ([TheRestOfYourLife][]) contains the finished code of the [_Ray Tracing: The Rest Of Your Life_][] book.
+This folder contains the finished code for _Ray Tracing: The Rest Of Your Life_ ([local][] /
+[online][]).
+
 
 Intent
 -------
-This folder is not meant to act as it's own tutorial. The source presented here is provided so that you can compare your work when going along with the book. We strongly recommend reading and following along with the book if you want to understand the source.
+This folder is not meant to act as its own tutorial. The source presented here is provided so you
+can compare your work when progressing through the book. We strongly recommend reading and following
+along with the book to understand the source.
+
 
 Programming Language
 ---------------------
-This book is written in c++ with some modern features of c++11. The code as written is designed to be readable by the largest collection of potential programmers. The code is not meant to illustrate idealized c++ code.
+This book is written in C++, and uses some modern features of C++11. The language and features were
+chosen to be broadly understood by the largest collection of programmers. It is not meant to
+represent ideal C++ code.
+
 
 Building
 ---------
-No mechanism for building is included with this project.
+As the source is intended for illustration & comparison only, it does not include any mechanism for
+building a final program. As far as possible, the code is privately tested on multiple platforms to
+ensure that it is generally usable on any OS (primarily Windows, OSX, and Linux), compiler, or build
+environment.
 
-The _Ray Tracing in One Weekend_ series has a long history of being written in other programming languages ([Implementations in Other Languages][]) and across all three primary operating systems.
+It is therefore necessary for you to create your own build tooling. However, the source begins as a
+single main file, and uses only a small collection of additional header files.
 
-It is necessary for you to create your own build tooling. However, the source begins as a single main file and builds to only a small collection of additional header files.
+The _Ray Tracing in One Weekend_ series has a long history of implementations in other programming
+languages (see [_Implementations in Other Languages_][implementations]), and across all three
+primary operating systems. Feel free to add your own implementation to the list!
 
-The c++ code as written should compile across all three platforms (Win, OSX, Linux).
 
 Corrections & Contributions
 ----------------------------
 If you spot errors, have suggested corrections, or would like to help out with the project, please
-review the [CONTRIBUTING][] document for the most effective way to proceed.
+review the [CONTRIBUTING][] guidelines for the most effective way to proceed.
 
 
 
-[TheRestOfYourLife]:                         https://github.com/RayTracing/raytracing.github.io/tree/master/src/TheRestOfYourLife
-[_Ray Tracing: The Next Week_]:         https://github.com/RayTracing/raytracing.github.io/tree/master/books/RayTracingTheRestOfYourLife.html
-[Implementations in Other Languages]:   https://github.com/RayTracing/InOneWeekend/wiki/Implementations-in-Other-Languages
-[CONTRIBUTING]:                         ../../CONTRIBUTING.md
+[online]:          https://raytracing.github.com/books/RayTracingTheRestOfYourLife.html
+[local]:           ../../books/RayTracingTheRestOfYourLife.html
+[implementations]: https://github.com/RayTracing/raytracing.github.io/wiki/Implementations-in-Other-Languages
+[CONTRIBUTING]:    ../../CONTRIBUTING.md


### PR DESCRIPTION
- These READMEs need to be easy to read in the console, or in whatever
  IDE the user is working in, which may not wrap lines, and at word
  boundaries. Thus, keep lines to max line length (using 100 here)

- Fixed book links to refer to both the local clone or the official web
  site. When browsing from the GitHub repo view, this will show the HTML
  source. Locally, both links should launch the rendered form in
  browser.

- Fixed Implementations in Other Languages links from old `InOneWeekend`
  repo to the new wiki location in `raytracing.github.io`.

- Fixed `main.cc` link to use relative reference, rather than pointing
  to the tip of the master branch online (local clones should remain
  internally consistent).

- Removed unused link refs in the footer.

- General wording edits.