### PR TITLE
Add styling for code highlighting

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -320,10 +320,12 @@ Now we can change our main to use this:
         std::cout << "P3\n" << nx << " " << ny << "\n255\n";
         for (int j = ny-1; j >= 0; j--) {
             for (int i = 0; i < nx; i++) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 vec3 col(float(i) / float(nx), float(j) / float(ny), 0.2);
                 int ir = int(255.99*col[0]);
                 int ig = int(255.99*col[1]);
                 int ib = int(255.99*col[2]);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 std::cout << ir << " " << ig << " " << ib << "\n";
             }
         }
@@ -406,16 +408,20 @@ for now because we’ll add antialiasing later):
         int nx = 200;
         int ny = 100;
         std::cout << "P3\n" << nx << " " << ny << "\n255\n";
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         vec3 lower_left_corner(-2.0, -1.0, -1.0);
         vec3 horizontal(4.0, 0.0, 0.0);
         vec3 vertical(0.0, 2.0, 0.0);
         vec3 origin(0.0, 0.0, 0.0);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         for (int j = ny-1; j >= 0; j--) {
             for (int i = 0; i < nx; i++) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 float u = float(i) / float(nx);
                 float v = float(j) / float(ny);
                 ray r(origin, lower_left_corner + u*horizontal + v*vertical);
                 vec3 col = color(r);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 int ir = int(255.99*col[0]);
                 int ig = int(255.99*col[1]);
                 int ib = int(255.99*col[2]);
@@ -516,9 +522,12 @@ that hits a small sphere we place at -1 on the z-axis:
         return (discriminant > 0);
     }
 
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
     vec3 color(const ray& r) {
         if (hit_sphere(vec3(0,0,-1), 0.5, r))
             return vec3(1, 0, 0);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         vec3 unit_direction = unit_vector(r.direction());
         float t = 0.5*(unit_direction.y() + 1.0);
         return (1.0-t)*vec3(1.0, 1.0, 1.0) + t*vec3(0.5, 0.7, 1.0);
@@ -562,29 +571,36 @@ and 1) is to map each component to the interval from 0 to 1, and then map x/y/z 
 normal, we need the hit point, not just whether we hit or not. Let’s assume the closest hit point
 (smallest $t$). These changes in the code let us compute and visualize $N$:
 
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
     float hit_sphere(const vec3& center, float radius, const ray& r) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         vec3 oc = r.origin() - center;
         float a = dot(r.direction(), r.direction());
         float b = 2.0 * dot(oc, r.direction());
         float c = dot(oc, oc) - radius*radius;
         float discriminant = b*b - 4*a*c;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         if (discriminant < 0) {
             return -1.0;
         }
         else {
             return (-b - sqrt(discriminant) ) / (2.0*a);
         }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     }
 
     vec3 color(const ray& r) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         float t = hit_sphere(vec3(0,0,-1), 0.5, r);
         if (t > 0.0) {
             vec3 N = unit_vector(r.point_at_parameter(t) - vec3(0,0,-1));
             return 0.5*vec3(N.x()+1, N.y()+1, N.z()+1);
         }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         vec3 unit_direction = unit_vector(r.direction());
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         t = 0.5*(unit_direction.y() + 1.0);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         return (1.0-t)*vec3(1.0, 1.0, 1.0) + t*vec3(0.5, 0.7, 1.0);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -734,14 +750,19 @@ And the new main:
     #include "hitable_list.h"
     #include "float.h"
 
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
     vec3 color(const ray& r, hitable *world) {
         hit_record rec;
         if (world->hit(r, 0.0, MAXFLOAT, rec)) {
             return 0.5*vec3(rec.normal.x()+1, rec.normal.y()+1, rec.normal.z()+1);
         }
         else {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             vec3 unit_direction = unit_vector(r.direction());
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             float t = 0.5*(unit_direction.y() + 1.0);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             return (1.0-t)*vec3(1.0, 1.0, 1.0) + t*vec3(0.5, 0.7, 1.0);
         }
     }
@@ -754,18 +775,27 @@ And the new main:
         vec3 horizontal(4.0, 0.0, 0.0);
         vec3 vertical(0.0, 2.0, 0.0);
         vec3 origin(0.0, 0.0, 0.0);
+
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         hitable *list[2];
         list[0] = new sphere(vec3(0,0,-1), 0.5);
         list[1] = new sphere(vec3(0,-100.5,-1), 100);
         hitable *world = new hitable_list(list,2);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
         for (int j = ny-1; j >= 0; j--) {
             for (int i = 0; i < nx; i++) {
                 float u = float(i) / float(nx);
                 float v = float(j) / float(ny);
                 ray r(origin, lower_left_corner + u*horizontal + v*vertical);
 
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 vec3 p = r.point_at_parameter(2.0);
                 vec3 col = color(r, world);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
                 int ir = int(255.99*col[0]);
                 int ig = int(255.99*col[1]);
                 int ib = int(255.99*col[2]);
@@ -890,15 +920,22 @@ Main is also changed:
     int main() {
         int nx = 200;
         int ny = 100;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         int ns = 100;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         std::cout << "P3\n" << nx << " " << ny << "\n255\n";
+
         hitable *list[2];
         list[0] = new sphere(vec3(0,0,-1), 0.5);
         list[1] = new sphere(vec3(0,-100.5,-1), 100);
         hitable *world = new hitable_list(list,2);
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         camera cam;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         for (int j = ny-1; j >= 0; j--) {
             for (int i = 0; i < nx; i++) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 vec3 col(0, 0, 0);
                 for (int s=0; s < ns; s++) {
                     float u = float(i + random_double()) / float(nx);
@@ -907,9 +944,12 @@ Main is also changed:
                     col += color(r, world);
                 }
                 col /= float(ns);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
                 int ir = int(255.99*col[0]);
                 int ig = int(255.99*col[1]);
                 int ib = int(255.99*col[2]);
+
                 std::cout << ir << " " << ig << " " << ib << "\n";
             }
         }
@@ -985,8 +1025,10 @@ Then update the `color()` function to use the new random direction generator:
     vec3 color(const ray& r, hitable *world, int depth) {
         hit_record rec;
         if (world->hit(r, 0.0, MAXFLOAT, rec)) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             vec3 target = rec.p + rec.normal + random_in_unit_sphere();
             return 0.5 * color(ray(rec.p, target - rec.p), world);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
         else {
             vec3 unit_direction = unit_vector(r.direction());
@@ -1225,6 +1267,7 @@ We need to modify the color function to use this:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     vec3 color(const ray& r, hitable *world, int depth) {
         hit_record rec;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         if (world->hit(r, 0.001, MAXFLOAT, rec)) {
             ray scattered;
             vec3 attenuation;
@@ -1234,6 +1277,7 @@ We need to modify the color function to use this:
             else {
                 return vec3(0,0,0);
             }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
         else {
             vec3 unit_direction = unit_vector(r.direction());
@@ -1254,12 +1298,17 @@ metal spheres:
         int ny = 100;
         int ns = 100;
         std::cout << "P3\n" << nx << " " << ny << "\n255\n";
+
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         hitable *list[4];
         list[0] = new sphere(vec3(0,0,-1), 0.5, new lambertian(vec3(0.1, 0.2, 0.5)));
         list[1] = new sphere(vec3(0,-100.5,-1), 100, new lambertian(vec3(0.8, 0.8, 0.0)));
         list[2] = new sphere(vec3(1,0,-1), 0.5, new metal(vec3(0.8, 0.6, 0.2), 0.0));
         list[3] = new sphere(vec3(-1,0,-1), 0.5, new metal(vec3(0.8, 0.8, 0.8)));
         hitable *world = new hitable_list(list,4);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
         camera cam;
         for (int j = ny-1; j >= 0; j--) {
             for (int i = 0; i < nx; i++) {
@@ -1268,14 +1317,17 @@ metal spheres:
                     float u = float(i + random_double()) / float(nx);
                     float v = float(j + random_double()) / float(ny);
                     ray r = cam.get_ray(u, v);
-                    vec3 p = r.point_at_parameter(2.0);
                     col += color(r, world,0);
                 }
                 col /= float(ns);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 col = vec3( sqrt(col[0]), sqrt(col[1]), sqrt(col[2]) );
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
                 int ir = int(255.99*col[0]);
                 int ig = int(255.99*col[1]);
                 int ib = int(255.99*col[2]);
+
                 std::cout << ir << " " << ig << " " << ib << "\n";
             }
         }
@@ -1307,9 +1359,11 @@ absorb those. We’ll put a maximum of 1 on the radius of the sphere which yield
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class metal : public material {
         public:
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             metal(const vec3& a, float f) : albedo(a) {
                 if (f < 1) fuzz = f; else fuzz = 1;
             }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
             virtual bool scatter(const ray& r_in, const hit_record& rec,
                 vec3& attenuation, ray& scattered) const
@@ -1320,7 +1374,9 @@ absorb those. We’ll put a maximum of 1 on the radius of the sphere which yield
                 return (dot(scattered.direction(), rec.normal) > 0);
             }
             vec3 albedo;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             float fuzz;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1396,14 +1452,18 @@ And the dielectric material that always refracts when possible is:
     class dielectric : public material {
         public:
             dielectric(float ri) : ref_idx(ri) {}
-            virtual bool scatter(const ray& r_in, const hit_record& rec,
-                vec3& attenuation, ray& scattered) const
+            virtual bool scatter(
+                const ray& r_in,
+                const hit_record& rec,
+                vec3& attenuation,
+                ray& scattered) const
             {
                 vec3 outward_normal;
                 vec3 reflected = reflect(r_in.direction(), rec.normal);
                 float ni_over_nt;
                 attenuation = vec3(1.0, 1.0, 0.0);
                 vec3 refracted;
+
                 if (dot(r_in.direction(), rec.normal) > 0) {
                      outward_normal = -rec.normal;
                      ni_over_nt = ref_idx;
@@ -1412,12 +1472,14 @@ And the dielectric material that always refracts when possible is:
                      outward_normal = rec.normal;
                      ni_over_nt = 1.0 / ref_idx;
                 }
+
                 if (refract(r_in.direction(), outward_normal, ni_over_nt, refracted))
                    scattered = ray(rec.p, refracted);
                 else {
                    scattered = ray(rec.p, reflected);
                    return false;
                 }
+
                 return true;
             }
 
@@ -1475,7 +1537,9 @@ This yields our full glass material:
         public:
             dielectric(float ri) : ref_idx(ri) {}
             virtual bool scatter(
-                const ray& r_in, const hit_record& rec, vec3& attenuation,
+                const ray& r_in,
+                const hit_record& rec,
+                vec3& attenuation,
                 ray& scattered) const
             {
                 vec3 outward_normal;
@@ -1483,32 +1547,46 @@ This yields our full glass material:
                 float ni_over_nt;
                 attenuation = vec3(1.0, 1.0, 1.0);
                 vec3 refracted;
+
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 float reflect_prob;
                 float cosine;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
                 if (dot(r_in.direction(), rec.normal) > 0) {
                      outward_normal = -rec.normal;
                      ni_over_nt = ref_idx;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                      cosine = ref_idx * dot(r_in.direction(), rec.normal)
                             / r_in.direction().length();
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 }
                 else {
                      outward_normal = rec.normal;
                      ni_over_nt = 1.0 / ref_idx;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                      cosine = -dot(r_in.direction(), rec.normal)
                             / r_in.direction().length();
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 }
+
                 if (refract(r_in.direction(), outward_normal, ni_over_nt, refracted)) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                    reflect_prob = schlick(cosine, ref_idx);
                 }
                 else {
                    reflect_prob = 1.0;
                 }
+
                 if (random_double() < reflect_prob) {
                    scattered = ray(rec.p, reflected);
                 }
                 else {
                    scattered = ray(rec.p, refracted);
                 }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
                 return true;
             }
 
@@ -1577,6 +1655,7 @@ This implies $h = tan(\theta/2)$. Our camera now becomes:
                 vertical = vec3(0.0, 2*half_height, 0.0);
                 origin = vec3(0.0, 0.0, 0.0);
             }
+
             ray get_ray(float u, float v) {
                 return ray(origin,
                            lower_left_corner + u*horizontal + v*vertical - origin);
@@ -1638,12 +1717,15 @@ camera horizontally level until you decide to experiment with crazy camera angle
 
     class camera {
         public:
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             camera(vec3 lookfrom, vec3 lookat, vec3 vup, float vfov, float aspect) {
                 // vfov is top to bottom in degrees
                 vec3 u, v, w;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 float theta = vfov*M_PI/180;
                 float half_height = tan(theta/2);
                 float half_width = aspect * half_height;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 origin = lookatfrom;
                 w = unit_vector(lookfrom - lookat);
                 u = unit_vector(cross(vup, w));
@@ -1651,7 +1733,9 @@ camera horizontally level until you decide to experiment with crazy camera angle
                 lower_left_corner = origin - half_width*u - half_height*v - w;
                 horizontal = 2*half_width*u;
                 vertical = 2*half_height*v;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             }
+
             ray get_ray(float s, float t) {
                 return ray(origin,
                            lower_left_corner + s*horizontal + t*vertical - origin);
@@ -1735,10 +1819,12 @@ point:
 
     class camera {
         public:
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             camera(vec3 lookfrom, vec3 lookat, vec3 vup, float vfov, float aspect,
                 float aperture, float focus_dist)
             {
                 lens_radius = aperture / 2;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 float theta = vfov*M_PI/180;
                 float half_height = tan(theta/2);
                 float half_width = aspect * half_height;
@@ -1746,27 +1832,34 @@ point:
                 w = unit_vector(lookfrom - lookat);
                 u = unit_vector(cross(vup, w));
                 v = cross(w, u);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 lower_left_corner = origin
                                   - half_width * focus_dist * u
                                   - half_height * focus_dist * v
                                   - focus_dist * w;
                 horizontal = 2*half_width*focus_dist*u;
                 vertical = 2*half_height*focus_dist*v;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             }
+
             ray get_ray(float s, float t) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 vec3 rd = lens_radius*random_in_unit_disk();
                 vec3 offset = u * rd.x() + v * rd.y();
                 return ray(origin + offset,
                            lower_left_corner + s*horizontal + t*vertical
                                - origin - offset);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             }
 
             vec3 origin;
             vec3 lower_left_corner;
             vec3 horizontal;
             vec3 vertical;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             vec3 u, v, w;
             float lens_radius;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     };
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -97,7 +97,6 @@ to camera because for now it is not allowed to move; it just sends out rays over
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class camera {
         public:
-            // new:  add t0 and t1
             camera(
                 vec3 lookfrom,
                 vec3 lookat,
@@ -106,8 +105,10 @@ to camera because for now it is not allowed to move; it just sends out rays over
                 float aspect,
                 float aperture,
                 float focus_dist,
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 float t0,
                 float t1) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
                 time0 = t0;
                 time1 = t1;
@@ -127,11 +128,12 @@ to camera because for now it is not allowed to move; it just sends out rays over
                 vertical = 2*half_height*focus_dist*v;
             }
 
-            // new: add time to construct ray
             ray get_ray(float s, float t) {
                 vec3 rd = lens_radius*random_in_unit_disk();
                 vec3 offset = u * rd.x() + v * rd.y();
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 float time = time0 + random_double()*(time1-time0);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 return ray(
                     origin + offset,
                     lower_left_corner + s*horizontal + t*vertical - origin - offset,
@@ -143,7 +145,9 @@ to camera because for now it is not allowed to move; it just sends out rays over
             vec3 horizontal;
             vec3 vertical;
             vec3 u, v, w;
-            float time0, time1;  // new variables for shutter open/close times
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+            float time0, time1;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             float lens_radius;
     };
 
@@ -181,11 +185,12 @@ fewer classes and more efficient stationary spheres, so let your design taste gu
 intersection code barely needs a change: `center` just needs to become a function `center(time)`:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    // replace "center" with "center(r.time())"
     bool moving_sphere::hit(
         const ray& r, float t_min, float t_max, hit_record& rec) const {
 
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         vec3 oc = r.origin() - center(r.time());
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         float a = dot(r.direction(), r.direction());
         float b = dot(oc, r.direction());
         float c = dot(oc, oc) - radius*radius;
@@ -195,7 +200,9 @@ intersection code barely needs a change: `center` just needs to become a functio
             if (temp < t_max && temp > t_min) {
                 rec.t = temp;
                 rec.p = r.point_at_parameter(rec.t);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 rec.normal = (rec.p - center(r.time())) / radius;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 rec.mat_ptr = mat_ptr;
                 return true;
             }
@@ -203,7 +210,9 @@ intersection code barely needs a change: `center` just needs to become a functio
             if (temp < t_max && temp > t_min) {
                 rec.t = temp;
                 rec.p = r.point_at_parameter(rec.t);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 rec.normal = (rec.p - center(r.time())) / radius;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 rec.mat_ptr = mat_ptr;
                 return true;
             }
@@ -225,7 +234,9 @@ Be sure that in the materials you have the scattered rays be at the time of the 
                 vec3& attenuation, ray& scattered) const {
 
                 vec3 target = rec.p + rec.normal + random_in_unit_sphere();
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 scattered = ray(rec.p, target-rec.p, r_in.time());
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 attenuation = albedo;
                 return true;
             }
@@ -1124,9 +1135,11 @@ the interpolation:
                 float v = p.y() - floor(p.y());
                 float w = p.z() - floor(p.z());
 
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 u = u*u*(3-2*u);
                 v = v*v*(3-2*v);
                 w = w*w*(3-2*w);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
                 int i = floor(p.x());
                 int j = floor(p.y());
@@ -1151,7 +1164,11 @@ It is also a bit low frequency. We can scale the input point to make it vary mor
             noise_texture() {}
             noise_texture(float sc) : scale(sc) {}
             virtual vec3 value(float u, float v, const vec3& p) const {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ none delete
+                return vec3(1,1,1) * noise.noise(p);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 return vec3(1,1,1) * noise.noise(scale * p);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             }
             perlin noise;
             float scale;
@@ -1298,9 +1315,11 @@ effect is:
             noise_texture() {}
             noise_texture(float sc) : scale(sc) {}
             virtual vec3 value(float u, float v, const vec3& p) const {
-    //            return vec3(1,1,1)*0.5*(1 + noise.turb(scale * p));
-    //            return vec3(1,1,1)*noise.turb(scale * p);
-                  return vec3(1,1,1)*0.5*(1 + sin(scale*p.z() + 10*noise.turb(p))) ;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ none delete
+                return vec3(1,1,1) * noise.noise(scale * p);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+                return vec3(1,1,1) * 0.5 * (1 + sin(scale*p.z() + 10*noise.turb(p)));
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             }
             perlin noise;
             float scale;

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -1218,6 +1218,7 @@ math and get the concept, we can add it (see the highlighted region):
             float pdf;
             vec3 albedo;
             if (depth < 50 && rec.mat_ptr->scatter(r, rec, albedo, scattered, pdf)) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 vec3 on_light = vec3(213 + random_double()*(343-213),
                                      554,
                                      227 + random_double()*(332-227));
@@ -1232,6 +1233,7 @@ math and get the concept, we can add it (see the highlighted region):
                     return emitted;
                 pdf = distance_squared / (light_cosine * light_area);
                 scattered = ray(rec.p, to_light, r.time());
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
                 return emitted
                      + albedo * rec.mat_ptr->scattering_pdf(r, rec, scattered)
@@ -1374,9 +1376,11 @@ variable `pdf` to some other variable name to avoid a name conflict with the new
             float pdf_val;
             vec3 albedo;
             if (depth < 50 && rec.mat_ptr->scatter(r, rec, albedo, scattered, pdf_val)) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 cosine_pdf p(rec.normal);
                 scattered = ray(rec.p, p.generate(), r.time());
                 pdf_val = p.value(scattered.direction());
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 return emitted
                      + albedo * rec.mat_ptr->scattering_pdf(r, rec, scattered)
                               * color(scattered, world, depth+1)
@@ -1449,6 +1453,7 @@ And we change `xz_rect` to implement those functions:
                 box =  aabb(vec3(x0,k-0.0001,z0), vec3(x1, k+0.0001, z1));
                 return true;
             }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             virtual float  pdf_value(const vec3& o, const vec3& v) const {
                 hit_record rec;
                 if (this->hit(ray(o, v), 0.001, FLT_MAX, rec)) {
@@ -1465,6 +1470,7 @@ And we change `xz_rect` to implement those functions:
                     z0 + random_double()*(z1-z0));
                 return random_point - o;
             }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             material  *mp;
             float x0, x1, z0, z1, k;
     };
@@ -1484,8 +1490,10 @@ And then change `color()`:
             float pdf_val;
             vec3 albedo;
             if (depth < 50 && rec.mat_ptr->scatter(r, rec, albedo, scattered, pdf_val))
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 hitable *light_shape = new xz_rect(213, 343, 227, 332, 554, 0);
                 hitable_pdf p(light_shape, rec.p);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 scattered = ray(rec.p, p.generate(), r.time());
                 pdf_val = p.value(scattered.direction());
                 return emitted
@@ -1544,10 +1552,12 @@ And plugging it into `color()`:
             float pdf_val;
             vec3 albedo;
             if (depth < 50 && rec.mat_ptr->scatter(r, rec, albedo, scattered, pdf_val))
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 hitable *light_shape = new xz_rect(213, 343, 227, 332, 554, 0);
                 hitable_pdf p0(light_shape, rec.p);
                 cosine_pdf p1(rec.normal);
                 mixture_pdf p(&p0, &p1);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 scattered = ray(rec.p, p.generate(), r.time());
                 pdf_val = p.value(scattered.direction());
                 return emitted + albedo*rec.mat_ptr->scattering_pdf(r, rec, scattered)*
@@ -1678,6 +1688,7 @@ The Lambertian material becomes simpler:
                     return 0;
                 return cosine / M_PI;
             }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             bool scatter(const ray& r_in, const hit_record& hrec,
                 scatter_record& srec) const {
                 srec.is_specular = false;
@@ -1685,6 +1696,7 @@ The Lambertian material becomes simpler:
                 srec.pdf_ptr = new cosine_pdf(hrec.normal);
                 return true;
             }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             texture *albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1697,6 +1709,7 @@ And `color()` changes are small:
     vec3 color(const ray& r, hitable *world, hitable *light_shape, int depth) {
         hit_record hrec;
         if (world->hit(r, 0.001, MAXFLOAT, hrec)) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             scatter_record srec;
             vec3 emitted = hrec.mat_ptr->emitted(r, hrec, hrec.u, hrec.v, hrec.p);
             if (depth < 50 && hrec.mat_ptr->scatter(r, hrec, srec)) {
@@ -1708,6 +1721,7 @@ And `color()` changes are small:
                     + srec.attenuation * hrec.mat_ptr->scattering_pdf(r, hrec, scattered)
                                        * color(scattered, world, light_shape, depth+1)
                                        / pdf_val;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             }
             else
                 return emitted;
@@ -1728,6 +1742,7 @@ overall, and those are all fixable. For now, I will just fix `specular`. Metal i
         public:
             metal(const vec3& a, float f) : albedo(a)
                 { if (f < 1) fuzz = f; else fuzz = 1; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             virtual bool scatter(const ray& r_in, const hit_record& hrec,
                 scatter_record& srec) const {
                 vec3 reflected = reflect(unit_vector(r_in.direction()), hrec.normal);
@@ -1737,6 +1752,7 @@ overall, and those are all fixable. For now, I will just fix `specular`. Metal i
                 srec.pdf_ptr = 0;
                 return true;
             }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             vec3 albedo;
             float fuzz;
     };
@@ -1756,11 +1772,13 @@ just like it did before.
             scatter_record srec;
             vec3 emitted = hrec.mat_ptr->emitted(r, hrec, hrec.u, hrec.v, hrec.p);
             if (depth < 50 && hrec.mat_ptr->scatter(r, hrec, srec)) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 if (srec.is_specular) {
                     return srec.attenuation
                          * color(srec.specular_ray, world, light_shape, depth+1);
                 }
                 else {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                     hitable_pdf plight(light_shape, hrec.p);
                     mixture_pdf p(&plight, srec.pdf_ptr);
                     ray scattered = ray(hrec.p, p.generate(), r.time());
@@ -1801,10 +1819,12 @@ We also need to change the block to metal.
         list[i++] = new translate(
             new rotate_y(new box(vec3(0, 0, 0), vec3(165, 165, 165), white),  -18),
             vec3(130,0,65));
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         material *aluminum = new metal(vec3(0.8, 0.85, 0.88), 0.0);
         list[i++] = new translate(
             new rotate_y(new box(vec3(0, 0, 0), vec3(165, 330, 165), aluminum),  15),
             vec3(265,0,295));
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         *scene = new hitable_list(list,i);
         vec3 lookfrom(278, 278, -800);
         vec3 lookat(278,278,0);
@@ -2052,7 +2072,9 @@ And we can insert that in the main loop:
         float v = float(j+random_double())/ float(ny);
         ray r = cam->get_ray(u, v);
         vec3 p = r.point_at_parameter(2.0);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         col += de_nan(color(r, world, &hlist, 0));
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </div>

--- a/style/book.css
+++ b/style/book.css
@@ -87,10 +87,14 @@ body {
 .md pre.listing.tilde {
     border: solid 3px #d4d4d4;
     background: #e4e4e0;
+    margin-left: 3ex;
+    padding: 1.5ex;
+    width: 94%;
 }
 
 .md pre.listing.tilde code {
     font-size: 86%;
+    margin-left: 0;
 }
 
 /* Hilight.js Syntax Coloring */
@@ -112,9 +116,20 @@ body {
 }
 
 .hljs-number {
-    color: #0a0;
+    color: #009944;
 }
 
+/* Code Line Types */
+
+.md code > .highlight {
+    background-color: #ccdbc8;
+}
+
+.md code > .delete {
+    text-decoration: line-through;
+    background-color: #ffcccc;
+    color: #a0a0a0;
+}
 
 /* -------------------------------------------------------------------------------------------------
 ** Images & Figures


### PR DESCRIPTION
This adds styles for deleted lines and for highlighted (or new) lines.

Note that switching sub-styles in the middle of a code block will
swallow any leading blank line before, so in some cases you'll see two
blank lines in the tilde block where there would normally be one. This
will still render with a single blank line.

In addition to addressing existing cases, I've also found other cases
where highlighting illustrates incremental changes from one version to
the next, particularly in _Ray Tracing In One Weekend_ (book 1).

See issue #14
Resolves #11