### PR TITLE
book print styling

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -13,10 +13,11 @@
 Overview
 ====================================================================================================
 
-<div class='warning'>
-  <p class='title'>WARNING<br>Content Under Development</h1>
-  <p class='text'>See <a href='https://github.com/RayTracing/raytracing.github.io/releases/'>release page</a> for latest official PDF version.
-</div>
+
+!!! ERROR: Content Under Development
+    See [the official release page](https://github.com/RayTracing/raytracing.github.io/releases/)
+    for latest official PDF version.
+
 
 I’ve taught many graphics classes over the years. Often I do them in ray tracing, because you are
 forced to write all the code but you can still get cool images with no API. I decided to adapt my
@@ -68,6 +69,7 @@ start with a plain text ppm file. Here’s a nice description from Wikipedia:
 
   ![Image 2-1: PPM Example](../images/img-1-02-1.jpg)
 
+<div class='together'>
 Let’s make some C++ code to output such a thing:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -90,6 +92,7 @@ Let’s make some C++ code to output such a thing:
         }
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 There are some things to note in that code:
 
@@ -105,11 +108,15 @@ There are some things to note in that code:
      fully on at the top. Red and green together make yellow so we should expect the upper right
      corner to be yellow.
 
+<div class='together'>
 Opening the output file (in ToyViewer on my mac, but try it in your favorite viewer and google “ppm
 viewer” if your viewer doesn’t support it) shows:
 
   ![Image 2-2](../images/img-1-02-2.jpg)
 
+</div>
+
+<div class='together'>
 Hooray! This is the graphics “hello world”. If your image doesn’t look like that, open the output
 file in a text editor and see what it looks like. It should start something like this:
 
@@ -134,6 +141,7 @@ file in a text editor and see what it looks like. It should start something like
     14 253 51
     15 253 51
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 If it doesn’t, then you probably just have some newlines or something similar that is confusing the
 image reader.
@@ -152,6 +160,7 @@ class `vec3` for colors, locations, directions, offsets, whatever. Some people d
 because it doesn’t prevent you from doing something silly, like adding a color to a location. They
 have a good point, but we’re going to always take the “less code” route when not obviously wrong.
 
+<div class='together'>
 Here’s the top part of my vec3 class:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -189,6 +198,7 @@ Here’s the top part of my vec3 class:
         float e[3];
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 I use floats here, but in some ray tracers I have used doubles. Neither is correct -- follow your
 own tastes. Everything is in the header file, and later on in the file are lots of vector
@@ -297,6 +307,7 @@ operations:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+<div class='together'>
 Now we can change our main to use this:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -318,6 +329,7 @@ Now we can change our main to use this:
         }
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 
 
@@ -334,6 +346,7 @@ here:
 
   ![Figure 4-1](../images/fig-1-04-1.jpg)
 
+<div class='together'>
 The function $p(t)$ in more verbose code form I call “point_at_parameter(t)”:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -356,6 +369,7 @@ The function $p(t)$ in more verbose code form I call “point_at_parameter(t)”
 
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 Now we are ready to turn the corner and make a ray tracer. At the core of a ray tracer is to send
 rays through pixels and compute what color is seen in the direction of those rays. This is of the
@@ -374,6 +388,7 @@ length vector because I think not doing that makes for simpler and slightly fast
 
   ![Figure 4-2](../images/fig-1-04-2.jpg)
 
+<div class='together'>
 Below in code, the ray $r$ goes to approximately the pixel centers (I won’t worry about exactness
 for now because we’ll add antialiasing later):
 
@@ -410,7 +425,9 @@ for now because we’ll add antialiasing later):
         }
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 The `color(ray)` function linearly blends white and blue depending on the up/downess of the $y$
 coordinate. I first made it a unit vector so $-1.0 < y < 1.0$. I then did a standard graphics trick
 of scaling that to $0.0 < t < 1.0$. When $t = 1.0$ I want blue. When $t = 0.0$ I want white. In
@@ -423,11 +440,14 @@ with $t$ going from zero to one. In our case this produces:
 
   ![Image 4-1](../images/img-1-04-1.jpg)
 
+</div>
+
 
 
 Adding a Sphere
 ====================================================================================================
 
+<div class='together'>
 Let’s add a single object to our ray tracer. People often use spheres in ray tracers because
 calculating whether a ray hits a sphere is pretty straightforward. Recall that the equation for a
 sphere centered at the origin of radius $R$ is $x^2 + y^2 + z^2 = R^2$. The way you can read that
@@ -435,20 +455,26 @@ equation is “for any $(x, y, z)$, if $x^2 + y^2 + z^2 = R^2$ then $(x,y,z)$ is
 otherwise it is not”. It gets uglier if the sphere center is at $(C_x, C_y, C_z)$:
 
   $$ (x-C_x)^2 + (y-C_y)^2 + (z-C_z)^2 = R^2 $$
+</div>
 
+<div class='together'>
 In graphics, you almost always want your formulas to be in terms of vectors so all the x/y/z stuff
 is under the hood in the `vec3` class. You might note that the vector from center
 $C = (C_x,C_y,C_z)$ to point $P = (x,y,z)$ is $(p - C)$, and therefore
 
   $$ dot((p - C),(p - C)) = (x-C_x)^2 + (y-C_y)^2 + (z-C_z)^2 $$
+</div>
 
+<div class='together'>
 So the equation of the sphere in vector form is:
 
   $$ dot((p - C),(p - C)) = R^2 $$
+</div>
 
-We can read this as “any point p that satisfies this equation is on the sphere”. We want to know 
-if our ray $p(t) = A + t*B$ ever hits the sphere anywhere. If it does hit the sphere, there is 
-some $t$ for which $p(t)$ satisfies the sphere equation. So we are looking for any $t$ where this 
+<div class='together'>
+We can read this as “any point p that satisfies this equation is on the sphere”. We want to know
+if our ray $p(t) = A + t*B$ ever hits the sphere anywhere. If it does hit the sphere, there is
+some $t$ for which $p(t)$ satisfies the sphere equation. So we are looking for any $t$ where this
 is true:
 
   $$ dot((p(t) - C),(p(t) - C)) = R^2 $$
@@ -456,12 +482,16 @@ is true:
 or expanding the full form of the ray $p(t)$:
 
   $$ dot((A + t*B - C), (A + t*B - C)) = R^2 $$
+</div>
 
+<div class='together'>
 The rules of vector algebra are all that we would want here, and if we expand that equation and
 move all the terms to the left hand side we get:
 
   $$ t^2 \cdot dot(B,B) + 2t \cdot dot(B,A-C) + dot(A-C,A-C) - R^2 = 0 $$
+</div>
 
+<div class='together'>
 The vectors and $R$ in that equation are all constant and known. The unknown is $t$, and the
 equation is a quadratic, like you probably saw in your high school math class. You can solve for $t$
 and there is a square root part that is either positive (meaning two real solutions), negative
@@ -470,6 +500,9 @@ always relates very directly to the geometry. What we have is:
 
   ![Figure 5-1](../images/fig-1-05-1.jpg)
 
+</div>
+
+<div class='together'>
 If we take that math and hard-code it into our program, we can test it by coloring red any pixel
 that hits a small sphere we place at -1 on the z-axis:
 
@@ -491,10 +524,14 @@ that hits a small sphere we place at -1 on the z-axis:
         return (1.0-t)*vec3(1.0, 1.0, 1.0) + t*vec3(0.5, 0.7, 1.0);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 What we get is this:
 
   ![Image 5-1](../images/img-1-05-1.jpg)
+
+</div>
 
 Now this lacks all sorts of things -- like shading and reflection rays and more than one object --
 but we are closer to halfway done than we are to our start! One thing to be aware of is that we
@@ -516,6 +553,7 @@ minus the center:
 
   ![Figure 6-1](../images/fig-1-06-1.jpg)
 
+<div class='together'>
 On the earth, this implies that the vector from the earth’s center to you points straight up. Let’s
 throw that into the code now, and shade it. We don’t have any lights or anything yet, so let’s just
 visualize the normals with a color map. A common trick used for visualizing normals (because it’s
@@ -550,10 +588,14 @@ normal, we need the hit point, not just whether we hit or not. Let’s assume th
         return (1.0-t)*vec3(1.0, 1.0, 1.0) + t*vec3(0.5, 0.7, 1.0);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And that yields this picture:
 
   ![Image 6-1](../images/img-1-06-1.jpg)
+
+</div>
 
 Now, how about several spheres? While it is tempting to have an array of spheres, a very clean
 solution is the make an “abstract class” for anything a ray might hit and make both a sphere and a
@@ -562,6 +604,7 @@ quandary -- calling it an “object” would be good if not for “object orient
 is often used, with the weakness being maybe we will want volumes. “Hitable” emphasizes the member
 function that unites them. I don’t love any of these but I will go with “hitable”.
 
+<div class='together'>
 This `hitable` abstract class will have a hit function that takes in a ray. Most ray tracers have
 found it convenient to add a valid interval for hits $t_{min}$ to $t_{max}$, so the hit only
 “counts” if $t_{min} < t < t_{max}$. For the initial rays this is positive $t$, but as we will see,
@@ -592,7 +635,9 @@ we’ll want motion blur at some point, so I’ll add a time input variable. Her
 
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And here’s the sphere (note that I eliminated a bunch of redundant 2’s that cancel each other out):
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -639,6 +684,9 @@ And here’s the sphere (note that I eliminated a bunch of redundant 2’s that 
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+</div>
+
+<div class='together'>
 And a list of objects:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -675,7 +723,9 @@ And a list of objects:
 
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And the new main:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -725,11 +775,15 @@ And the new main:
         }
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 This yields a picture that is really just a visualization of where the spheres are along with their
 surface normal. This is often a great way to look at your model for flaws and characteristics.
 
   ![Image 6-2](../images/img-1-06-2.jpg)
+
+</div>
 
 
 
@@ -745,9 +799,10 @@ a bit so we can make a cooler camera later.
 
 One thing we need is a random number generator that returns real random numbers. We need a function
 that returns a canonical random number which by convention returns random real in the range
-$0 ≤ ran < 1$. The “less than” before the 1 is important as we will sometimes take advantage of 
+$0 ≤ ran < 1$. The “less than” before the 1 is important as we will sometimes take advantage of
 that.
 
+<div class='together'>
 A simple approach to this is to use the `rand()` function that can be found in `<cstdlib>`. This
 function returns a random integer in the range 0 and RANDMAX. Hence we can get a real random number
 as desired with the following code snippet:
@@ -763,7 +818,9 @@ as desired with the following code snippet:
     }
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 C++ did not traditionally have a standard random number generator, but newer versions of C++ have
 addressed this issue with the `<random>` header (if imperfectly according to some experts).
 If you want to use this, you can obtain a random number with the conditions we need as follows:
@@ -784,12 +841,17 @@ If you want to use this, you can obtain a random number with the conditions we n
       }
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 For a given pixel we have several samples within that pixel and send rays through each of the
 samples. The colors of these rays are then averaged:
 
   ![Figure 7-1](../images/fig-1-07-1.jpg)
 
+</div>
+
+<div class='together'>
 Putting that all together yields a camera class encapsulating our simple axis-aligned camera from
 before:
 
@@ -819,7 +881,9 @@ before:
     };
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Main is also changed:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -851,11 +915,15 @@ Main is also changed:
         }
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Zooming into the image that is produced, the big change is in edge pixels that are part background
 and part foreground:
 
   ![Image 7-1](../images/img-1-07-1.jpg)
+
+</div>
 
 
 
@@ -869,6 +937,7 @@ are tightly bound (that could be useful for procedural objects where the geometr
 linked). We’ll go with separate -- which is usual in most renderers -- but do be aware of the
 limitation.
 
+<div class='together'>
 Diffuse objects that don’t emit light merely take on the color of their surroundings, but they
 modulate that with their own intrinsic color. Light that reflects off a diffuse surface has its
 direction randomized. So, if we send three rays into a crack between two diffuse surfaces they will
@@ -876,17 +945,23 @@ each have different random behavior:
 
   ![Figure 8-1](../images/fig-1-08-1.jpg)
 
+</div>
+
 They also might be absorbed rather than reflected. The darker the surface, the more likely
 absorption is. (That’s why it is dark!) Really any algorithm that randomizes direction will produce
 surfaces that look matte. One of the simplest ways to do this turns out to be exactly correct for
 ideal diffuse surfaces. (I used to do it as a lazy hack that approximates mathematically ideal
 Lambertian.)
 
+<div class='together'>
 Pick a random point s from the unit radius sphere that is tangent to the hitpoint, and send a ray
 from the hitpoint $p$ to the random point $s$. That sphere has center $(p + N)$:
 
   ![Figure 8-2](../images/fig-1-08-2.jpg)
 
+</div>
+
+<div class='together'>
 We also need a way to pick a random point in a unit radius sphere centered at the origin. We’ll use
 what is usually the easiest algorithm: a rejection method. First, we pick a random point in the unit
 cube where x, y, and z all range from -1 to +1. We reject this point and try again if the point is
@@ -901,7 +976,9 @@ outside the sphere. A do/while construct is perfect for that:
         return p;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Then update the `color()` function to use the new random direction generator:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -918,11 +995,16 @@ Then update the `color()` function to use the new random direction generator:
         }
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 This gives us:
 
   ![Image 8-1](../images/img-1-08-1.jpg)
 
+</div>
+
+<div class='together'>
 Note the shadowing under the sphere. This picture is very dark, but our spheres only absorb half the
 energy on each bounce, so they are 50% reflectors. If you can’t see the shadow, don’t worry, we will
 fix that now. These spheres should look pretty light (in real life, a light grey). The reason for
@@ -940,11 +1022,16 @@ square-root:
     int ib = int(255.99*col[2]);
     std::cout << ir << " " << ig << " " << ib << "\n";
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 That yields light grey, as we desire:
 
   ![Image 8-2](../images/img-1-08-2.jpg)
 
+</div>
+
+<div class='together'>
 There’s also a subtle bug in there. Some of the reflected rays hit the object they are reflecting
 off of not at exactly $t=0$, but instead at $t=-0.0000001$ or $t=0.00000001$ or whatever floating
 point approximation the sphere intersector gives us. So we need to ignore hits very near zero:
@@ -954,6 +1041,7 @@ point approximation the sphere intersector gives us. So we need to ignore hits v
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This gets rid of the shadow acne problem. Yes it is really called that.
+</div>
 
 
 
@@ -969,6 +1057,7 @@ two things:
   1. Produce a scattered ray (or say it absorbed the incident ray).
   2. If scattered, say how much the ray should be attenuated.
 
+<div class='together'>
 This suggests the abstract class:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -979,7 +1068,9 @@ This suggests the abstract class:
                 ray& scattered) const = 0;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 The `hit_record` is to avoid a bunch of arguments so we can stuff whatever info we want in there.
 You can use arguments instead; it’s a matter of taste. Hitables and materials need to know each
 other so there is some circularity of the references. In C++ you just need to alert the compiler
@@ -1008,6 +1099,7 @@ that the pointer is to a class, which the “class material” in the hitable cl
 
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 What we have set up here is that material will tell us how rays interact with the surface.
 `hit_record` is just a way to stuff a bunch of arguments into a struct so we can send them as a
@@ -1016,6 +1108,7 @@ group. When a ray hits a surface (a particular sphere for example), the material
 `main()` when we start. When the `color()` routine gets the `hit_record` it can call member
 functions of the material pointer to find out what ray, if any, is scattered.
 
+<div class='together'>
 To achieve this, we must have a reference to the material for our sphere class to returned
 within `hit_record`. See the lines below marked with **`/* NEW */`**.
 
@@ -1058,7 +1151,9 @@ within `hit_record`. See the lines below marked with **`/* NEW */`**.
         return false;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 For the Lambertian (diffuse) case we already have, it can either scatter always and attenuate by its
 reflectance $R$, or it can scatter with no attenuation but absorb the fraction $1-R$ of the rays. Or
 it could be a mixture of those strategies. For Lambertian materials we get this simple class:
@@ -1079,15 +1174,20 @@ it could be a mixture of those strategies. For Lambertian materials we get this 
             vec3 albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 Note we could just as well only scatter with some probability $p$ and have attenuation be
 $albedo/p$. Your choice.
 
+<div class='together'>
 For smooth metals the ray won’t be randomly scattered. The key math is: how does a ray get
 reflected from a metal mirror? Vector math is our friend here:
 
   ![Figure 9-1](../images/fig-1-09-1.jpg)
 
+</div>
+
+<div class='together'>
 The reflected ray direction in red is just $(v + 2B)$. In our design, $N$ is a unit vector, but $v$
 may not be. The length of $B$ should be $dot(v,N)$. Because $v$ points in, we will need a minus
 sign, yielding:
@@ -1097,7 +1197,9 @@ sign, yielding:
         return v - 2*dot(v,n)*n;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 The metal material just reflects rays using that formula:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1115,7 +1217,9 @@ The metal material just reflects rays using that formula:
             vec3 albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 We need to modify the color function to use this:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1138,7 +1242,9 @@ We need to modify the color function to use this:
         }
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 You will also need to modify the sphere class to have a material pointer to it. And add some
 metal spheres:
 
@@ -1175,16 +1281,24 @@ metal spheres:
         }
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Which gives:
 
   ![Image 9-1](../images/img-1-09-1.jpg)
 
+</div>
+
+<div class='together'>
 We can also randomize the reflected direction by using a small sphere and choosing a new endpoint
 for the ray:
 
   ![Figure 9-2](../images/fig-1-09-2.jpg)
 
+</div>
+
+<div class='together'>
 The bigger the sphere, the fuzzier the reflections will be. This suggests adding a fuzziness
 parameter that is just the radius of the sphere (so zero is no perturbation). The catch is that for
 big spheres or grazing rays, we may scatter below the surface. We can just have the surface
@@ -1210,9 +1324,14 @@ absorb those. We’ll put a maximum of 1 on the radius of the sphere which yield
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+</div>
+
+<div class='together'>
 We can try that out by adding fuzziness 0.3 and 1.0 to the metals:
 
   ![Image 9-2](../images/img-1-09-2.jpg)
+
+</div>
 
 
 
@@ -1223,16 +1342,20 @@ Clear materials such as water, glass, and diamonds are dielectrics. When a light
 splits into a reflected ray and a refracted (transmitted) ray. We’ll handle that by randomly
 choosing between reflection or refraction and only generating one scattered ray per interaction.
 
+<div class='together'>
 The hardest part to debug is the refracted ray. I usually first just have all the light refract if
 there is a refraction ray at all. For this project, I tried to put two glass balls in our scene, and
 I got this (I have not told you how to do this right or wrong yet, but soon!):
 
   ![Image 10-1](../images/img-1-10-1.jpg)
 
+</div>
+
 Is that right? Glass balls look odd in real life. But no, it isn’t right. The world should be
 flipped upside down and no weird black stuff. I just printed out the ray straight through the middle
 of the image and it was clearly wrong. That often does the job.
 
+<div class='together'>
 The refraction is described by Snell’s law:
 
   $$ n \cdot sin(theta) = n' \cdot sin(theta') $$
@@ -1242,6 +1365,9 @@ and the geometry is:
 
   ![Figure 10-1](../images/fig-1-10-1.jpg)
 
+</div>
+
+<div class='together'>
 One troublesome practical issue is that when the ray is in the material with the higher refractive
 index, there is no real solution to Snell’s law and thus there is no refraction possible. Here all
 the light is reflected, and because in practice that is usually inside solid objects, it is called
@@ -1261,7 +1387,9 @@ when you are submerged. The code for refraction is thus a bit more complicated t
             return false;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And the dielectric material that always refracts when possible is:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1296,12 +1424,14 @@ And the dielectric material that always refracts when possible is:
             float ref_idx;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 Attenuation is always 1 -- the glass surface absorbs nothing. The `attenuation = vec3(1.0, 1.0,
 0.0)` above will also kill the blue channel which is the type of color bug that can be hard to find
 -- it will give a color shift only. Try it the way it is and then change it to
 `attenuation = vec3(1.0, 1.0, 1.0)` to see the difference.
 
+<div class='together'>
 If we try that out with these parameters:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1315,12 +1445,15 @@ We get:
 
   ![Image 10-2](../images/img-1-10-2.jpg)
 
+</div>
+
 (The reader Becker has pointed out that when there is a reflection ray the function returns `false`
 so there are no reflections. He is right, and that is why there are none in the image above. I
 am leaving this in rather than correcting this because it is a very interesting example of a major
 bug that still leaves a reasonably plausible image. These sleeper bugs are the hardest bugs to
 find because we humans are not designed to find fault with what we see.)
 
+<div class='together'>
 Now real glass has reflectivity that varies with angle -- look at a window at a steep angle and it
 becomes a mirror. There is a big ugly equation for that, but almost everybody uses a simple and
 surprisingly simple polynomial approximation by Christophe Schlick:
@@ -1332,7 +1465,9 @@ surprisingly simple polynomial approximation by Christophe Schlick:
         return r0 + (1-r0)*pow((1 - cosine),5);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 This yields our full glass material:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1380,7 +1515,9 @@ This yields our full glass material:
             float ref_idx;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 An interesting and easy trick with dielectric spheres is to note that if you use a negative radius,
 the geometry is unaffected but the surface normal points inward, so it can be used as a bubble
 to make a hollow glass sphere:
@@ -1392,10 +1529,14 @@ to make a hollow glass sphere:
     list[3] = new sphere(vec3(-1,0,-1), 0.5, new dielectric(1.5));
     list[4] = new sphere(vec3(-1,0,-1), -0.45, new dielectric(1.5));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 This gives:
 
   ![Image 10-3](../images/img-1-10-3.jpg)
+
+</div>
 
 
 
@@ -1408,11 +1549,15 @@ image is not square, the fov is different horizontally and vertically. I always 
 also usually specify it in degrees and change to radians inside a constructor -- a matter of
 personal taste.
 
+<div class='together'>
 I first keep the rays coming from the origin and heading to the $z = -1$ plane. We could make it the
 $z = -2$ plane, or whatever, as long as we made $h$ a ratio to that distance. Here is our setup:
 
   ![Figure 11-1](../images/fig-1-11-1.jpg)
 
+</div>
+
+<div class='together'>
 This implies $h = tan(\theta/2)$. Our camera now becomes:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1444,7 +1589,9 @@ This implies $h = tan(\theta/2)$. Our camera now becomes:
     };
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 When calling it with camera `cam(90, float(nx)/float(ny))` and these spheres:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1457,6 +1604,8 @@ When calling it with camera `cam(90, float(nx)/float(ny))` and these spheres:
 gives:
 
   ![Image 11-1](../images/img-1-11-1.jpg)
+
+</div>
 
 To get an arbitrary viewpoint, let’s first name the points we care about. We’ll call the position
 where we place the camera _lookfrom_, and the point we look at _lookat_. (Later, if you want, you
@@ -1516,6 +1665,7 @@ camera horizontally level until you decide to experiment with crazy camera angle
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+<div class='together'>
 This allows us to change the viewpoint:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1529,6 +1679,8 @@ to get:
 And we can change field of view to get:
 
   ![Image 11-3](../images/img-1-11-3.jpg)
+
+</div>
 
 
 
@@ -1562,6 +1714,7 @@ film on the plane that is in focus (at the distance `focus_dist`).
 
   ![Figure 12-2](../images/fig-1-12-2.jpg)
 
+<div class='together'>
 For that we just need to have the ray origins be on a disk around `lookfrom` rather than from a
 point:
 
@@ -1617,7 +1770,9 @@ point:
     };
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Using a big aperture:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1634,11 +1789,14 @@ We get:
 
   ![Image 12-1](../images/img-1-12-1.jpg)
 
+</div>
+
 
 
 Where Next?
 ====================================================================================================
 
+<div class='together'>
 First let’s make the image on the cover of this book -- lots of random spheres:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1681,10 +1839,14 @@ First let’s make the image on the cover of this book -- lots of random spheres
         return new hitable_list(list,i);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 This gives:
 
   ![Image 13-1](../images/img-1-13-1.jpg)
+
+</div>
 
 An interesting thing you might note is the glass balls don’t really have shadows which makes them
 look like they are floating. This is not a bug (you don’t see glass balls much in real life, where

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -15,10 +15,11 @@
 Overview
 ====================================================================================================
 
-<div class='warning'>
-  <p class='title'>WARNING<br>Content Under Development</h1>
-  <p class='text'>See <a href='https://github.com/RayTracing/raytracing.github.io/releases/'>release page</a> for latest official PDF version.
-</div>
+
+!!! ERROR: Content Under Development
+    See [the official release page](https://github.com/RayTracing/raytracing.github.io/releases/)
+    for latest official PDF version.
+
 
 In Ray Tracing In One Weekend, you built a simple brute force path tracer. In this installment we’ll
 add textures, volumes (like fog), rectangles, instances, lights, and support for lots of objects
@@ -65,6 +66,7 @@ at that one time. The way it is usually done is to have the camera move and the 
 have each ray exist at exactly one time. This way the “engine” of the ray tracer can just make sure
 the objects are where they need to be for the ray, and the intersection guts don’t change much.
 
+<div class='together'>
 For this we will first need to have a ray store the time it exists at:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -84,6 +86,7 @@ For this we will first need to have a ray store the time it exists at:
     };
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 Now we need to modify the camera to generate rays at a random time between `time1` and `time2`.
 Should the camera keep track of `time1` and `time2` or should that be up to the user of camera when
@@ -171,6 +174,7 @@ times need not match up with the camera aperture open close.
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+<div class='together'>
 An alternative to making a new moving sphere class is to just make them all move and have the
 stationary ones have the same begin and end point. I’m on the fence about that trade-off between
 fewer classes and more efficient stationary spheres, so let your design taste guide you. The
@@ -207,7 +211,9 @@ intersection code barely needs a change: `center` just needs to become a functio
         return false;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Be sure that in the materials you have the scattered rays be at the time of the incident ray.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -227,9 +233,11 @@ Be sure that in the materials you have the scattered rays be at the time of the 
         vec3 albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 If we take the example diffuse spheres from scene at the end of the last book and make them move
-from their centers at `time==0`, to `center + vec3(0, 0.5*random_double(), 0)` at `time==1`, with 
+from their centers at `time==0`, to `center + vec3(0, 0.5*random_double(), 0)` at `time==1`, with
 the camera aperture open over that frame.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -280,7 +288,9 @@ the camera aperture open over that frame.
         return new hitable_list(list,i);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And with these viewing parameters gives:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -296,6 +306,8 @@ And with these viewing parameters gives:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   ![Image 2-1](../images/img-2-2-01.jpg)
+
+</div>
 
 
 
@@ -314,6 +326,7 @@ can be a sublinear search. The two most common families of sorting are to 1) div
 2) divide the objects. The latter is usually much easier to code up and just as fast to run for most
 models.
 
+<div class='together'>
 The key idea of a bounding volume over a set of primitives is to find a volume that fully encloses
 (bounds) all the objects. For example, suppose you computed a bounding sphere of 10 objects. Any ray
 that misses the bounding sphere definitely misses all ten objects. If the ray hits the bounding
@@ -325,16 +338,21 @@ sphere, then it might hit one of the ten objects. So the bounding code is always
     else
         return false
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 A key thing is we are dividing objects into subsets. We are not dividing the screen or the volume.
 Any object is in just one bounding volume, but bounding volumes can overlap.
 
+<div class='together'>
 To make things sub-linear we need to make the bounding volumes hierarchical. For example, if we
 divided a set of objects into two groups, red and blue, and used rectangular bounding volumes, we’d
 have:
 
   ![Figure 3-1](../images/fig-2-3-01.jpg)
 
+</div>
+
+<div class='together'>
 Note that the blue and red bounding volumes are contained in the purple one, but they might
 overlap, and they are not ordered -- they are just both inside. So the tree shown on the right has
 no concept of ordering in the left and right children; they are simply inside. The code would be:
@@ -347,6 +365,7 @@ no concept of ordering in the left and right children; they are simply inside. T
             return true and info of closer hit
     return false
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 To get that all to work we need a way to make good divisions, rather than bad ones, and a way to
 intersect a ray with a bounding volume. A ray bounding volume intersection needs to be fast, and
@@ -359,6 +378,7 @@ need to be called if precise) axis-aligned bounding boxes, or AABBs. Any method 
 intersect a ray with an AABB is fine. And all we need to know is whether or not we hit it; we don’t
 need hit points or normals or any of that stuff that we need for an object we want to display.
 
+<div class='together'>
 Most people use the “slab” method. This is based on the observation that an n-dimensional AABB is
 just the intersection of n axis-aligned intervals, often called “slabs” An interval is just
 the points between two endpoints, _e.g._, $x$ such that $3 < x < 5$, or more succinctly $x$ in
@@ -366,36 +386,53 @@ $(3,5)$. In 2D, two intervals overlapping makes a 2D AABB (a rectangle):
 
   ![Figure 3-2](../images/fig-2-3-02.jpg)
 
+</div>
+
+<div class='together'>
 For a ray to hit one interval we first need to figure out whether the ray hits the boundaries. For
 example, again in 2D, this is the ray parameters $t_0$ and $t_1$. (If the ray is parallel to the
 plane those will be undefined.)
 
   ![Figure 3-3](../images/fig-2-3-03.jpg)
 
+</div>
+
+<div class='together'>
 In 3D, those boundaries are planes. The equations for the planes are $x = x_0$, and $x = x_1$. Where
 does the ray hit that plane? Recall that the ray can be thought of as just a function that given a
 $t$ returns a location $p(t)$:
 
   $$ p(t) = A + t \cdot B $$
+</div>
 
+<div class='together'>
 That equation applies to all three of the x/y/z coordinates. For example $x(t) = A_x + t \cdot B_x$.
 This ray hits the plane $x = x_0$ at the $t$ that satisfies this equation:
 
   $$ x_0 = A_x + t_0 \cdot B_x $$
+</div>
 
+<div class='together'>
 Thus $t$ at that hitpoint is:
 
   $$ t_0 = \frac{x_0 - A_x}{B_x} $$
+</div>
 
+<div class='together'>
 We get the similar expression for $x_1$:
 
   $$ t_1 = \frac{x_1 - A_x}{B_x} $$
+</div>
 
+<div class='together'>
 The key observation to turn that 1D math into a hit test is that for a hit, the $t$-intervals need
 to overlap. For example, in 2D the green and blue overlapping only happens if there is a hit:
 
   ![Figure 3-4](../images/fig-2-3-04.jpg)
 
+</div>
+
+<div class='together'>
 What “do the t intervals in the slabs overlap?” would like in code is something like:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -413,7 +450,9 @@ slab method:
     compute (tz0, tz1)
     return overlap?( (tx0, tx1), (ty0, ty1), (tz0, tz1))
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 There are some caveats that make this less pretty than it first appears. First, suppose the ray is
 travelling in the negative $x$ direction. The interval $(t_{x0}, t_{x1})$ as computed above might be
 reversed, _e.g._ something like $(7, 3)$. Second, the divide in there could give us infinities. And
@@ -426,7 +465,9 @@ First let’s look at computing the intervals:
 
   $$ t_{x0} = \frac{x_0 - A_x}{B_x} $$
   $$ t_{x1} = \frac{x_1 - A_x}{B_x} $$
+</div>
 
+<div class='together'>
 One troublesome thing is that perfectly valid rays will have $B_x = 0$, causing division by zero.
 Some of those rays are inside the slab, and some are not. Also, the zero will have a ± sign under
 IEEE floating point. The good news for $B_x = 0$ is that $t_{x0}$ and $t_{x1}$ will both be +∞ or
@@ -434,11 +475,13 @@ both be -∞ if not between $x_0$ and $x_1$. So, using min and max should get us
 
   $$ t_{x0} = min(\frac{x_0 - A_x}{B_x}, \frac{x_1 - A_x}{B_x}) $$
   $$ t_{x1} = max(\frac{x_0 - A_x}{B_x}, \frac{x_1 - A_x}{B_x}) $$
+</div>
 
 The remaining troublesome case if we do that is if $B_x = 0$ and either $x_0 - A_x = 0$ or $x_1-A_x
 = 0$ so we get a `NaN`. In that case we can probably accept either hit or no hit answer, but we’ll
 revisit that later.
 
+<div class='together'>
 Now, let’s look at that overlap function. Suppose we can assume the intervals are not reversed (so
 the first value is less than the second value in the interval) and we want to return true in that
 case. The boolean overlap that also computes the overlap interval $(f, F)$ of intervals $(d, D)$ and
@@ -450,7 +493,9 @@ $(e, E)$ would be:
         F = min(D, E)
         return (f < F)
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 If there are any `NaN`s running around there, the compare will return false so we need to be sure
 our bounding boxes have a little padding if we care about grazing cases (and we probably should
 because in a ray tracer all cases come up eventually). With all three dimensions in a loop and
@@ -486,7 +531,9 @@ passing in the interval $t_{min}$, $t_{max}$ we get:
             vec3 _max;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Note that the built-in `fmax()` is replaced by `ffmax()` which is quite a bit faster because it
 doesn’t worry about `NaN`s and other exceptions. In reviewing this intersection method, Andrew
 Kensler at Pixar tried some experiments and has proposed this version of the code which works
@@ -508,7 +555,9 @@ extremely well on many compilers, and I have adopted it as my go-to method:
         return true;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 We now need to add a function to compute bounding boxes to all of the hitables. Then we will make a
 hierarchy of boxes over all the primitives and the individual primitives, like spheres, will live at
 the leaves. That function returns a bool because not all primitives have bounding boxes (_e.g._,
@@ -523,7 +572,9 @@ frame and the bounding box will bound the object moving through that interval.
             virtual bool bounding_box(float t0, float t1, aabb& box) const = 0;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 For a sphere, that `bounding_box` function is easy:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -533,7 +584,9 @@ For a sphere, that `bounding_box` function is easy:
         return true;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 For `moving sphere`, we can take the box of the sphere at $t_0$, and the box of the sphere at $t_1$,
 and compute the box of those two boxes:
 
@@ -547,7 +600,9 @@ and compute the box of those two boxes:
         return true;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 For lists you can store the bounding box at construction, or compute it on the fly. I like doing it
 the fly because it is only usually called at BVH construction.
 
@@ -570,7 +625,9 @@ the fly because it is only usually called at BVH construction.
         return true;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 This requires the `surrounding_box` function for `aabb` which computes the bounding box of two
 boxes:
 
@@ -585,7 +642,9 @@ boxes:
         return aabb(small,big);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 A BVH is also going to be a `hitable` -- just like lists of `hitable`s. It’s really a container, but
 it can respond to the query “does this ray hit you?”. One design question is whether we have two
 classes, one for the tree, and one for the nodes in the tree; or do we have just one class and have
@@ -610,10 +669,12 @@ a class:
         return true;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 Note that the children pointers are to generic hitables. They can be other `bvh_nodes`, or
 `spheres`, or any other `hitable`.
 
+<div class='together'>
 The `hit` function is pretty straightforward: check whether the box for the node is hit, and if so,
 check the children and sort out any details:
 
@@ -644,7 +705,9 @@ check the children and sort out any details:
         else return false;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 The most complicated part of any efficiency structure, including the BVH, is building it. We do this
 in the constructor. A cool thing about BVHs is that as long as the list of objects in a `bvh_node`
 gets divided into two sub-lists, the hit function will work. It will work best if the division is
@@ -656,11 +719,14 @@ list along one axis. I’ll go for simplicity:
 2. sort the primitives using library qsort
 3. put half in each subtree
 
+</div>
+
 I used the old-school C `qsort` rather than the C++ sort because I need a different compare operator
 depending on axis, and `qsort` takes a compare function rather than using the less-than operator. I
 pass in a pointer to pointer -- this is just C for “array of pointers” because a pointer in C can
 also just be a pointer to the first element of an array.
 
+<div class='together'>
 When the list coming in is two elements, I put one in each subtree and end the recursion. The
 traverse algorithm should be smooth and not have to check for null pointers, so if I just have one
 element I duplicate it in each subtree. Checking explicitly for three elements and just following
@@ -696,6 +762,7 @@ This yields:
         box = surrounding_box(box_left, box_right);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 The check for whether there is a bounding box at all is in case you sent in something like an
 infinite plane that doesn’t have a bounding box. We don’t have any of those primitives, so it
@@ -749,6 +816,7 @@ being able to make any color a texture is great.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+<div class='together'>
 Now we can make textured materials by replacing the vec3 color with a texture pointer:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -765,15 +833,23 @@ Now we can make textured materials by replacing the vec3 color with a texture po
             texture *albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 where you used to have
 
-`new lambertian(vec3(0.5, 0.5, 0.5)))`
- 
-now you should replace the vec3(...) with `new constant_texture(vec3(...))`
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    new lambertian(vec3(0.5, 0.5, 0.5)))
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`new lambertian(new constant_texture(vec3(0.5, 0.5, 0.5))))`
+now you should replace the `vec3(...)` with `new constant_texture(vec3(...))`
 
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    new lambertian(new constant_texture(vec3(0.5, 0.5, 0.5))))
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
+
+<div class='together'>
 We can create a checker texture by noting that the sign of sine and cosine just alternates in a
 regular way and if we multiply trig functions in all three dimensions, the sign of that product
 forms a 3D checker pattern.
@@ -794,10 +870,12 @@ forms a 3D checker pattern.
             texture *even;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 Those checker odd/even pointers can be to a constant texture or to some other procedural texture.
 This is in the spirit of shader networks introduced by Pat Hanrahan back in the 1980s.
 
+<div class='together'>
 If we add this to our random_scene() function’s base sphere:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -812,6 +890,9 @@ We get:
 
   ![Image 4-1](../images/img-2-4-01.jpg)
 
+</div>
+
+<div class='together'>
 If we add a new scene:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -844,11 +925,14 @@ We get:
 
   ![Image 4-2](../images/img-2-4-02.jpg)
 
+</div>
+
 
 
 Perlin Noise
 ====================================================================================================
 
+<div class='together'>
 To get cool looking solid textures most people use some form of Perlin noise. These are named after
 their inventor Ken Perlin. Perlin texture doesn’t return white noise like this:
 
@@ -858,16 +942,22 @@ Instead it returns something similar to blurred white noise:
 
   ![Image 5-2](../images/img-2-5-02.jpg)
 
+</div>
+
 A key part of Perlin noise is that it is repeatable: it takes a 3D point as input and always returns
 the same randomish number. Nearby points return similar numbers. Another important part of Perlin
 noise is that it be simple and fast, so it’s usually done as a hack. I’ll build that hack up
 incrementally based on Andrew Kensler’s description.
 
+<div class='together'>
 We could just tile all of space with a 3D array of random numbers and use them in blocks. You get
 something blocky where the repeating is clear:
 
   ![Image 5-3](../images/img-2-5-03.jpg)
 
+</div>
+
+<div class='together'>
 Let’s just use some sort of hashing to scramble this, instead of tiling. This has a bit of support
 code to make it all happen:
 
@@ -919,7 +1009,9 @@ code to make it all happen:
     int *perlin::perm_y = perlin_generate_perm();
     int *perlin::perm_z = perlin_generate_perm();
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Now if we create an actual texture that takes these floats between 0 and 1 and creates grey
 colors:
 
@@ -933,7 +1025,9 @@ colors:
             perlin noise;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And we can use that one some spheres:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -945,7 +1039,9 @@ And we can use that one some spheres:
         return new hitable_list(list, 2);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 With the same camera as before:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -956,11 +1052,16 @@ With the same camera as before:
     camera cam(lookfrom, lookat, vec3(0,1,0), 20, float(nx)/float(ny),
                aperture, dist_to_focus, 0.0, 1.0);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Add the hashing does scramble as hoped:
 
   ![Image 5-4](../images/img-2-5-04.jpg)
 
+</div>
+
+<div class='together'>
 To make it smooth, we can linearly interpolate:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1001,11 +1102,16 @@ To make it smooth, we can linearly interpolate:
             static int *perm_z;
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And we get:
 
   ![Image 5-5](../images/img-2-5-05.jpg)
 
+</div>
+
+<div class='together'>
 Better, but there are obvious grid features in there. Some of it is Mach bands, a known perceptual
 artifact of linear interpolation of color. A standard trick is to use a hermite cubic to round off
 the interpolation:
@@ -1027,11 +1133,16 @@ the interpolation:
                 int k = floor(p.z());
                 ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 This gives a smoother looking image:
 
   ![Image 5-6](../images/img-2-5-06.jpg)
 
+</div>
+
+<div class='together'>
 It is also a bit low frequency. We can scale the input point to make it vary more quickly:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1051,6 +1162,9 @@ which gives:
 
   ![Image 5-7](../images/img-2-5-07.jpg)
 
+</div>
+
+<div class='together'>
 This is still a bit grid blocky looking, probably because the min and max of the pattern always
 lands exactly on the integer x/y/z. Ken Perlin’s very clever trick was to instead put random unit
 vectors (instead of just floats) on the lattice points, and use a dot product to move the min and
@@ -1062,7 +1176,9 @@ max off the lattice. So, first we need to change the random floats to random vec
     int *perlin::perm_y = perlin_generate_perm();
     int *perlin::perm_z = perlin_generate_perm();
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 These vectors are any reasonable set of irregular directions, and I won't bother to make them
 exactly uniform:
 
@@ -1078,7 +1194,9 @@ exactly uniform:
         return p;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 The Perlin class is now:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1108,7 +1226,9 @@ The Perlin class is now:
             static int *perm_z;
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And the interpolation becomes a bit more complicated:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1128,11 +1248,16 @@ And the interpolation becomes a bit more complicated:
         return accum;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 This finally gives something more reasonable looking:
 
   ![Image 5-8](../images/img-2-5-08.jpg)
 
+</div>
+
+<div class='together'>
 Very often, a composite noise that has multiple summed frequencies is used. This is usually called
 turbulence and is a sum of repeated calls to noise:
 
@@ -1149,13 +1274,18 @@ turbulence and is a sum of repeated calls to noise:
         return fabs(accum);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
-Here fabs() is the math.h absolute value function.
+Here `fabs()` is the `math.h` absolute value function.
 
+<div class='together'>
 Used directly, turbulence gives a sort of camouflage netting appearance:
 
   ![Image 5-9](../images/img-2-5-09.jpg)
 
+</div>
+
+<div class='together'>
 However, usually turbulence is used indirectly. For example, the “hello world” of procedural solid
 textures is a simple marble-like texture. The basic idea is to make color proportional to something
 like a sine function, and use turbulence to adjust the phase (so it shifts $x$ in $sin( x )$) which
@@ -1181,6 +1311,8 @@ Which yields:
 
   ![Image 5-10](../images/img-2-5-10.jpg)
 
+</div>
+
 
 
 Image Texture Mapping
@@ -1189,6 +1321,7 @@ Image Texture Mapping
 We used the hitpoint p before to index a procedure solid texture like marble. We can also read in an
 image and use a 2D $(u,v)$ texture coordinate to index into the image.
 
+<div class='together'>
 A direct way to use scaled $(u,v)$ in an image is to round the u and v to integers, and use that as
 $(i,j)$ pixels. This is awkward, because we don’t want to have to change the code when we change
 image resolution. So instead, one of the the most universal unofficial standards in graphics is to
@@ -1198,7 +1331,9 @@ position is:
 
   $$ u = i/(nx-1) $$
   $$ v = j/(nx-1) $$
+</div>
 
+<div class='together'>
 This is just a fractional position. For a hitable, we need to also return a u and v in the hit
 record. For spheres, this is usually based on some form of longitude and latitude, _i.e._, spherical
 coordinates. So if we have a $(\theta,\phi)$ in spherical coordinates we just need to scale $\theta$
@@ -1207,34 +1342,44 @@ the axis through the poles, the normalization to $[0,1]$ would be:
 
   $$ u = \phi / (2\pi) $$
   $$ v = \theta / \pi $$
+</div>
 
+<div class='together'>
 To compute $\theta$ and $\phi$, for a given hitpoint, the formula for spherical coordinates of a
 unit radius sphere on the origin is:
 
   $$ x = cos(\phi) cos(\theta) $$
   $$ y = sin(\phi) cos(\theta) $$
   $$ z = sin(\theta) $$
+</div>
 
+<div class='together'>
 We need to invert that. Because of the lovely `math.h` function `atan2()` which takes any number
 proportional to sine and cosine and returns the angle, we can pass in $x$ and $y$ (the $cos(\theta)$
 cancel):
 
   $$ \phi = atan2(y, x) $$
+</div>
 
-The $atan2$ returns in the range $-\pi$ to $\pi$ so we need to take a little care there. 
+<div class='together'>
+The $atan2$ returns in the range $-\pi$ to $\pi$ so we need to take a little care there.
 The $\theta$ is more straightforward:
 
   $$ \theta = asin(z) $$
 
 which returns numbers in the range $-\pi/2$ to $\pi/2$.
+</div>
 
+<div class='together'>
 So for a sphere, the $(u,v)$ coord computation is accomplished by a utility function that expects
 things on the unit sphere centered at the origin. The call inside sphere::hit should be:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     get_sphere_uv((rec.p-center)/radius, rec.u, rec.v);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 The utility function is:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1245,6 +1390,7 @@ The utility function is:
         v = (theta + M_PI/2) / M_PI;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 Now we also need to create a texture class that holds an image. I am going to use my favorite image
 utility `stb_image`. It reads in an image into a big array of unsigned char. These are just packed
@@ -1275,6 +1421,7 @@ RGBs that each range 0..255 for black to fully-on.
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+<div class='together'>
 The representation of a packed array in that order is pretty standard. Thankfully, the `stb_image`
 package makes that super simple -- just include the header in `main.h` with a `#define`:
 
@@ -1282,9 +1429,11 @@ package makes that super simple -- just include the header in `main.h` with a `#
     #define STB_IMAGE_IMPLEMENTATION
     #include "stb_image.h"
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
-  ![Image 6-1](../images/earthmap.jpg)
+<div class='together'>
 
+  ![Image 6-1: earthmap.jpg](../images/earthmap.jpg)
 
 To read an image from a file earthmap.jpg (I just grabbed a random earth map from the web -- any
 standard projection will do for our purposes), and then assign it to a diffuse material, the code
@@ -1295,20 +1444,25 @@ is:
     unsigned char *tex_data = stbi_load("earthmap.jpg", &nx, &ny, &nn, 0);
     material *mat = new lambertian(new image_texture(tex_data, nx, ny));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 We start to see some of the power of all colors being textures -- we can assign any kind of texture
 to the lambertian material, and lambertian doesn’t need to be aware of it.
 
+<div class='together'>
 To test this, assign it to a sphere, and then temporarily cripple the color() function in main to
 just return attenuation. You should get something like:
 
   ![Image 6-2](../images/img-2-6-02.jpg)
+
+</div>
 
 
 
 Rectangles and Lights
 ====================================================================================================
 
+<div class='together'>
 First, let’s make a light emitting material. We need to add an emitted function (we could also add
 it to hit_record instead -- that’s a matter of design taste). Like the background, it just tells the
 ray what color it is and performs no reflection. It’s very simple:
@@ -1325,7 +1479,9 @@ ray what color it is and performs no reflection. It’s very simple:
             texture *emit;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 So that I don’t have to make all the non-emitting materials implement `emitted()`, I have the base
 class return black:
 
@@ -1339,7 +1495,9 @@ class return black:
             }
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Next, let’s make the background black in our color function, and pay attention to emitted:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1358,29 +1516,38 @@ Next, let’s make the background black in our color function, and pay attention
             return vec3(0,0,0);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 Now, let’s make some rectangles. Rectangles are often convenient for modelling man-made
 environments. I’m a fan of doing axis-aligned rectangles because they are easy. (We’ll get to
 instancing so we can rotate them later.)
 
+<div class='together'>
 First, here is a rectangle in an xy plane. Such a plane is defined by its z value. For example, $z =
 k$. An axis-aligned rectangle is defined by lines $x=x_0$ , $x=x_1$ , $y=y_0$ , $y=y_1$.
 
   ![Figure 7-1](../images/fig-2-7-01.jpg)
 
+</div>
+
+<div class='together'>
 To determine whether a ray hits such a rectangle, we first determine where the ray hits the plane.
 Recall that a ray $p(t) = a + t \cdot b$ has its z component defined by $z(t) = a_z + t \cdot b_z$.
 Rearranging those terms we can solve for what the t is where $z=k$.
 
   $$ t = (k-a_z) / b_z $$
+</div>
 
+<div class='together'>
 Once we have t, we can plug that into the equations for x and y:
 
   $$ x = a_x + t*b_x $$
   $$ y = a_y + t*b_y $$
+</div>
 
 It is a hit if $x_0 < x < x_1$ and $y_0 < y < y_1$.
 
+<div class='together'>
 The actual `xy_rect` class is thus:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1398,7 +1565,9 @@ The actual `xy_rect` class is thus:
             float x0, x1, y0, y1, k;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And the hit function is:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1419,7 +1588,9 @@ And the hit function is:
         return true;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 If we set up a rectangle as a light:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1435,19 +1606,27 @@ If we set up a rectangle as a light:
         return new hitable_list(list,4);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 We get:
 
   ![Image 7-1](../images/img-2-7-01.jpg)
 
+</div>
+
 Note that the light is brighter than $(1,1,1)$. This allows it to be bright enough to light things.
 
+<div class='together'>
 Fool around with making some spheres lights too.
 
   ![Image 7-2](../images/img-2-7-02.jpg)
 
+</div>
+
 Now let’s add the other two axes and the famous Cornell Box.
 
+<div class='together'>
 This is yz and xz.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1479,7 +1658,9 @@ This is yz and xz.
             float y0, y1, z0, z1, k;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 With unsurprising hit functions:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1517,7 +1698,9 @@ With unsurprising hit functions:
         return true;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Let’s make the 5 walls and the light of the box:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1538,7 +1721,9 @@ Let’s make the 5 walls and the light of the box:
         return new hitable_list(list,i);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And the view info:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1551,11 +1736,16 @@ And the view info:
     camera cam(lookfrom, lookat, vec3(0,1,0), vfov, float(nx)/float(ny),
         aperture, dist_to_focus, 0.0, 1.0);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 We get:
 
   ![Image 7-3](../images/img-2-7-03.jpg)
 
+</div>
+
+<div class='together'>
 This is very noisy because the light is small. But why are the other walls missing? They are facing
 the wrong way. We need outward facing normals. Let’s make a hitable that does nothing but hold
 another hitable, but reverses the normals:
@@ -1583,7 +1773,9 @@ another hitable, but reverses the normals:
             hitable *ptr;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 This makes Cornell:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1605,10 +1797,14 @@ This makes Cornell:
         return new hitable_list(list,i);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And voila:
 
   ![Image 7-4](../images/img-2-7-04.jpg)
+
+</div>
 
 
 
@@ -1653,6 +1849,7 @@ make an axis-aligned block primitive that holds 6 rectangles:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+<div class='together'>
 Now we can add two blocks (but not rotated)
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1660,10 +1857,16 @@ Now we can add two blocks (but not rotated)
     list[i++] = new box(vec3(265, 0, 295), vec3(430, 330, 460), white);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+</div>
+
+<div class='together'>
 This gives:
 
   ![Image 8-1](../images/img-2-8-01.jpg)
 
+</div>
+
+<div class='together'>
 Now that we have boxes, we need to rotate them a bit to have them match the _real_ Cornell box. In
 ray tracing, this is usually done with an _instance_. An instance is a geometric primitive that has
 been moved or rotated somehow. This is especially easy in ray tracing because we don’t move
@@ -1674,6 +1877,9 @@ subtract 2 off the x-component of the ray origin.
 
   ![Figure 8-1](../images/fig-2-8-01.jpg)
 
+</div>
+
+<div class='together'>
 Whether you think of this as a move or a change of coordinates is up to you. The code for this, to
 move any underlying hitable is a _translate_ instance.
 
@@ -1708,7 +1914,9 @@ move any underlying hitable is a _translate_ instance.
             return false;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Rotation isn’t quite as easy to understand or generate the formulas for. A common graphics tactic is
 to apply all rotations about the x, y, and z axes. These rotations are in some sense axis-aligned.
 First, let’s rotate by theta about the z-axis. That will be changing only x and y, and in ways that
@@ -1716,33 +1924,40 @@ don’t depend on z.
 
   ![Figure 8-2](../images/fig-2-8-02.jpg)
 
+</div>
+
+<div class='together'>
 This involves some basic trigonometry that uses formulas that I will not cover here. That gives you
 the correct impression it’s a little involved, but it is straightforward, and you can find it in any
 graphics text and in many lecture notes. The result for rotating counter-clockwise about z is:
 
-  $$ x\prime = cos(\theta) \cdot x - sin(\theta) \cdot y $$
-  $$ y\prime = sin(\theta) \cdot x + cos(\theta) \cdot y $$
+  $$ x' = cos(\theta) \cdot x - sin(\theta) \cdot y $$
+  $$ y' = sin(\theta) \cdot x + cos(\theta) \cdot y $$
+</div>
 
-The great thing is that it works for any $\theta$ and doesn’t need any cases for quadrants or 
-anything like that. The inverse transform is the opposite geometric operation: rotate by $-\theta$. 
-Here, recall that $cos(\theta) = cos(-\theta)$ and $sin(-\theta) = -sin(\theta)$, so the formulas 
+The great thing is that it works for any $\theta$ and doesn’t need any cases for quadrants or
+anything like that. The inverse transform is the opposite geometric operation: rotate by $-\theta$.
+Here, recall that $cos(\theta) = cos(-\theta)$ and $sin(-\theta) = -sin(\theta)$, so the formulas
 are very simple.
 
+<div class='together'>
 Similarly, for rotating about y (as we want to do for the blocks in the box) the formulas are:
 
-  $$ x\prime =  cos(\theta) \cdot x + sin(\theta) \cdot z $$
-  $$ z\prime = -sin(\theta) \cdot x + cos(\theta) \cdot z $$
+  $$ x' =  cos(\theta) \cdot x + sin(\theta) \cdot z $$
+  $$ z' = -sin(\theta) \cdot x + cos(\theta) \cdot z $$
 
 And about the x-axis:
 
-  $$ y\prime = cos(\theta) \cdot y - sin(\theta) \cdot z $$
-  $$ z\prime = sin(\theta) \cdot y + cos(\theta) \cdot z $$
+  $$ y' = cos(\theta) \cdot y - sin(\theta) \cdot z $$
+  $$ z' = sin(\theta) \cdot y + cos(\theta) \cdot z $$
+</div>
 
 Unlike the situation with translations, the surface normal vector also changes, so we need to
 transform directions too if we get a hit. Fortunately for rotations, the same formulas apply. If you
 add scales, things get more complicated. See the web page https://in1weekend.blogspot.com/ for links
 to that.
 
+<div class='together'>
 For a y-rotation class we have:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1761,7 +1976,9 @@ For a y-rotation class we have:
             aabb bbox;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 With constructor:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1794,7 +2011,9 @@ With constructor:
         bbox = aabb(min, max);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And the hit function:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1821,7 +2040,9 @@ And the hit function:
             return false;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And the changes to Cornell is:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1834,10 +2055,14 @@ And the changes to Cornell is:
                     vec3(265,,0,295)
                 );
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Which yields:
 
   ![Image 8-2](../images/img-2-8-02.jpg)
+
+</div>
 
 
 
@@ -1859,14 +2084,17 @@ through.
 
   ![Figure 9-1](../images/fig-2-9-01.jpg)
 
+<div class='together'>
 As the ray passes through the volume, it may scatter at any point. The denser the volume, the more
 likely that is. The probability that the ray scatters in any small distance $\delta L$ is:
 
   $$ probability = C \cdot \delta L $$
+</div>
 
-where $C$ is proportional to the optical density of the volume. If you go through all the 
-differential equations, for a random number you get a distance where the scattering occurs. If 
-that distance is outside the volume, then there is no “hit”. For a constant volume we just need 
+<div class='together'>
+where $C$ is proportional to the optical density of the volume. If you go through all the
+differential equations, for a random number you get a distance where the scattering occurs. If
+that distance is outside the volume, then there is no “hit”. For a constant volume we just need
 the density $C$ and the boundary. I’ll use another hitable for the boundary. The resulting class is:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1887,7 +2115,9 @@ the density $C$ and the boundary. I’ll use another hitable for the boundary. T
             material *phase_function;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 The scattering function of isotropic picks a uniform random direction:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1907,7 +2137,9 @@ The scattering function of isotropic picks a uniform random direction:
             texture *albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And the hit function is:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1956,11 +2188,13 @@ And the hit function is:
         return false;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 The reason we have to be so careful about the logic around the boundary is we need to make sure this
 works for ray origins inside the volume. In clouds, things bounce around a lot so that is a common
 case.
 
+<div class='together'>
 If we replace the two blocks with smoke and fog (dark and light particles) and make the light bigger
 (and dimmer so it doesn’t blow out the scene) for faster convergence:
 
@@ -1995,10 +2229,14 @@ If we replace the two blocks with smoke and fog (dark and light particles) and m
         return new hitable_list(list,i);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 We get:
 
   ![Image 9-1](../images/img-2-9-01.jpg)
+
+</div>
 
 
 
@@ -2067,9 +2305,12 @@ why we get caustics and subsurface for free. It’s a double-edged design decisi
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+<div class='together'>
 Running it with 10,000 rays per pixel yields:
 
   ![Image 10-1](../images/img-2-10-01.jpg)
+
+</div>
 
 Now go off and make a really cool image of your own! See https://in1weekend.blogspot.com/ for
 pointers to further reading and features, and feel free to email questions, comments, and cool

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -15,10 +15,11 @@
 Overview
 ====================================================================================================
 
-<div class='warning'>
-  <p class='title'>WARNING<br>Content Under Development</h1>
-  <p class='text'>See <a href='https://github.com/RayTracing/raytracing.github.io/releases/'>release page</a> for latest official PDF version.
-</div>
+
+!!! ERROR: Content Under Development
+    See [the official release page](https://github.com/RayTracing/raytracing.github.io/releases/)
+    for latest official PDF version.
+
 
 In _Ray Tracing In One Weekend_ and _Ray Tracing: the Next Week_, you built a “real” ray tracer.
 
@@ -57,18 +58,24 @@ estimate of an answer, and this estimate gets more and more accurate the longer 
 basic characteristic of simple programs producing noisy but ever-better answers is what MC is all
 about, and it is especially good for applications like graphics where great accuracy is not needed.
 
-As an example, let’s estimate $\pi$. There are many ways to do this, with the Buffon Needle 
+<div class='together'>
+As an example, let’s estimate $\pi$. There are many ways to do this, with the Buffon Needle
 problem being a classic case study. We’ll do a variation inspired by that. Suppose you have a circle
 inscribed inside a square:
 
   ![Figure 2-1](../images/fig-3-02-1.jpg)
 
+</div>
+
+<div class='together'>
 Now, suppose you pick random points inside the square. The fraction of those random points that end
 up inside the circle should be proportional to the area of the circle. The exact fraction should in
 fact be the ratio of the circle area to the square area. Fraction:
 
   $$ \frac{Pi \cdot R^2}{(2R)^2} = \frac{Pi}{4} $$
+</div>
 
+<div class='together'>
 Since the *R* cancels out, we can pick whatever is computationally convenient. Let’s go with R=1
 centered at the origin:
 
@@ -90,9 +97,11 @@ centered at the origin:
         std::cout << "Estimate of Pi = " << 4*float(inside_circle) / N << "\n";
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 This gives me the answer `Estimate of Pi = 3.196`
 
+<div class='together'>
 If we change the program to run forever and just print out a running estimate:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -117,7 +126,9 @@ If we change the program to run forever and just print out a running estimate:
         }
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 We get very quickly near $\pi$, and then more slowly zero in on it. This is an example of the *Law
 of Diminishing Returns*, where each sample helps less than the last. This is the worst part of MC.
 We can mitigate this diminishing return by *stratifying* the samples (often called *jittering*),
@@ -125,6 +136,9 @@ where instead of taking random samples, we take a grid and take one sample withi
 
   ![Figure 2-2](../images/fig-3-02-2.jpg)
 
+</div>
+
+<div class='together'>
 This changes the sample generation, but we need to know how many samples we are taking in advance
 because we need to know the grid. Let’s take a hundred million and try it both ways:
 
@@ -161,6 +175,7 @@ I get:
     Regular Estimate of Pi = 3.1415
     Stratified Estimate of Pi = 3.14159
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 Interestingly, the stratified method is not only better, it converges with a better asymptotic rate!
 Unfortunately, this advantage decreases with the dimension of the problem (so for example, with the
@@ -181,6 +196,7 @@ classic integral:
 
 $$ I = \int_{0}^{2} x^2 dx $$
 
+<div class='together'>
 In computer sciency notation, we might write this as:
 
 $$ I = area( x^2, 0, 2 ) $$
@@ -188,7 +204,9 @@ $$ I = area( x^2, 0, 2 ) $$
 We could also write it as:
 
 $$ I = 2 \cdot average(x^2, 0, 2) $$
+</div>
 
+<div class='together'>
 This suggests a MC approach:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -204,6 +222,7 @@ This suggests a MC approach:
         std::cout << "I =" << 2*sum/N << "\n";
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 This, as expected, produces approximately the exact answer we get with algebra, $I = 8/3$. But we
 could also do it for functions that we can’t analytically integrate like $log(sin(x))$. In graphics,
@@ -218,11 +237,15 @@ that problem if we sent more random samples toward the light, but then we would 
 those samples to adjust for the over-sampling. How we do that adjustment? To do that we will need
 the concept of a _probability density function_.
 
+<div class='together'>
 First, what is a _density function_? It’s just a continuous form of a histogram. Here’s an example
 from the histogram Wikipedia page:
 
   ![Figure 3-1](../images/fig-3-03-1.jpg)
 
+</div>
+
+<div class='together'>
 If we added data for more trees, the histogram would get taller. If we divided the data into more
 bins, it would get shorter. A discrete density function differs from a histogram in that it
 normalizes the frequency y-axis to a fraction or percentage (just a fraction times 100). A
@@ -232,10 +255,13 @@ adjust them so they don’t get shorter as we add more bins. For the case of the
 we might try:
 
   $$ \text{Bin-height} = \frac{(\text{Fraction of trees between height }H\text{ and }H’)}{(H-H’)} $$
+</div>
 
+<div class='together'>
 That would work! We could interpret that as a statistical predictor of a tree’s height:
 
   $$ \text{Probability a random tree is between } H \text{ and } H’ = \text{Bin-height}\cdot(H-H’)$$
+</div>
 
 If we wanted to know about the chances of being in a span of multiple bins, we would sum.
 
@@ -247,18 +273,23 @@ to look something like the figure below. But how high should it be?
 
   ![Figure 3-2](../images/fig-3-03-2.jpg)
 
+<div class='together'>
 The height is just $p(2)$. What should that be? We could reasonably make it anything by
 convention, and we should pick something that is convenient. Just as with histograms we can sum up
 (integrate) the region to figure out the probability that $r$ is in some interval $(x0,x1)$:
 
   $$ \text{Probability } x0 < r < x1 = C \cdot area(p(r), x0, x1) $$
+</div>
 
+<div class='together'>
 where $C$ is a scaling constant. We may as well make $C = 1$ for cleanliness, and that is exactly
 what is done in probability. And we know the probability $r$ has the value 1 somewhere, so for
 this case
 
   $$ area(p(r), 0, 2) = 1 $$
+</div>
 
+<div class='together'>
 Since $p(r)$ is proportional to $r$ , _i.e._, $p = C’ \cdot r$ for some other constant $C’$
 
   $$
@@ -268,30 +299,38 @@ Since $p(r)$ is proportional to $r$ , _i.e._, $p = C’ \cdot r$ for some other 
   $$
 
 So $p(r) = r/2$.
+</div>
 
 How do we generate a random number with that pdf $p(r)$? For that we will need some more machinery.
 Don’t worry this doesn’t go on forever!
 
-Given a random number from `d = random_double()` that is uniform and between 0 and 1, we should be 
+<div class='together'>
+Given a random number from `d = random_double()` that is uniform and between 0 and 1, we should be
 able to find some function $f(d)$ that gives us what we want. Suppose $e = f(d) = d^2$. That is no
 longer a uniform _pdf_ . The _pdf_ of $e$ will be bigger near 0 than it is near 1 (squaring a
 number between 0 and 1 makes it smaller). To take this general observation to a function, we need
 the cumulative probability distribution function $P(x)$:
 
   $$ P(x) = area(p, -\infty, x) $$
+</div>
 
+<div class='together'>
 Note that for x where we didn’t define $p(x)$, $p(x) = 0$, _i.e._, the probability of an $x$ there
 is zero. For our example _pdf_ $p(r) = r/2$ , the $P(x)$ is:
 
   $$ P(x) = 0 : x < 0                 $$
   $$ P(x) = \frac{x^2}{4} : 0 < x < 2 $$
   $$ P(x) = 1 : x > 2                 $$
+</div>
 
+<div class='together'>
 One question is, what’s up with $x$ versus $r$? They are dummy variables -- analogous to the
 function arguments in a program. If we evaluate $P$ at $x = 0.5$ , we get:
 
   $$ P(1.0) = \frac{1}{4} $$
+</div>
 
+<div class='together'>
 This says _the probability that a random variable with our pdf is less than one is 25%_ . This
 gives rise to a clever observation that underlies many methods to generate non-uniform random
 numbers. We want a function `f()` that when we call it as `f(random_double())` we get a return value
@@ -300,17 +339,23 @@ should be less than 1, and 75% should be above one. If $f()$ is increasing, then
 $f(0.25) = 1.0$. This can be generalized to figure out $f()$ for every possible input:
 
   $$ f(P(x)) = x $$
+</div>
 
+<div class='together'>
 That means $f$ just undoes whatever $P$ does. So,
 
   $$ f(x) = P^-1 (x) $$
+</div>
 
+<div class='together'>
 The -1 means “inverse function”. Ugly notation, but standard. For our purposes what this means is,
 if we have pdf $p()$ and its cumulative distribution function $P()$ , then if we do this to a random
 number we’ll get what we want:
 
-  $$ e = P^-1 (random_double()) $$
+  $$ e = P^-1 (\text{random_double}()) $$
+</div>
 
+<div class='together'>
 For our _pdf_ $p(x) = x/2$ , and corresponding $P(x)$ , we need to compute the inverse of $P$. If
 we have
 
@@ -322,15 +367,19 @@ we get the inverse by solving for $x$ in terms of $y$:
 
 Thus our random number with density $p$ we get by:
 
-  $$ e = \sqrt{4*random_double()} $$
+  $$ e = \sqrt{4*\text{random_double}()} $$
+</div>
 
-Note that does range 0 to 2 as hoped, and if we send in $1/4$ for `random_double()` we get 1 as 
+Note that does range 0 to 2 as hoped, and if we send in $1/4$ for `random_double()` we get 1 as
 desired.
 
+<div class='together'>
 We can now sample our old integral
 
   $$ I = \int_{0}^{2} x^2 $$
+</div>
 
+<div class='together'>
 We need to account for the non-uniformity of the _pdf_ of $x$. Where we sample too much we should
 down-weight. The _pdf_ is a perfect measure of how much or little sampling is being done. So the
 weighting function should be proportional to $1/pdf$ . In fact it is exactly $1/pdf$ :
@@ -357,11 +406,13 @@ weighting function should be proportional to $1/pdf$ . In fact it is exactly $1/
         std::cout << "I =" << sum/N << "\n";
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 Since we are sampling more where the integrand is big, we might expect less noise and thus faster
 convergence. This is why using a carefully chosen non-uniform pdf is usually called _importance
 sampling_.
 
+<div class='together'>
 If we take that same code with uniform samples so the pdf = $1/2$ over the range [0,2] we can use
 the machinery to get `x = 2*random_double()` and the code is:
 
@@ -387,12 +438,14 @@ the machinery to get `x = 2*random_double()` and the code is:
         std::cout << "I =" << sum/N << "\n";
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Note that we don’t need that 2 in the `2*sum/N` anymore -- that is handled by the _pdf_ , which is
 2 when you divide by it. You’ll note that importance sampling helps a little, but not a ton. We
 could make the pdf follow the integrand exactly:
 
-  $$ p(x) = (3/8)x^2 $$
+  $$ p(x) = \frac{3}{8}x^2 $$
 
 And we get the corresponding
 
@@ -400,8 +453,10 @@ And we get the corresponding
 
 and
 
-  $$ P^-1(x) = 8x^{1/3} $$
+  $$ P^{-1}(x) = 8x^\frac{1}{3} $$
+</div>
 
+<div class='together'>
 This perfect importance sampling is only possible when we already know the answer (we got $P$ by
 integrating $p$ analytically), but it’s a good exercise to make sure our code works. For just 1
 sample we get:
@@ -428,9 +483,11 @@ sample we get:
         std::cout << "I =" << sum/N << "\n";
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 Which always returns the exact answer.
 
+<div class='together'>
 Let’s review now because that was most of the concepts that underlie MC ray tracers.
 
   1. You have an integral of $f(x)$ over some domain $[a,b]$
@@ -438,12 +495,12 @@ Let’s review now because that was most of the concepts that underlie MC ray tr
   3. You average a whole ton of $f(r)/p(r)$ where $r$ is a random number $r$ with pdf $p$ .
 
 This will always converge to the right answer. The more $p$ follows $f$, the faster it converges.
+</div>
 
 
 
 MC Integration on the Sphere of Directions
 ====================================================================================================
-
 
 In our ray tracer we pick random directions, and directions can be represented as points on the
 unit-sphere. The same methodology as before applies. But now we need to have a pdf defined over 2D.
@@ -451,6 +508,7 @@ Suppose we have this integral over all directions:
 
   $$ \int cos^2(\theta) $$
 
+<div class='together'>
 By MC integration, we should just be able to sample $cos^2(\theta) / p(direction)$. But what is
 direction in that context? We could make it based on polar coordinates, so $p$ would be in terms of
 $(\theta, \phi)$ . However you do it, remember that a pdf has to integrate to 1 and represent the
@@ -466,7 +524,9 @@ uniform random samples in a unit sphere:
         return p;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 To get points on a unit sphere we can just normalize the vector to those points:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -478,7 +538,9 @@ To get points on a unit sphere we can just normalize the vector to those points:
         return unit_vector(p);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Now what is the pdf of these uniform points? As a density on the unit sphere, it is $1/area$ of the
 sphere or $1/(4\pi)$. If the integrand is $cos^2(\theta)$ and $\theta$ is the angle with the z axis:
 
@@ -498,15 +560,16 @@ sphere or $1/(4\pi)$. If the integrand is $cos^2(\theta)$ and $\theta$ is the an
         std::cout << "I =" << sum/N << "\n";
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
-The analytic answer (if you remember enough advanced calc, check me!) is $\frac{4}{3} \pi$, and the 
+The analytic answer (if you remember enough advanced calc, check me!) is $\frac{4}{3} \pi$, and the
 code above produces that. Next, we are ready to apply that in ray tracing!
 
 The key point here is that all the integrals and probability and all that are over the unit sphere.
 The area on the unit sphere is how you measure the directions. Call it direction, solid angle, or
 area -- it’s all the same thing. Solid angle is the term usually used. If you are comfortable with
 that, great! If not, do what I do and imagine the area on the unit sphere that a set of directions
-goes through. The solid angle $\omega$ and the projected area $A$ on the unit sphere are the same 
+goes through. The solid angle $\omega$ and the projected area $A$ on the unit sphere are the same
 thing.
 
   ![Figure 4-1](../images/fig-3-04-1.jpg)
@@ -526,7 +589,7 @@ used model for light interacting with a surface. One natural way to model this i
 First, is the light absorbed?
 
 Probability of light scattering: $A$
-  
+
 Probability of light being absorbed: $1-A$
 
 Here $A$ stands for _albedo_ (latin for _whiteness_). Albedo is a precise technical term in some
@@ -541,18 +604,22 @@ over solid angle. I will refer to this as its _scattering pdf_: $s(direction)$. 
 can also vary with incident direction, as you will notice when you look at reflections off a road --
 they become mirror-like as your viewing angle approaches grazing.
 
+<div class='together'>
 The color of a surface in terms of these quantities is:
 
   $$ Color = \int A \cdot s(direction) \cdot color(direction) $$
+</div>
 
 Note that $A$ and $s()$ might depend on the view direction, so of course color can vary with view
 direction. Also $A$ and $s()$ may vary with position on the surface or within the volume.
 
+<div class='together'>
 If we apply the MC basic formula we get the following statistical estimate:
 
   $$ Color = (A \cdot s(direction) \cdot color(direction)) / p(direction) $$
 
-Where $p(direction)$ is the pdf of whatever direction we randomly generate.
+where $p(direction)$ is the pdf of whatever direction we randomly generate.
+</div>
 
 For a Lambertian surface we already implicitly implemented this formula for the special case where
 $p()$ is a cosine density. The $s()$ of a Lambertian surface is proportional to $cos(\theta)$, where
@@ -560,6 +627,7 @@ $\theta$ is the angle relative to the surface normal. Remember that all pdf need
 one. For $cos(\theta) < 0$ we have $s(direction) = 0$, and the integral of cos over the hemisphere
 is $\pi$.
 
+<div class='together'>
 To see that remember that in spherical coordinates remember that:
 
   $$ \delta A = sin(\theta) \delta \theta \delta \phi $$
@@ -568,11 +636,15 @@ So:
 
   $$ Area = \int_{0}^{2 \pi} \int_{0}^{\pi / 2} cos(\theta)sin(\theta) \delta \theta \delta \phi =
     2 \pi \cdot \frac{1}{2} = \pi $$
+</div>
 
+<div class='together'>
 So for a Lambertian surface the scattering pdf is:
 
   $$ s(direction) = cos(\theta) / \pi $$
+</div>
 
+<div class='together'>
 If we sample using the same pdf, so $p(direction) = cos(\theta) / \pi$, the numerator and
 denominator cancel out and we get:
 
@@ -583,7 +655,9 @@ can send extra rays in important directions such as toward the lights.
 
 The treatment above is slightly non-standard because I want the same math to work for surfaces and
 volumes. To do otherwise will make some ugly code.
+</div>
 
+<div class='together'>
 If you read the literature, you’ll see reflection described by the bidirectional reflectance
 distribution function (BRDF). It relates pretty simply to our terms:
 
@@ -592,14 +666,16 @@ distribution function (BRDF). It relates pretty simply to our terms:
 So for a Lambertian surface for example, $BRDF = A / \pi$. Translation between our terms and BRDF is
 easy.
 
-For participation media (volumes), our albedo is usually called scattering albedo, and our
-scattering pdf is usually called phase function.
+For participation media (volumes), our albedo is usually called _scattering albedo_, and our
+scattering pdf is usually called _phase function_.
+</div>
 
 
 
 Importance Sampling Materials
 ====================================================================================================
 
+<div class='together'>
 Our goal over the next two chapters is to instrument our program to send a bunch of extra rays
 toward light sources so that our picture is less noisy. Let’s assume we can send a bunch of rays
 toward the light source using a pdf $pLight(direction)$ . Let’s also assume we have a pdf related to
@@ -608,15 +684,17 @@ linear mixtures of them to form mixture densities that are also pdfs. For exampl
 would be:
 
   $$ p(direction) = 0.5 \cdot pLight(direction) + 0.5* \cdot pSurface(direction) $$
+</div>
 
 As long as the weights are positive and add up to one, any such mixture of pdfs is a pdf. And
 remember, we can use any pdf -- it doesn’t change the answer we converge to! So, the game is to
-figure out how to make the pdf larger where the product $s(direction)*color(direction)$ is large. 
+figure out how to make the pdf larger where the product $s(direction)*color(direction)$ is large.
 For diffuse surfaces, this is mainly a matter of guessing where $color(direction)$ is high.
 
 For a mirror, $s()$ is huge only near one direction, so it matters a lot more. Most renderers in
 fact make mirrors a special case and just make the $s/p$ implicit -- our code currently does that.
 
+<div class='together'>
 Let’s do simple refactoring and temporarily remove all materials that aren’t Lambertian. We can use
 our Cornell Box scene again, and let’s generate the camera in the function that generates the model:
 
@@ -648,18 +726,22 @@ our Cornell Box scene again, and let’s generate the camera in the function tha
                           vfov, aspect, aperture, dist_to_focus, 0.0, 1.0);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 At 500x500 my code produces this image in 10min on 1 core of my Macbook:
 
   ![Figure 6-1](../images/img-3-06-1.jpg)
 
 Reducing that noise is our goal. We’ll do that by constructing a pdf that sends more rays to the
 light.
+</div>
 
 First, let’s instrument the code so that it explicitly samples some pdf and then normalizes for
 that. Remember MC basics: $\int f(x) \approx f(r)/p(r)$. For the Lambertian material,
 let’s sample like we do now: $p(direction) = cos(\theta) / \pi$.
 
+<div class='together'>
 We modify the base-class _material_ to enable this importance sampling:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -678,7 +760,9 @@ We modify the base-class _material_ to enable this importance sampling:
             }
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And _Lambertian_ material becomes:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -703,8 +787,10 @@ And _Lambertian_ material becomes:
             texture *albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
-And the color function gets a minor modification.
+<div class='together'>
+And the color function gets a minor modification:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     vec3 color(const ray& r, hitable *world, int depth) {
@@ -726,9 +812,11 @@ And the color function gets a minor modification.
             return vec3(0,0,0);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 You should get exactly the same picture.
 
+<div class='together'>
 Now, just for the experience, try a different sampling strategy. Let’s choose randomly from the
 hemisphere that is above the surface. This would be $p(direction) = 1/(2* \pi)$ .
 
@@ -745,10 +833,14 @@ hemisphere that is above the surface. This would be $p(direction) = 1/(2* \pi)$ 
         return true;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
-And again I __should__ get the same picture except with different variance, but I don’t!
+<div class='together'>
+And again I _should_ get the same picture except with different variance, but I don’t!
 
   ![Figure 6-2](../images/img-3-06-2.jpg)
+
+</div>
 
 It’s pretty close to our old picture, but there are differences that are not noise. The front of the
 tall box is much more uniform in color. So I have the most difficult kind of bug to find in a Monte
@@ -771,13 +863,16 @@ have had advanced calculus, you may recall that on the sphere in spherical coord
 $dA = \sin(\theta) \cdot d\theta \cdot d\phi$. If you haven’t, you’ll have to take my word for the
 next step, but you’ll get it when you take advanced calc.
 
+<div class='together'>
 Given a directional pdf, $p(direction) = f(\theta)$ on the sphere, the 1D pdfs on $\theta$ and
 $\phi$ are:
 
   $$ a(\phi) = \frac{1}{2\pi} $$
 (uniform)
   $$ b(\theta) = 2*\pi*f(\theta)\sin(\theta) $$
+</div>
 
+<div class='together'>
 For uniform random numbers $r_1$ and $r_2$, the material presented in Chapter 3 leads to:
 
   $$ r_1 = \int_{0}^{\phi} \frac{1}{2\pi} = \frac{\phi}{2\pi} $$
@@ -789,7 +884,9 @@ Solving for $\phi$ we get:
 For $\theta$ we have:
 
   $$ r_2 = \int_{0}^{\theta} 2 \pi f(t) \sin(t) $$
+</div>
 
+<div class='together'>
 Here, $t$ is a dummy variable. Let’s try some different functions for $f()$. Let’s first try a
 uniform density on the sphere. The area of the unit sphere is $4\pi$ , so a uniform $p(direction) =
 \frac{1}{4\pi}$ on the unit sphere.
@@ -802,7 +899,9 @@ Solving for $\cos(\theta)$ gives:
 
 We don’t solve for theta because we probably only need to know $\cos(\theta)$ anyway and don’t want
 needless $\arccos()$ calls running around.
+</div>
 
+<div class='together'>
 To generate a unit vector direction toward $(\theta,\phi)$ we convert to Cartesian coordinates:
 
   $$ x = \cos(\phi) \cdot \sin(\theta) $$
@@ -821,7 +920,9 @@ Simplifying a little, $(1 - 2 r_2)^2 = 1 - 4r_2 + 4r_2^2$, so:
   $$ x = \cos(2 \pi r_1) \cdot 2 \sqrt{r_2(1 - r_2)} $$
   $$ y = \sin(2 \pi r_1) \cdot 2 \sqrt{r_2(1 - r_2)} $$
   $$ z = 1 - 2 r_2 $$
+</div>
 
+<div class='together'>
 We can output some of these:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -837,25 +938,34 @@ We can output some of these:
         }
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And plot them for free on plot.ly (a great site with 3D scatterplot support):
 
   ![Image 7-1](../images/fig-3-07-1.jpg)
 
+</div>
+
 On the plot.ly website you can rotate that around and see that it appears uniform.
 
+<div class='together'>
 Now let’s derive uniform on the hemisphere. The density being uniform on the hemisphere means
 $p(direction) = 1 / (2 \pi)$ and just changing the constant in the theta equations yields:
 
   $$ \cos(\theta) = 1 - r_2 $$
+</div>
 
+<div class='together'>
 It is comforting that $\cos(\theta)$ will vary from 1 to 0, and thus theta will vary from 0 to
 $\pi/2$. Rather than plot it, let’s do a 2D integral with a known solution. Let’s integrate cosine
 cubed over the hemisphere (just picking something arbitrary with a known solution). First let’s do
 it by hand:
 
   $$ \int \cos^3 = 2 \pi \int_{0}^{\pi/2} \cos^3 \sin = \frac{\pi}{2} $$
+</div>
 
+<div class='together'>
 Now for integration with importance sampling. $p(direction) = 1/(2 \pi)$, so we average $f/p$
 which is $\cos^3 / (1/(2 \pi))$, and we can test this:
 
@@ -875,7 +985,9 @@ which is $\cos^3 / (1/(2 \pi))$, and we can test this:
         std::cout << "Estimate = " << sum/N << "\n";
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Now let’s generate directions with $p(directions) = \cos(\theta) / \pi$.
 
   $$ r_2 = \int_{0}^{\theta} 2 \pi \frac{\cos(t)}{\pi} \sin(t) = 1 - \cos^2(\theta) $$
@@ -889,7 +1001,9 @@ We can save a little algebra on specific cases by noting
   $$ z = \cos(\theta) = \sqrt{1 - r_2} $$
   $$ x = \cos(\phi) \sin(\theta) = \cos(2 \pi r_1) \sqrt{1 - z^2} = \cos(2 \pi r_1) \sqrt{r_2} $$
   $$ y = \sin(\phi) \sin(\theta) = \sin(2 \pi r_1) \sqrt{1 - z^2} = \sin(2 \pi r_1) \sqrt{r_2} $$
+</div>
 
+<div class='together'>
 Let’s also start generating them as random vectors:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -914,6 +1028,7 @@ Let’s also start generating them as random vectors:
         std::cout << "Estimate = " << sum/N << "\n";
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 We can generate other densities later as we need them. In the next chapter we’ll get them aligned to
 the surface normal vector.
@@ -931,15 +1046,19 @@ world, and some virtual place and orientation in the virtual world. A picture is
 relative positions/orientations of the camera and scene, so as long as the camera and scene are
 described in the same coordinate system, all is well.
 
+<div class='together'>
 Suppose we have an origin $\mathbf{O}$ and cartesian unit vectors $\vec{x}$, $\vec{y}$, and
 $\vec{z}$. When we say a location is (3, -2, 7), we really are saying:
 
   $$ \text{Location is } \mathbf{O} + 3\vec{x} - 2\vec{y} + 7\vec{z} $$
+</div>
 
+<div class='together'>
 If we want to measure coordinates in another coordinate system with origin $\mathbf{O}’$ and basis
 vectors $\vec{U}$, $\vec{V}$, and $\vec{W}$, we can just find the numbers $(u, v, w)$ such that:
 
   $$ \text{Location is } \mathbf{O}’ + u\vec{U} + v\vec{V} + w\vec{W} $$
+</div>
 
 If you take an intro graphics course, there will be a lot of time spent on coordinate systems and
 4×4 coordinate transformation matrices. Pay attention, it’s important stuff in graphics! But we
@@ -947,6 +1066,7 @@ won’t need it. What we need to is generate random directions with a set distri
 $\vec{n}$. We don’t need an origin because a direction is relative to no specified origin. We do
 need two cotangent vectors that are mutually perpendicular to $\vec{n}$ and each other.
 
+<div class='together'>
 Some models will come with at least one cotangent vector. The hard case of making an ONB is when we
 just have one vector. Suppose we have any vector $\vec{a}$ that is not zero length or parallel to
 $\vec{n}$. We can get to vectors $\vec{s}$ and $\vec{t}$ parallel to $\vec{n}$ by using the property
@@ -955,7 +1075,9 @@ of the cross product that $\vec{c} \times \vec{d}$ is perpendicular to both $\ve
   $$ \vec{t} = \text{unit_vector}(\vec{a} \times \vec{n}) $$
 
   $$ \vec{s} = \vec{t} \times \vec{n} $$
+</div>
 
+<div class='together'>
 The catch is, we don’t have an $\vec{a}$ and if we pick a particular one at some point we will get
 an $\vec{n}$ parallel to $\vec{a}$. A common method is to use an if-statement to determine whether
 $\vec{n}$ is a particular axis, and if not, use that axis.
@@ -966,12 +1088,18 @@ $\vec{n}$ is a particular axis, and if not, use that axis.
     else
         a = (1, 0, 0)
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Once we have an ONB and we have a $random(x,y,z)$ relative the the Z-axis we can get the vector
 relative to $\vec{n}$ as:
 
-  $$ \text{Random vector} = \vec{x} \cdot \vec{s} + \vec{y} \cdot \vec{t} + \vec{z} \cdot \vec{n} $$
+  $$
+  \text{Random vector} = (\vec{x} \cdot \vec{s}) + (\vec{y} \cdot \vec{t}) + (\vec{z} \cdot \vec{n})
+  $$
+</div>
 
+<div class='together'>
 You may notice we used similar math to get rays from a camera. That could be viewed as a change to
 the camera’s natural coordinate system. Should we make a class for ONBs or are utility functions
 enough? I’m not sure, but let’s make a class because it won't really be more complicated than
@@ -1004,7 +1132,9 @@ utility functions:
         axis[0] = cross(w(), v());
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 We can rewrite our Lambertian material using this to get:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1024,14 +1154,16 @@ We can rewrite our Lambertian material using this to get:
         return true;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Which produces:
 
   ![Image 8-1](../images/img-3-08-1.jpg)
 
 Is that right? We still don’t know for sure. Tracking down bugs is hard in the absence of reliable
 reference solutions. Let’s table that for now and move on to get rid of some of that noise.
-
+</div>
 
 
 Sampling Lights Directly
@@ -1042,6 +1174,7 @@ than unimportant directions. We could use shadow rays and separate out direct li
 I’ll just send more rays to the light. We can then use that later to send more rays in whatever
 direction we want.
 
+<div class='together'>
 It’s really easy to pick a random direction toward the light; just pick a random point on the light
 and send a ray in that direction. But we also need to know the _pdf(direction)_. What is that? For a
 light of area $A$, if we sample uniformly on that light, the _pdf_ on the surface of the light is
@@ -1050,6 +1183,9 @@ a simple correspondence, as outlined in the diagram:
 
   ![Figure 9-1](../images/fig-3-09-1.jpg)
 
+</div>
+
+<div class='together'>
 If we look at a small area $dA$ on the light, the probability of sampling it is $p_q(q) \cdot dA$.
 On the sphere, the probability of sampling the small area $dw$ on the sphere is $p(direction) \cdot
 dw$. There is a geometric relationship between $dw$ and $dA$:
@@ -1066,7 +1202,9 @@ Since the probability of sampling dw and dA must be the same, we have
 So
 
   $$ p(direction) = \frac{distance(p,q)^2}{cos(alpha) \cdot A} $$
+</div>
 
+<div class='together'>
 If we hack our color function to sample the light in a very hard-coded fashion just to check that
 math and get the concept, we can add it (see the highlighted region):
 
@@ -1106,12 +1244,16 @@ math and get the concept, we can add it (see the highlighted region):
             return vec3(0,0,0);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
-
+<div class='together'>
 With 10 samples per pixel this yields:
 
   ![Image 9-1](../images/img-3-09-1.jpg)
 
+</div>
+
+<div class='together'>
 This is about what we would expect from something that samples only the light sources, so this
 appears to work. The noisy pops around the light on the ceiling are because the light is two-sided
 and there is a small space between light and ceiling. We probably want to have the light just emit
@@ -1127,16 +1269,21 @@ down. We can do that by letting the emitted member function of hitable take extr
             return vec3(0,0,0);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 We also need to flip the light so its normals point in the -y direction and we get:
 
   ![Image 9-2](../images/img-3-09-2.jpg)
+
+</div>
 
 
 
 Mixture Densities
 ====================================================================================================
 
+<div class='together'>
 We have used a _pdf_ related to $cosine(\theta)$, and a _pdf_ related to sampling the light. We
 would like a _pdf_ that combines these. A common tool in probability is to mix the densities to
 form a mixture density. Any weighted average of _pdf_ s is a _pdf_. For example, we could just
@@ -1145,7 +1292,9 @@ average the two densities:
   $$ pdf\_mixture(direction) = \frac{1}{2} pdf\_reflection(direction) +
         \frac{1}{2}pdf\_light(direction)
   $$
+</div>
 
+<div class='together'>
 How would we instrument our code to do that? There is a very important detail that makes this not
 quite as easy as one might expect. Choosing the random direction is simple:
 
@@ -1155,16 +1304,21 @@ quite as easy as one might expect. Choosing the random direction is simple:
     else
         Pick direction according to pdf_light
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 But evaluating $pdf\_mixture$ is slightly more subtle. We need to evaluate both $pdf\_reflection$
 and $pdf\_light$ because there are some directions where either _pdf_ could have generated the
 direction. For example, we might generate a direction toward the light using $pdf\_reflection$.
 
+<div class='together'>
 If we step back a bit, we see that there are two functions a _pdf_ needs to support:
 
 1. What is your value at this location?
 2. Return a random number that is distributed appropriately.
 
+</div>
+
+<div class='together'>
 The details of how this is done under the hood varies for the $pdf\_reflection$ and the $pdf\_light$
 and the mixture density of the two of them, but that is exactly what class hierarchies were invented
 for! It’s never obvious what goes in an abstract class, so my approach is to be greedy and hope a
@@ -1177,12 +1331,14 @@ minimal interface works, and for the _pdf_ this implies:
             virtual vec3 generate() const = 0;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 We’ll see if that works by fleshing out the subclasses. For sampling the light, we will need
 `hitable` to answer some queries that it doesn’t have an interface for. We’ll probably need to mess
 with it too, but we can start by seeing if we can put something in `hitable` involving sampling the
 bounding box that works with all its subclasses.
 
+<div class='together'>
 First, let’s try a cosine density:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1202,7 +1358,9 @@ First, let’s try a cosine density:
             onb uvw;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 We can try this in the `color()` function, with the main changes highlighted. We also need to change
 variable `pdf` to some other variable name to avoid a name conflict with the new `pdf` class.
 
@@ -1231,12 +1389,17 @@ variable `pdf` to some other variable name to avoid a name conflict with the new
             return vec3(0,0,0);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 This yields an apparently matching result so all we’ve done so far is refactor where `pdf` is
+</div>
 computed:
 
   ![Image 10-1](../images/img-3-10-1.jpg)
 
+</div>
+
+<div class='together'>
 Now we can try sampling directions toward a `hitable` like the light.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1253,7 +1416,9 @@ Now we can try sampling directions toward a `hitable` like the light.
             hitable *ptr;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 This assumes two as-yet not implemented functions in the `hitable` class. To avoid having to add
 instrumentation to all of `hitable` subclasses, we’ll add two dummy functions to the `hitable`
 class:
@@ -1268,7 +1433,9 @@ class:
             virtual vec3 random(const vec3& o) const {return vec3(1, 0, 0);}
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And we change `xz_rect` to implement those functions:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1302,7 +1469,9 @@ And we change `xz_rect` to implement those functions:
             float x0, x1, z0, z1, k;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And then change `color()`:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1331,11 +1500,16 @@ And then change `color()`:
             return vec3(0,0,0);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 At 10 samples per pixel we get:
 
   ![Image 10-2](../images/img-3-10-2.jpg)
 
+</div>
+
+<div class='together'>
 Now we would like to do a mixture density of the cosine and light sampling. The mixture density
 class is straightforward:
 
@@ -1355,7 +1529,9 @@ class is straightforward:
             pdf *p[2];
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And plugging it into `color()`:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1384,10 +1560,14 @@ And plugging it into `color()`:
             return vec3(0,0,0);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 1000 samples per pixel yields:
 
   ![Image 10-3](../images/img-3-10-3.jpg)
+
+</div>
 
 We’ve basically gotten this same picture (with different levels of noise) with several different
 sampling patterns. It looks like the original picture was slightly wrong! Note by “wrong” here I
@@ -1438,10 +1618,13 @@ book.
 Cleaning Up pdf Management.
 ====================================================================================================
 
+<div class='together'>
 So far I have the color function create two hard-coded `pdf`s :
 
 1. `p0()` related to the shape of the light
 2. `p1()` related to the normal vector and type of surface
+
+</div>
 
 We can pass information about the light (or whatever `hitable` we want to sample) into the `color`
 function, and we can ask the `material` function for a `pdf` (we would have to instrument it to do
@@ -1456,6 +1639,7 @@ need to be careful when we ask for the `pdf` value and be aware of whether for t
 `color()` it is diffuse or specular. Fortunately, we know that we should only call the `pdf value()`
 if it is diffuse so we can handle that implicitly.
 
+<div class='together'>
 We can redesign `material` and stuff all the new arguments into a `struct` like we did for
 `hitable`:
 
@@ -1478,7 +1662,9 @@ We can redesign `material` and stuff all the new arguments into a `struct` like 
                 float u, float v, const vec3& p) const { return vec3(0,0,0); }
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 The Lambertian material becomes simpler:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1502,7 +1688,9 @@ The Lambertian material becomes simpler:
             texture *albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And `color()` changes are small:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1528,7 +1716,9 @@ And `color()` changes are small:
             return vec3(0,0,0);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 We have not yet dealt with specular surfaces, nor instances that mess with the surface normal, and
 we have added a memory leak by calling `new` in Lambertian material. But this design is clean
 overall, and those are all fixable. For now, I will just fix `specular`. Metal is easy to fix.
@@ -1551,10 +1741,12 @@ overall, and those are all fixable. For now, I will just fix `specular`. Metal i
             float fuzz;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 Note that if fuzziness is high, this surface isn’t ideally specular, but the implicit sampling works
 just like it did before.
 
+<div class='together'>
 `Color` just needs a new case to generate an implicitly sampled ray:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1587,7 +1779,9 @@ just like it did before.
             return vec3(0,0,0);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 We also need to change the block to metal.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1621,14 +1815,18 @@ We also need to change the block to metal.
                           vfov, aspect, aperture, dist_to_focus, 0.0, 1.0);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 The resulting image has a noisy reflection on the ceiling because the directions toward the box are
 not sampled with more density.
 
   ![Image 12-1](../images/img-3-12-1.jpg)
 
-We could make the pdf include the block. Let’s do that instead with a glass sphere because it’s
+</div>
 
+<div class='together'>
+We could make the pdf include the block. Let’s do that instead with a glass sphere because it’s
 easier. When we sample a sphere’s solid angle uniformly from a point outside the sphere, we are
 really just sampling a cone uniformly (the cone is tangent to the sphere). Let’s say the code has
 `theta_max`. Recall from Chapter 9, that to sample $\theta$ we have:
@@ -1642,41 +1840,56 @@ Here $f(t)$ is an as yet uncalculated constant $C$, so:
 Doing some algebra/calculus this yields:
 
   $$ r2 = 2 \pi \cdot C \cdot (1-cos(\theta)) $$
+</div>
 
+<div class='together'>
 So
 
   $$ cos(\theta) = 1 - r2/(2 \pi \cdot C) $$
+</div>
 
+<div class='together'>
 We know that for $r2 = 1$ we should get $\theta_{max}$, so we can solve for $C$:
 
   $$ cos(\theta) = 1 + r2 \cdot (cos(\theta_{max})-1) $$
+</div>
 
+<div class='together'>
 $\phi$ we sample like before, so:
 
   $$ z = cos(\theta) = 1 + r2 \cdot (cos(\theta_{max})-1) $$
   $$ x = cos(\phi) \cdot sin(\theta) = cos(2 \pi \cdot r1) \cdot \sqrt{1-z^2} $$
   $$ y = sin(\phi) \cdot sin(\theta) = sin(2 \pi \cdot r1) \cdot \sqrt{1-z^2} $$
+</div>
 
+<div class='together'>
 Now what is $\theta_{max}$?
 
   ![Figure 12-1](../images/fig-3-12-1.jpg)
 
+</div>
+
+<div class='together'>
 We can see from the figure that $sin(\theta_{max}) = R / length( c - p )$. So:
 
   $$ cos(\theta_{max}) = \sqrt{1- (R / length( c - p ))^2} $$
+</div>
 
+<div class='together'>
 We also need to evaluate the _pdf_ of directions. For directions toward the sphere this is
 $1/solid\_angle$. What is the solid angle of the sphere? It has something to do with the $C$ above.
 It, by definition, is the area on the unit sphere, so the integral is
 
   $$ solid\_angle = \int_{0}^{2 \pi} \int_{0}^{\theta_{max}} sin(\theta) d \theta d \phi
        = 2 \pi \cdot (1-cos(\theta_{max})) $$
+</div>
 
 It’s good to check the math on all such calculations. I usually plug in the extreme cases (thank you
 for that concept, Mr. Horton -- my high school physics teacher). For a zero radius sphere
 $cos(\theta_{max}) = 0$, and that works. For a sphere tangent at $p$, $cos(\theta_{max}) = 0$, and
 $2 \pi$ is the area of a hemisphere, so that works too.
 
+<div class='together'>
 The sphere class needs the two `pdf`-related functions:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1699,7 +1912,9 @@ The sphere class needs the two `pdf`-related functions:
         return uvw.local(random_to_sphere(radius, distance_squared));
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 With the utility function:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1713,7 +1928,9 @@ With the utility function:
         return vec3(x, y, z);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 We can first try just sampling the sphere rather than the light:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1731,13 +1948,18 @@ We can first try just sampling the sphere rather than the light:
                 col += color(r, world, glass_sphere, 0);
             }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 This yields a noisy box, but the caustic under the sphere is good. It took five times as long as
 sampling the light did for my code. This is probably because those rays that hit the glass are
 expensive!
 
   ![Image 12-2](../images/img-3-12-2.jpg)
 
+</div>
+
+<div class='together'>
 We should probably just sample both the sphere and the light. We can do that by creating a mixture
 density of their two densities. We could do that in the `color` function by passing a list of
 hitables in and building a mixture `pdf`, or we could add `pdf` functions to `hitable_list`. I
@@ -1757,7 +1979,9 @@ think both tactics would work fine, but I will go with instrumenting `hitable_li
         return list[ index ]->random(o);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 We assemble a list to pass in to `color`.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1779,23 +2003,30 @@ We assemble a list to pass in to `color`.
                 col += color(r, world, &hlist, 0);
             }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And we get a decent image with 1000 samples as before:
 
   ![Image 12-3](../images/img-3-12-3.jpg)
 
+</div>
+
+<div class='together'>
 An astute reader pointed out there are some black specks in the image above. All Monte Carlo Ray
 Tracers have this as a main loop:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     pixel_color = average(many many samples)
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
 If you find yourself getting some form of acne in the images, and this acne is white or black, so
 one "bad" sample seems to kill the whole pixel, that sample is probably a huge number or a `NaN`.
 This particular acne is probably a `NaN`. Mine seems to come up once in every 10-100 million rays
 or so.
 
+<div class='together'>
 So big decision: sweep this bug under the rug and check for `NaN`s, or just kill `NaN`s and hope
 this doesn't come back to bite us later. I will always opt for the lazy strategy, especially when I
 know floating point is hard. First, how do we check for a `NaN`? The one thing I always remember
@@ -1810,7 +2041,9 @@ for `NaN`s is that any `if` test with a `NaN` in it is false. This leads to the 
         return temp;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 And we can insert that in the main loop:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1822,10 +2055,14 @@ And we can insert that in the main loop:
         col += de_nan(color(r, world, &hlist, 0));
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</div>
 
+<div class='together'>
 Happily, the black specks are gone:
 
   ![Image 12-4](../images/img-3-12-4.jpg)
+
+</div>
 
 
 

--- a/style/book.css
+++ b/style/book.css
@@ -1,32 +1,6 @@
-/* Under-Development Warning Box */
-
-div.warning {
-    background: #fdd;
-    margin:     1em 4em;
-    border:     solid 4px red;
-    padding:    0em 4ex;
-}
-
-div.warning a {
-    font-family: sans-serif;
-}
-
-div.warning p {
-    font-family: sans-serif;
-    font-size:   100%;
-    font-weight: normal;
-    color:       black;
-}
-
-div.warning p.title {
-    font-family: sans-serif;
-    font-size:   160%;
-    font-weight: bold;
-    color:       red;
-}
-
-
-/* General Body Styles */
+/* -------------------------------------------------------------------------------------------------
+** General Body Styles
+** -----------------------------------------------------------------------------------------------*/
 
 body {
     font-family: sans-serif;
@@ -36,15 +10,10 @@ body {
     font-family: sans-serif;
 }
 
-.md div.title {
-    font-size: 220%;
-    letter-spacing: -0.06em;
-}
 
-.md .subtitle {
-    font-size: 100%;
-    font-style: italic;
-}
+/* -------------------------------------------------------------------------------------------------
+** Table of Contents
+** -----------------------------------------------------------------------------------------------*/
 
 .md .longTOC, .md .mediumTOC, .md .shortTOC {
     font-family: sans-serif;
@@ -62,6 +31,25 @@ body {
     font-size: 165%;
     margin-bottom: -1em;
     border-bottom: solid 4px #777;
+}
+
+.md .longTOC, .md .mediumTOC, .md .shortTOC {
+    font-family: sans-serif;
+}
+
+
+/* -------------------------------------------------------------------------------------------------
+** Titles & Headers
+** -----------------------------------------------------------------------------------------------*/
+
+.md div.title {
+    font-size: 220%;
+    letter-spacing: -0.06em;
+}
+
+.md .subtitle {
+    font-size: 100%;
+    font-style: italic;
 }
 
 .md h1 {
@@ -82,7 +70,9 @@ body {
 }
 
 
-/* Code */
+/* -------------------------------------------------------------------------------------------------
+** Code
+** -----------------------------------------------------------------------------------------------*/
 
 .md code {
     font-family: Consolas, Menlo, monospace;
@@ -103,27 +93,91 @@ body {
     font-size: 86%;
 }
 
-.md .hljs-meta {
-    color: #d60;
+/* Hilight.js Syntax Coloring */
+
+.hljs-comment {
+    color: #40f;
 }
 
-.md .hljs-title {
+.hljs-keyword {
+    color: #a62;
+}
+
+.hljs-meta {
+    color: #f40;
+}
+
+.hljs-title {
     font-weight: bold;
 }
 
-.md .hljs-number {
+.hljs-number {
     color: #0a0;
 }
 
 
-/* Images and Figures */
+/* -------------------------------------------------------------------------------------------------
+** Images & Figures
+** -----------------------------------------------------------------------------------------------*/
 
 .md img {
-    margin-top: 1.5em;
+    margin-top: 1.0em;
     width: 72ex;
 }
 
 .md div.imagecaption {
     text-align: center;
     margin-bottom: 1em;
+}
+
+
+/* -------------------------------------------------------------------------------------------------
+** Print Styling
+** -----------------------------------------------------------------------------------------------*/
+
+@media print {
+
+    @page {
+        margin: 1.5cm 2.5cm 1.0cm 2.5cm;
+        size: letter portrait;
+    }
+
+    body {
+        line-height: 110%;
+    }
+
+    div.together {
+        page-break-inside: avoid;
+    }
+
+    .md {
+        font-size: 80%;
+    }
+
+    .md h1 {
+        page-break-before: always;
+    }
+
+    .md img {
+        page-break-before: avoid;
+    }
+
+    .md code {
+        font-size: 86%;
+    }
+
+    .md p code {
+        padding: 0;
+        color: #b63;
+        background: none;
+    }
+
+    .md pre.listing.tilde {
+        margin: 0 auto;
+        width: 86%;
+    }
+
+    .md pre.listing.tilde code {
+        font-size: 65%;
+    }
 }


### PR DESCRIPTION
Added @media print CSS queries for styling the printed version of the
book from the rendered HTML.

This change includes markup of the book content to hint which chunks
belong together on the same page. Look for `<div class='together'>`.

This includes minor fixes to book content.