### PR TITLE
src: change header guard format

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -349,8 +349,8 @@ here:
 The function $p(t)$ in more verbose code form I call “point_at_parameter(t)”:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #ifndef RAYH
-    #define RAYH
+    #ifndef RAY_H
+    #define RAY_H
 
     #include "common/vec3.h"
 
@@ -630,8 +630,8 @@ go with the simple solution and compute a bundle of stuff I will store in some s
 we’ll want motion blur at some point, so I’ll add a time input variable. Here’s the abstract class:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #ifndef HITTABLEH
-    #define HITTABLEH
+    #ifndef HITTABLE_H
+    #define HITTABLE_H
 
     #include "ray.h"
 
@@ -655,8 +655,8 @@ we’ll want motion blur at some point, so I’ll add a time input variable. Her
 And here’s the sphere (note that I eliminated a bunch of redundant 2’s that cancel each other out):
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #ifndef SPHEREH
-    #define SPHEREH
+    #ifndef SPHERE_H
+    #define SPHERE_H
 
     #include "hittable.h"
 
@@ -705,8 +705,8 @@ And here’s the sphere (note that I eliminated a bunch of redundant 2’s that 
 And a list of objects:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #ifndef HITTABLELISTH
-    #define HITTABLELISTH
+    #ifndef HITTABLE_LIST_H
+    #define HITTABLE_LIST_H
 
     #include "hittable.h"
 
@@ -746,8 +746,8 @@ need infinity, but we will also throw our own definition of pi in there, which w
 There is no standard portable definition of pi, so we just define our own constant for it.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #ifndef CONSTANTSH
-    #define CONSTANTSH
+    #ifndef CONSTANTS_H
+    #define CONSTANTS_H
 
     #include <limits>
 
@@ -858,8 +858,8 @@ function returns a random integer in the range 0 and RANDMAX. Hence we can get a
 as desired with the following code snippet:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #ifndef RANDOMH
-    #define RANDOMH
+    #ifndef RANDOM_H
+    #define RANDOM_H
 
     #include <cstdlib>
 
@@ -876,8 +876,8 @@ addressed this issue with the `<random>` header (if imperfectly according to som
 If you want to use this, you can obtain a random number with the conditions we need as follows:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #ifndef RANDOMH
-    #define RANDOMH
+    #ifndef RANDOM_H
+    #define RANDOM_H
 
     #include <functional>
     #include <random>
@@ -906,8 +906,8 @@ Putting that all together yields a camera class encapsulating our simple axis-al
 before:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #ifndef CAMERAH
-    #define CAMERAH
+    #ifndef CAMERA_H
+    #define CAMERA_H
 
     #include "ray.h"
 
@@ -1139,8 +1139,8 @@ other so there is some circularity of the references. In C++ you just need to al
 that the pointer is to a class, which the “class material” in the hittable class below does:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #ifndef HITTABLEH
-    #define HITTABLEH
+    #ifndef HITTABLE_H
+    #define HITTABLE_H
     #include "ray.h"
 
     class material;
@@ -1649,8 +1649,8 @@ $z = -2$ plane, or whatever, as long as we made $h$ a ratio to that distance. He
 This implies $h = tan(\theta/2)$. Our camera now becomes:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #ifndef CAMERAH
-    #define CAMERAH
+    #ifndef CAMERA_H
+    #define CAMERA_H
 
     #include "common/constants.h"
     #include "ray.h"
@@ -1721,8 +1721,8 @@ have to -- use world up (0,1,0) to specify vup. This is convenient and will natu
 camera horizontally level until you decide to experiment with crazy camera angles.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #ifndef CAMERAH
-    #define CAMERAH
+    #ifndef CAMERA_H
+    #define CAMERA_H
 
     #include "ray.h"
 
@@ -1814,8 +1814,8 @@ For that we just need to have the ray origins be on a disk around `lookfrom` rat
 point:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #ifndef CAMERAH
-    #define CAMERAH
+    #ifndef CAMERA_H
+    #define CAMERA_H
 
     #include "random.h"
     #include "ray.h"

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -1441,11 +1441,10 @@ RGBs that each range 0..255 for black to fully-on.
 
 <div class='together'>
 The representation of a packed array in that order is pretty standard. Thankfully, the `stb_image`
-package makes that super simple -- just include the header in `main.h` with a `#define`:
+package makes that super simple -- just include the header `common/rtw_stb_image.h` in `main.h`:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #define STB_IMAGE_IMPLEMENTATION
-    #include "common/stb_image.h"
+    #include "common/rtw_stb_image.h"
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </div>
 

--- a/src/InOneWeekend/camera.h
+++ b/src/InOneWeekend/camera.h
@@ -1,5 +1,5 @@
-#ifndef CAMERAH
-#define CAMERAH
+#ifndef CAMERA_H
+#define CAMERA_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/InOneWeekend/hittable.h
+++ b/src/InOneWeekend/hittable.h
@@ -1,5 +1,5 @@
-#ifndef HITTABLEH
-#define HITTABLEH
+#ifndef HITTABLE_H
+#define HITTABLE_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/InOneWeekend/hittable_list.h
+++ b/src/InOneWeekend/hittable_list.h
@@ -1,5 +1,5 @@
-#ifndef HITTABLELISTH
-#define HITTABLELISTH
+#ifndef HITTABLE_LIST_H
+#define HITTABLE_LIST_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/InOneWeekend/material.h
+++ b/src/InOneWeekend/material.h
@@ -1,5 +1,5 @@
-#ifndef MATERIALH
-#define MATERIALH
+#ifndef MATERIAL_H
+#define MATERIAL_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/InOneWeekend/random.h
+++ b/src/InOneWeekend/random.h
@@ -1,5 +1,5 @@
-#ifndef RANDOMH
-#define RANDOMH
+#ifndef RANDOM_H
+#define RANDOM_H
 
 #include <cstdlib>
 

--- a/src/InOneWeekend/ray.h
+++ b/src/InOneWeekend/ray.h
@@ -1,5 +1,5 @@
-#ifndef RAYH
-#define RAYH
+#ifndef RAY_H
+#define RAY_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/InOneWeekend/sphere.h
+++ b/src/InOneWeekend/sphere.h
@@ -1,5 +1,5 @@
-#ifndef SPHEREH
-#define SPHEREH
+#ifndef SPHERE_H
+#define SPHERE_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheNextWeek/aabb.h
+++ b/src/TheNextWeek/aabb.h
@@ -1,5 +1,5 @@
-#ifndef AABBH
-#define AABBH
+#ifndef AABB_H
+#define AABB_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheNextWeek/aarect.h
+++ b/src/TheNextWeek/aarect.h
@@ -1,5 +1,5 @@
-#ifndef AARECTH
-#define AARECTH
+#ifndef AARECT_H
+#define AARECT_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheNextWeek/box.h
+++ b/src/TheNextWeek/box.h
@@ -1,5 +1,5 @@
-#ifndef BOXH
-#define BOXH
+#ifndef BOX_H
+#define BOX_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheNextWeek/bvh.h
+++ b/src/TheNextWeek/bvh.h
@@ -1,5 +1,5 @@
-#ifndef BVHH
-#define BVHH
+#ifndef BVH_H
+#define BVH_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheNextWeek/camera.h
+++ b/src/TheNextWeek/camera.h
@@ -1,5 +1,5 @@
-#ifndef CAMERAH
-#define CAMERAH
+#ifndef CAMERA_H
+#define CAMERA_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheNextWeek/constant_medium.h
+++ b/src/TheNextWeek/constant_medium.h
@@ -1,5 +1,5 @@
-#ifndef CMEDH
-#define CMEDH
+#ifndef CONSTANT_MEDIUM_H
+#define CONSTANT_MEDIUM_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheNextWeek/hittable.h
+++ b/src/TheNextWeek/hittable.h
@@ -1,5 +1,5 @@
-#ifndef HITTABLEH
-#define HITTABLEH
+#ifndef HITTABLE_H
+#define HITTABLE_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheNextWeek/hittable_list.h
+++ b/src/TheNextWeek/hittable_list.h
@@ -1,5 +1,5 @@
-#ifndef HITTABLELISTH
-#define HITTABLELISTH
+#ifndef HITTABLE_LIST_H
+#define HITTABLE_LIST_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheNextWeek/material.h
+++ b/src/TheNextWeek/material.h
@@ -1,5 +1,5 @@
-#ifndef MATERIALH
-#define MATERIALH
+#ifndef MATERIAL_H
+#define MATERIAL_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheNextWeek/moving_sphere.h
+++ b/src/TheNextWeek/moving_sphere.h
@@ -1,5 +1,5 @@
-#ifndef MOVINGSPHEREH
-#define MOVINGSPHEREH
+#ifndef MOVING_SPHERE_H
+#define MOVING_SPHERE_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheNextWeek/perlin.h
+++ b/src/TheNextWeek/perlin.h
@@ -1,5 +1,5 @@
-#ifndef PERLINH
-#define PERLINH
+#ifndef PERLIN_H
+#define PERLIN_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheNextWeek/random.h
+++ b/src/TheNextWeek/random.h
@@ -1,5 +1,5 @@
-#ifndef RANDOMH
-#define RANDOMH
+#ifndef RANDOM_H
+#define RANDOM_H
 
 #include <cstdlib>
 

--- a/src/TheNextWeek/ray.h
+++ b/src/TheNextWeek/ray.h
@@ -1,5 +1,5 @@
-#ifndef RAYH
-#define RAYH
+#ifndef RAY_H
+#define RAY_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheNextWeek/sphere.h
+++ b/src/TheNextWeek/sphere.h
@@ -1,5 +1,5 @@
-#ifndef SPHEREH
-#define SPHEREH
+#ifndef SPHERE_H
+#define SPHERE_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheNextWeek/surface_texture.h
+++ b/src/TheNextWeek/surface_texture.h
@@ -1,5 +1,5 @@
-#ifndef SURFTEXTH
-#define SURFTEXTH
+#ifndef SURFACE_TEXTURE_H
+#define SURFACE_TEXTURE_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheNextWeek/texture.h
+++ b/src/TheNextWeek/texture.h
@@ -1,5 +1,5 @@
-#ifndef TEXTUREH
-#define TEXTUREH
+#ifndef TEXTURE_H
+#define TEXTURE_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/aabb.h
+++ b/src/TheRestOfYourLife/aabb.h
@@ -1,5 +1,5 @@
-#ifndef AABBH
-#define AABBH
+#ifndef AABB_H
+#define AABB_H
 //==================================================================================================
 // Originally written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/aarect.h
+++ b/src/TheRestOfYourLife/aarect.h
@@ -1,5 +1,5 @@
-#ifndef AARECTH
-#define AARECTH
+#ifndef AARECT_H
+#define AARECT_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/box.h
+++ b/src/TheRestOfYourLife/box.h
@@ -1,5 +1,5 @@
-#ifndef BOXH
-#define BOXH
+#ifndef BOX_H
+#define BOX_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/bvh.h
+++ b/src/TheRestOfYourLife/bvh.h
@@ -1,5 +1,5 @@
-#ifndef BVHH
-#define BVHH
+#ifndef BVH_H
+#define BVH_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/camera.h
+++ b/src/TheRestOfYourLife/camera.h
@@ -1,5 +1,5 @@
-#ifndef CAMERAH
-#define CAMERAH
+#ifndef CAMERA_H
+#define CAMERA_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/constant_medium.h
+++ b/src/TheRestOfYourLife/constant_medium.h
@@ -1,5 +1,5 @@
-#ifndef CMEDH
-#define CMEDH
+#ifndef CONSTANT_MEDIUM_H
+#define CONSTANT_MEDIUM_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/hittable.h
+++ b/src/TheRestOfYourLife/hittable.h
@@ -1,5 +1,5 @@
-#ifndef HITTABLEH
-#define HITTABLEH
+#ifndef HITTABLE_H
+#define HITTABLE_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/hittable_list.h
+++ b/src/TheRestOfYourLife/hittable_list.h
@@ -1,5 +1,5 @@
-#ifndef HITTABLELISTH
-#define HITTABLELISTH
+#ifndef HITTABLE_LIST_H
+#define HITTABLE_LIST_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/material.h
+++ b/src/TheRestOfYourLife/material.h
@@ -1,5 +1,5 @@
-#ifndef MATERIALH
-#define MATERIALH
+#ifndef MATERIAL_H
+#define MATERIAL_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/moving_sphere.h
+++ b/src/TheRestOfYourLife/moving_sphere.h
@@ -1,5 +1,5 @@
-#ifndef MOVINGSPHEREH
-#define MOVINGSPHEREH
+#ifndef MOVING_SPHERE_H
+#define MOVING_SPHERE_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/onb.h
+++ b/src/TheRestOfYourLife/onb.h
@@ -1,5 +1,5 @@
-#ifndef ONBH
-#define ONBH
+#ifndef ONB_H
+#define ONB_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/pdf.h
+++ b/src/TheRestOfYourLife/pdf.h
@@ -1,5 +1,5 @@
-#ifndef PDFH
-#define PDFH
+#ifndef PDF_H
+#define PDF_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/perlin.h
+++ b/src/TheRestOfYourLife/perlin.h
@@ -1,5 +1,5 @@
-#ifndef PERLINH
-#define PERLINH
+#ifndef PERLIN_H
+#define PERLIN_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/random.h
+++ b/src/TheRestOfYourLife/random.h
@@ -1,5 +1,5 @@
-#ifndef RANDOMH
-#define RANDOMH
+#ifndef RANDOM_H
+#define RANDOM_H
 
 #include <cstdlib>
 

--- a/src/TheRestOfYourLife/ray.h
+++ b/src/TheRestOfYourLife/ray.h
@@ -1,5 +1,5 @@
-#ifndef RAYH
-#define RAYH
+#ifndef RAY_H
+#define RAY_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -1,5 +1,5 @@
-#ifndef SPHEREH
-#define SPHEREH
+#ifndef SPHERE_H
+#define SPHERE_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/surface_texture.h
+++ b/src/TheRestOfYourLife/surface_texture.h
@@ -1,5 +1,5 @@
-#ifndef SURFTEXTH
-#define SURFTEXTH
+#ifndef SURFACE_TEXTURE_H
+#define SURFACE_TEXTURE_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/TheRestOfYourLife/texture.h
+++ b/src/TheRestOfYourLife/texture.h
@@ -1,5 +1,5 @@
-#ifndef TEXTUREH
-#define TEXTUREH
+#ifndef TEXTURE_H
+#define TEXTURE_H
 //==================================================================================================
 // Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //

--- a/src/common/vec3.h
+++ b/src/common/vec3.h
@@ -1,5 +1,5 @@
-#ifndef VEC3H
-#define VEC3H
+#ifndef VEC3_H
+#define VEC3_H
 //==================================================================================================
 // Originally written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //


### PR DESCRIPTION
Old style was `HITTABLELISTH`, new is `HITTABLE_LIST_H`. Easier to
scan.

Resolves #220