### PR TITLE
Clarify sphere intersect + slight perf improvement

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -535,6 +535,7 @@ normal, we need the hit point, not just whether we hit or not. Let’s assume th
         auto b = 2.0 * dot(oc, r.direction());
         auto c = dot(oc, oc) - radius*radius;
         auto discriminant = b*b - 4*a*c;
+
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         if (discriminant < 0) {
             return -1.0;
@@ -568,6 +569,46 @@ And that yields this picture:
   ![Image 6-1](../images/img-1-06-1.png)
 
 </div>
+
+Let’s revisit the ray-sphere equation:
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    vec3 oc = r.origin() - center;
+    auto a = dot(r.direction(), r.direction());
+    auto b = 2.0 * dot(oc, r.direction());
+    auto c = dot(oc, oc) - radius*radius;
+    auto discriminant = b*b - 4*a*c;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First, recall that a vector dotted with itself is equal to the squared length of that vector.
+
+Second, notice how the equation for `b` has a factor of two in it. Consider what happens to the
+quadratic equation if $b = 2h$:
+
+  $$ \frac{-b \pm \sqrt{b^2 - 4ac}}{2a} $$
+
+  $$ = \frac{-2h \pm \sqrt{(2h)^2 - 4ac}}{2a} $$
+
+  $$ = \frac{-2h \pm 2\sqrt{h^2 - ac}}{2a} $$
+
+  $$ = \frac{-h \pm \sqrt{h^2 - ac}}{a} $$
+
+Using these observations, we can now simplify the sphere-intersection code to this:
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    vec3 oc = r.origin() - center;
+    auto a = r.direction().squared_length();
+    auto half_b = dot(oc, r.direction());
+    auto c = oc.squared_length() - radius*radius;
+    auto discriminant = half_b*half_b - a*c;
+
+    if (discriminant < 0) {
+        return -1.0;
+    }
+    else {
+        return (-half_b - sqrt(discriminant) ) / a;
+    }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 
 Now, how about several spheres? While it is tempting to have an array of spheres, a very clean
 solution is the make an “abstract class” for anything a ray might hit and make both a sphere and a
@@ -609,7 +650,7 @@ we’ll want motion blur at some point, so I’ll add a time input variable. Her
 </div>
 
 <div class='together'>
-And here’s the sphere (note that I eliminated a bunch of redundant 2’s that cancel each other out):
+And here’s the sphere:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #ifndef SPHERE_H
@@ -629,19 +670,21 @@ And here’s the sphere (note that I eliminated a bunch of redundant 2’s that 
 
     bool sphere::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
         vec3 oc = r.origin() - center;
-        auto a = dot(r.direction(), r.direction());
-        auto b = dot(oc, r.direction());
-        auto c = dot(oc, oc) - radius*radius;
-        auto discriminant = b*b - a*c;
+        auto a = r.direction().squared_length();
+        auto half_b = dot(oc, r.direction());
+        auto c = oc.squared_length() - radius*radius;
+        auto discriminant = half_b*half_b - a*c;
+
         if (discriminant > 0) {
-            auto temp = (-b - sqrt(discriminant))/a;
+            auto root = sqrt(discriminant);
+            auto temp = (-half_b - root)/a;
             if (temp < t_max && temp > t_min) {
                 rec.t = temp;
                 rec.p = r.point_at_parameter(rec.t);
                 rec.normal = (rec.p - center) / radius;
                 return true;
             }
-            temp = (-b + sqrt(discriminant)) / a;
+            temp = (-half_b + root) / a;
             if (temp < t_max && temp > t_min) {
                 rec.t = temp;
                 rec.p = r.point_at_parameter(rec.t);
@@ -1176,12 +1219,14 @@ within `hit_record`. See the lines below marked with **`/* NEW */`**.
 
     bool sphere::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
         vec3 oc = r.origin() - center;
-        auto a = dot(r.direction(), r.direction());
-        auto b = dot(oc, r.direction());
-        auto c = dot(oc, oc) - radius*radius;
-        auto discriminant = b*b - a*c;
+        auto a = r.direction().squared_length();
+        auto half_b = dot(oc, r.direction());
+        auto c = oc.squared_length() - radius*radius;
+        auto discriminant = half_b*half_b - a*c;
+
         if (discriminant > 0) {
-            auto temp = (-b - sqrt(discriminant))/a;
+            auto root = sqrt(discriminant);
+            auto temp = (-half_b - root)/a;
             if (temp < t_max && temp > t_min) {
                 rec.t = temp;
                 rec.p = r.point_at_parameter(rec.t);
@@ -1189,7 +1234,7 @@ within `hit_record`. See the lines below marked with **`/* NEW */`**.
                 rec.mat_ptr = mat_ptr; /* NEW */
                 return true;
             }
-            temp = (-b + sqrt(discriminant)) / a;
+            temp = (-half_b + root) / a;
             if (temp < t_max && temp > t_min) {
                 rec.t = temp;
                 rec.p = r.point_at_parameter(rec.t);

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -183,12 +183,14 @@ intersection code barely needs a change: `center` just needs to become a functio
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         vec3 oc = r.origin() - center(r.time());
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-        auto a = dot(r.direction(), r.direction());
-        auto b = dot(oc, r.direction());
-        auto c = dot(oc, oc) - radius*radius;
-        auto discriminant = b*b - a*c;
+        auto a = r.direction().squared_length();
+        auto half_b = dot(oc, r.direction());
+        auto c = oc.squared_length() - radius*radius;
+        auto discriminant = half_b*half_b - a*c;
+
         if (discriminant > 0) {
-            auto temp = (-b - sqrt(discriminant))/a;
+            auto root = sqrt(discriminant);
+            auto temp = (-half_b - root)/a;
             if (temp < t_max && temp > t_min) {
                 rec.t = temp;
                 rec.p = r.point_at_parameter(rec.t);
@@ -198,7 +200,7 @@ intersection code barely needs a change: `center` just needs to become a functio
                 rec.mat_ptr = mat_ptr;
                 return true;
             }
-            temp = (-b + sqrt(discriminant))/a;
+            temp = (-half_b + root) / a;
             if (temp < t_max && temp > t_min) {
                 rec.t = temp;
                 rec.p = r.point_at_parameter(rec.t);

--- a/src/InOneWeekend/sphere.h
+++ b/src/InOneWeekend/sphere.h
@@ -1,7 +1,7 @@
 #ifndef SPHERE_H
 #define SPHERE_H
 //==================================================================================================
-// Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
+// Originally written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //
 // To the extent possible under law, the author(s) have dedicated all copyright and related and
 // neighboring rights to this software to the public domain worldwide. This software is distributed
@@ -27,12 +27,14 @@ class sphere: public hittable  {
 
 bool sphere::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
     vec3 oc = r.origin() - center;
-    auto a = dot(r.direction(), r.direction());
-    auto b = dot(oc, r.direction());
-    auto c = dot(oc, oc) - radius*radius;
-    auto discriminant = b*b - a*c;
+    auto a = r.direction().squared_length();
+    auto half_b = dot(oc, r.direction());
+    auto c = oc.squared_length() - radius*radius;
+    auto discriminant = half_b*half_b - a*c;
+
     if (discriminant > 0) {
-        auto temp = (-b - sqrt(discriminant))/a;
+        auto root = sqrt(discriminant);
+        auto temp = (-half_b - root)/a;
         if (temp < t_max && temp > t_min) {
             rec.t = temp;
             rec.p = r.point_at_parameter(rec.t);
@@ -40,7 +42,7 @@ bool sphere::hit(const ray& r, double t_min, double t_max, hit_record& rec) cons
             rec.mat_ptr = mat_ptr;
             return true;
         }
-        temp = (-b + sqrt(discriminant)) / a;
+        temp = (-half_b + root) / a;
         if (temp < t_max && temp > t_min) {
             rec.t = temp;
             rec.p = r.point_at_parameter(rec.t);

--- a/src/TheNextWeek/sphere.h
+++ b/src/TheNextWeek/sphere.h
@@ -1,7 +1,7 @@
 #ifndef SPHERE_H
 #define SPHERE_H
 //==================================================================================================
-// Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
+// Originally written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //
 // To the extent possible under law, the author(s) have dedicated all copyright and related and
 // neighboring rights to this software to the public domain worldwide. This software is distributed
@@ -33,12 +33,14 @@ bool sphere::bounding_box(double t0, double t1, aabb& box) const {
 
 bool sphere::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
     vec3 oc = r.origin() - center;
-    auto a = dot(r.direction(), r.direction());
-    auto b = dot(oc, r.direction());
-    auto c = dot(oc, oc) - radius*radius;
-    auto discriminant = b*b - a*c;
+    auto a = r.direction().squared_length();
+    auto half_b = dot(oc, r.direction());
+    auto c = oc.squared_length() - radius*radius;
+    auto discriminant = half_b*half_b - a*c;
+
     if (discriminant > 0) {
-        auto temp = (-b - sqrt(b*b-a*c))/a;
+        auto root = sqrt(discriminant);
+        auto temp = (-half_b - root)/a;
         if (temp < t_max && temp > t_min) {
             rec.t = temp;
             rec.p = r.point_at_parameter(rec.t);
@@ -47,7 +49,7 @@ bool sphere::hit(const ray& r, double t_min, double t_max, hit_record& rec) cons
             rec.mat_ptr = mat_ptr;
             return true;
         }
-        temp = (-b + sqrt(b*b-a*c))/a;
+        temp = (-half_b + root)/a;
         if (temp < t_max && temp > t_min) {
             rec.t = temp;
             rec.p = r.point_at_parameter(rec.t);

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -1,7 +1,7 @@
 #ifndef SPHERE_H
 #define SPHERE_H
 //==================================================================================================
-// Written in 2016 by Peter Shirley <ptrshrl@gmail.com>
+// Originally written in 2016 by Peter Shirley <ptrshrl@gmail.com>
 //
 // To the extent possible under law, the author(s) have dedicated all copyright and related and
 // neighboring rights to this software to the public domain worldwide. This software is distributed
@@ -57,12 +57,14 @@ bool sphere::bounding_box(double t0, double t1, aabb& box) const {
 
 bool sphere::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
     vec3 oc = r.origin() - center;
-    auto a = dot(r.direction(), r.direction());
-    auto b = dot(oc, r.direction());
-    auto c = dot(oc, oc) - radius*radius;
-    auto discriminant = b*b - a*c;
+    auto a = r.direction().squared_length();
+    auto half_b = dot(oc, r.direction());
+    auto c = oc.squared_length() - radius*radius;
+    auto discriminant = half_b*half_b - a*c;
+
     if (discriminant > 0) {
-        auto temp = (-b - sqrt(b*b-a*c))/a;
+        auto root = sqrt(discriminant);
+        auto temp = (-half_b - root)/a;
         if (temp < t_max && temp > t_min) {
             rec.t = temp;
             rec.p = r.point_at_parameter(rec.t);
@@ -71,7 +73,7 @@ bool sphere::hit(const ray& r, double t_min, double t_max, hit_record& rec) cons
             rec.mat_ptr = mat_ptr;
             return true;
         }
-        temp = (-b + sqrt(b*b-a*c))/a;
+        temp = (-half_b + root)/a;
         if (temp < t_max && temp > t_min) {
             rec.t = temp;
             rec.p = r.point_at_parameter(rec.t);


### PR DESCRIPTION
This change updates both the books and the code.

The sphere intersection code used the fact that the b (in the quadratic
formula) had a factor of two in it. This yielded a simplification in the
formula that hinted at, but not explained. Further, the variable in the
new formula used the unfortunate name `b`, when it was really b/2.

This change adds a deriviation of the simplification, and changes the
code to use a more honest name, and also adds some very tiny efficiency
improvements.

Resolves #113