### PR TITLE
Rename bounding_box() output param to output_box

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -158,7 +158,7 @@ times need not match up with the camera aperture open and close.
             {};
             virtual bool hit(
                 const ray& r, double tmin, double tmax, hit_record& rec) const;
-            virtual bool bounding_box(double t0, double t1, aabb& box) const;
+            virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
             vec3 center(double time) const;
             vec3 center0, center1;
             double time0, time1;
@@ -585,7 +585,7 @@ frame and the bounding box will bound the object moving through that interval.
         public:
             virtual bool hit(
                 const ray& r, double t_min, double t_max, hit_record& rec) const = 0;
-            virtual bool bounding_box(double t0, double t1, aabb& box) const = 0;
+            virtual bool bounding_box(double t0, double t1, aabb& output_box) const = 0;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </div>
@@ -594,9 +594,10 @@ frame and the bounding box will bound the object moving through that interval.
 For a sphere, that `bounding_box` function is easy:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    bool sphere::bounding_box(double t0, double t1, aabb& box) const {
-        box = aabb(center - vec3(radius, radius, radius),
-                   center + vec3(radius, radius, radius));
+    bool sphere::bounding_box(double t0, double t1, aabb& output_box) const {
+        output_box = aabb(
+            center - vec3(radius, radius, radius),
+            center + vec3(radius, radius, radius));
         return true;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -607,12 +608,14 @@ For `moving sphere`, we can take the box of the sphere at $t_0$, and the box of 
 and compute the box of those two boxes:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    bool moving_sphere::bounding_box(double t0, double t1, aabb& box) const {
-        aabb box0(center(t0) - vec3(radius, radius, radius),
-                  center(t0) + vec3(radius, radius, radius));
-        aabb box1(center(t1) - vec3(radius, radius, radius),
-                  center(t1) + vec3(radius, radius, radius));
-        box = surrounding_box(box0, box1);
+    bool moving_sphere::bounding_box(double t0, double t1, aabb& output_box) const {
+        aabb box0(
+            center(t0) - vec3(radius, radius, radius),
+            center(t0) + vec3(radius, radius, radius));
+        aabb box1(
+            center(t1) - vec3(radius, radius, radius),
+            center(t1) + vec3(radius, radius, radius));
+        output_box = surrounding_box(box0, box1);
         return true;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -623,17 +626,17 @@ For lists you can store the bounding box at construction, or compute it on the f
 the fly because it is only usually called at BVH construction.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    bool hittable_list::bounding_box(double t0, double t1, aabb& box) const {
+    bool hittable_list::bounding_box(double t0, double t1, aabb& output_box) const {
         if (list_size < 1) return false;
         aabb temp_box;
         bool first_true = list[0]->bounding_box(t0, t1, temp_box);
         if (!first_true)
             return false;
         else
-            box = temp_box;
+            output_box = temp_box;
         for (int i = 1; i < list_size; i++) {
             if(list[i]->bounding_box(t0, t1, temp_box)) {
-                box = surrounding_box(box, temp_box);
+                output_box = surrounding_box(output_box, temp_box);
             }
             else
                 return false;
@@ -675,15 +678,15 @@ a class:
 
             virtual bool hit(
                 const ray& r, double tmin, double tmax, hit_record& rec) const;
-            virtual bool bounding_box(double t0, double t1, aabb& box) const;
+            virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
 
             hittable *left;
             hittable *right;
             aabb box;
     };
 
-    bool bvh_node::bounding_box(double t0, double t1, aabb& b) const {
-        b = box;
+    bool bvh_node::bounding_box(double t0, double t1, aabb& output_box) const {
+        output_box = box;
         return true;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1593,8 +1596,8 @@ The actual `xy_rect` class is thus:
                 : x0(_x0), x1(_x1), y0(_y0), y1(_y1), k(_k), mp(mat)
             {};
             virtual bool hit(const ray& r, double t0, double t1, hit_record& rec) const;
-            virtual bool bounding_box(double t0, double t1, aabb& box) const {
-                box =  aabb(vec3(x0,y0, k-0.0001), vec3(x1, y1, k+0.0001));
+            virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+                output_box =  aabb(vec3(x0,y0, k-0.0001), vec3(x1, y1, k+0.0001));
                 return true;
             }
             material *mp;
@@ -1674,8 +1677,8 @@ This is xz and yz:
                 : x0(_x0), x1(_x1), z0(_z0), z1(_z1), k(_k), mp(mat)
             {};
             virtual bool hit(const ray& r, double t0, double t1, hit_record& rec) const;
-            virtual bool bounding_box(double t0, double t1, aabb& box) const {
-                box =  aabb(vec3(x0,k-0.0001,z0), vec3(x1, k+0.0001, z1));
+            virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+                output_box =  aabb(vec3(x0,k-0.0001,z0), vec3(x1, k+0.0001, z1));
                 return true;
             }
             material *mp;
@@ -1690,8 +1693,8 @@ This is xz and yz:
                 : y0(_y0), y1(_y1), z0(_z0), z1(_z1), k(_k), mp(mat)
             {};
             virtual bool hit(const ray& r, double t0, double t1, hit_record& rec) const;
-            virtual bool bounding_box(double t0, double t1, aabb& box) const {
-                box =  aabb(vec3(k-0.0001, y0, z0), vec3(k+0.0001, y1, z1));
+            virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+                output_box =  aabb(vec3(k-0.0001, y0, z0), vec3(k+0.0001, y1, z1));
                 return true;
             }
             material  *mp;
@@ -1806,8 +1809,8 @@ another hittable, but reverses the normals:
                     return false;
             }
 
-            virtual bool bounding_box(double t0, double t1, aabb& box) const {
-                return ptr->bounding_box(t0, t1, box);
+            virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+                return ptr->bounding_box(t0, t1, output_box);
             }
 
             hittable *ptr;
@@ -1860,8 +1863,8 @@ make an axis-aligned block primitive that holds 6 rectangles:
             box() {}
             box(const vec3& p0, const vec3& p1, material *ptr);
             virtual bool hit(const ray& r, double t0, double t1, hit_record& rec) const;
-            virtual bool bounding_box(double t0, double t1, aabb& box) const {
-                box =  aabb(pmin, pmax);
+            virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+                output_box =  aabb(pmin, pmax);
                 return true;
             }
             vec3 pmin, pmax;
@@ -1930,7 +1933,7 @@ move any underlying hittable is a _translate_ instance.
                 : ptr(p), offset(displacement) {}
             virtual bool hit(
                 const ray& r, double t_min, double t_max, hit_record& rec) const;
-            virtual bool bounding_box(double t0, double t1, aabb& box) const;
+            virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
             hittable *ptr;
             vec3 offset;
     };
@@ -1945,9 +1948,9 @@ move any underlying hittable is a _translate_ instance.
             return false;
     }
 
-    bool translate::bounding_box(double t0, double t1, aabb& box) const {
-        if (ptr->bounding_box(t0, t1, box)) {
-            box = aabb(box.min() + offset, box.max() + offset);
+    bool translate::bounding_box(double t0, double t1, aabb& output_box) const {
+        if (ptr->bounding_box(t0, t1, output_box)) {
+            output_box = aabb(output_box.min() + offset, output_box.max() + offset);
             return true;
         }
         else
@@ -2006,8 +2009,9 @@ For a y-rotation class we have:
             rotate_y(hittable *p, double angle);
             virtual bool hit(
                 const ray& r, double t_min, double t_max, hit_record& rec) const;
-            virtual bool bounding_box(double t0, double t1, aabb& box) const {
-                box = bbox; return hasbox;
+            virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+                output_box = bbox;
+                return hasbox;
             }
             hittable *ptr;
             double sin_theta;
@@ -2145,8 +2149,8 @@ density $C$ and the boundary. I’ll use another hittable for the boundary. The 
             }
             virtual bool hit(
                 const ray& r, double t_min, double t_max, hit_record& rec) const;
-            virtual bool bounding_box(double t0, double t1, aabb& box) const {
-                return boundary->bounding_box(t0, t1, box);
+            virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+                return boundary->bounding_box(t0, t1, output_box);
             }
             hittable *boundary;
             double density;

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -1448,7 +1448,7 @@ class:
         public:
             virtual bool hit(const ray& r, double t_min, double t_max,
                 hit_record& rec) const = 0;
-            virtual bool bounding_box(double t0, double t1, aabb& box) const = 0;
+            virtual bool bounding_box(double t0, double t1, aabb& output_box) const = 0;
             virtual double pdf_value(const vec3& o, const vec3& v) const  {return 0.0;}
             virtual vec3 random(const vec3& o) const {return vec3(1, 0, 0);}
     };
@@ -1467,8 +1467,8 @@ And we change `xz_rect` to implement those functions:
                 : x0(_x0), x1(_x1), z0(_z0), z1(_z1), k(_k), mp(mat)
             {};
             virtual bool hit(const ray& r, double t0, double t1, hit_record& rec) const;
-            virtual bool bounding_box(double t0, double t1, aabb& box) const {
-                box =  aabb(vec3(x0,k-0.0001,z0), vec3(x1, k+0.0001, z1));
+            virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+                output_box = aabb(vec3(x0,k-0.0001,z0), vec3(x1, k+0.0001, z1));
                 return true;
             }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight

--- a/src/TheNextWeek/aarect.h
+++ b/src/TheNextWeek/aarect.h
@@ -20,8 +20,8 @@ class xy_rect: public hittable {
         xy_rect() {}
         xy_rect(double _x0, double _x1, double _y0, double _y1, double _k, material *mat) : x0(_x0), x1(_x1), y0(_y0), y1(_y1), k(_k), mp(mat) {};
         virtual bool hit(const ray& r, double t0, double t1, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const {
-               box =  aabb(vec3(x0,y0, k-0.0001), vec3(x1, y1, k+0.0001));
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+               output_box = aabb(vec3(x0,y0, k-0.0001), vec3(x1, y1, k+0.0001));
                return true; }
         material  *mp;
         double x0, x1, y0, y1, k;
@@ -32,8 +32,8 @@ class xz_rect: public hittable {
         xz_rect() {}
         xz_rect(double _x0, double _x1, double _z0, double _z1, double _k, material *mat) : x0(_x0), x1(_x1), z0(_z0), z1(_z1), k(_k), mp(mat) {};
         virtual bool hit(const ray& r, double t0, double t1, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const {
-               box =  aabb(vec3(x0,k-0.0001,z0), vec3(x1, k+0.0001, z1));
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+               output_box = aabb(vec3(x0,k-0.0001,z0), vec3(x1, k+0.0001, z1));
                return true; }
         material  *mp;
         double x0, x1, z0, z1, k;
@@ -44,8 +44,8 @@ class yz_rect: public hittable {
         yz_rect() {}
         yz_rect(double _y0, double _y1, double _z0, double _z1, double _k, material *mat) : y0(_y0), y1(_y1), z0(_z0), z1(_z1), k(_k), mp(mat) {};
         virtual bool hit(const ray& r, double t0, double t1, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const {
-               box =  aabb(vec3(k-0.0001, y0, z0), vec3(k+0.0001, y1, z1));
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+               output_box = aabb(vec3(k-0.0001, y0, z0), vec3(k+0.0001, y1, z1));
                return true; }
         material  *mp;
         double y0, y1, z0, z1, k;

--- a/src/TheNextWeek/box.h
+++ b/src/TheNextWeek/box.h
@@ -21,9 +21,10 @@ class box: public hittable  {
         box() {}
         box(const vec3& p0, const vec3& p1, material *ptr);
         virtual bool hit(const ray& r, double t0, double t1, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const {
-               box =  aabb(pmin, pmax);
-               return true; }
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+           output_box = aabb(pmin, pmax);
+           return true;
+        }
         vec3 pmin, pmax;
         hittable *list_ptr;
 };

--- a/src/TheNextWeek/bvh.h
+++ b/src/TheNextWeek/bvh.h
@@ -20,7 +20,7 @@ class bvh_node : public hittable  {
         bvh_node(hittable **l, int n, double time0, double time1);
 
         virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const;
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
 
         hittable *left;
         hittable *right;
@@ -28,8 +28,8 @@ class bvh_node : public hittable  {
 };
 
 
-bool bvh_node::bounding_box(double t0, double t1, aabb& b) const {
-    b = box;
+bool bvh_node::bounding_box(double t0, double t1, aabb& output_box) const {
+    output_box = box;
     return true;
 }
 
@@ -60,13 +60,14 @@ bool bvh_node::hit(const ray& r, double t_min, double t_max, hit_record& rec) co
     else return false;
 }
 
-
 int box_x_compare (const void * a, const void * b) {
         aabb box_left, box_right;
         hittable *ah = *(hittable**)a;
         hittable *bh = *(hittable**)b;
-        if(!ah->bounding_box(0,0, box_left) || !bh->bounding_box(0,0, box_right))
-                        std::cerr << "no bounding box in bvh_node constructor\n";
+
+        if (!ah->bounding_box(0,0, box_left) || !bh->bounding_box(0,0, box_right))
+            std::cerr << "no bounding box in bvh_node constructor\n";
+
         if ( box_left.min().x() - box_right.min().x() < 0.0  )
             return -1;
         else
@@ -78,26 +79,30 @@ int box_y_compare (const void * a, const void * b)
         aabb box_left, box_right;
         hittable *ah = *(hittable**)a;
         hittable *bh = *(hittable**)b;
-        if(!ah->bounding_box(0,0, box_left) || !bh->bounding_box(0,0, box_right))
+
+        if (!ah->bounding_box(0,0, box_left) || !bh->bounding_box(0,0, box_right))
                         std::cerr << "no bounding box in bvh_node constructor\n";
+
         if ( box_left.min().y() - box_right.min().y() < 0.0  )
             return -1;
         else
             return 1;
 }
+
 int box_z_compare (const void * a, const void * b)
 {
         aabb box_left, box_right;
         hittable *ah = *(hittable**)a;
         hittable *bh = *(hittable**)b;
-        if(!ah->bounding_box(0,0, box_left) || !bh->bounding_box(0,0, box_right))
-                        std::cerr << "no bounding box in bvh_node constructor\n";
+
+        if (!ah->bounding_box(0,0, box_left) || !bh->bounding_box(0,0, box_right))
+            std::cerr << "no bounding box in bvh_node constructor\n";
+
         if ( box_left.min().z() - box_right.min().z() < 0.0  )
             return -1;
         else
             return 1;
 }
-
 
 bvh_node::bvh_node(hittable **l, int n, double time0, double time1) {
     int axis = int(3*random_double());
@@ -119,7 +124,7 @@ bvh_node::bvh_node(hittable **l, int n, double time0, double time1) {
         right = new bvh_node(l + n/2, n - n/2, time0, time1);
     }
     aabb box_left, box_right;
-    if(!left->bounding_box(time0, time1, box_left) || !right->bounding_box(time0, time1, box_right))
+    if (!left->bounding_box(time0, time1, box_left) || !right->bounding_box(time0, time1, box_right))
         std::cerr << "no bounding box in bvh_node constructor\n";
     box = surrounding_box(box_left, box_right);
 }

--- a/src/TheNextWeek/constant_medium.h
+++ b/src/TheNextWeek/constant_medium.h
@@ -25,8 +25,8 @@ class constant_medium : public hittable  {
             phase_function = new isotropic(a);
         }
         virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const {
-            return boundary->bounding_box(t0, t1, box);
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+            return boundary->bounding_box(t0, t1, output_box);
         }
         hittable *boundary;
         double density;

--- a/src/TheNextWeek/hittable.h
+++ b/src/TheNextWeek/hittable.h
@@ -40,7 +40,7 @@ struct hit_record {
 class hittable {
     public:
         virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec) const = 0;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const = 0;
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const = 0;
 };
 
 class flip_normals : public hittable {
@@ -54,8 +54,8 @@ class flip_normals : public hittable {
             else
                 return false;
         }
-        virtual bool bounding_box(double t0, double t1, aabb& box) const {
-            return ptr->bounding_box(t0, t1, box);
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+            return ptr->bounding_box(t0, t1, output_box);
         }
         hittable *ptr;
 };
@@ -64,7 +64,7 @@ class translate : public hittable {
     public:
         translate(hittable *p, const vec3& displacement) : ptr(p), offset(displacement) {}
         virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const;
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
         hittable *ptr;
         vec3 offset;
 };
@@ -79,9 +79,11 @@ bool translate::hit(const ray& r, double t_min, double t_max, hit_record& rec) c
         return false;
 }
 
-bool translate::bounding_box(double t0, double t1, aabb& box) const {
-    if (ptr->bounding_box(t0, t1, box)) {
-        box = aabb(box.min() + offset, box.max()+offset);
+bool translate::bounding_box(double t0, double t1, aabb& output_box) const {
+    if (ptr->bounding_box(t0, t1, output_box)) {
+        output_box = aabb(
+            output_box.min() + offset,
+            output_box.max() + offset);
         return true;
     }
     else
@@ -92,8 +94,10 @@ class rotate_y : public hittable {
     public:
         rotate_y(hittable *p, double angle);
         virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const {
-            box = bbox; return hasbox;}
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+            output_box = bbox;
+            return hasbox;
+        }
         hittable *ptr;
         double sin_theta;
         double cos_theta;

--- a/src/TheNextWeek/hittable_list.h
+++ b/src/TheNextWeek/hittable_list.h
@@ -19,12 +19,12 @@ class hittable_list: public hittable  {
         hittable_list() {}
         hittable_list(hittable **l, int n) {list = l; list_size = n; }
         virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const;
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
         hittable **list;
         int list_size;
 };
 
-bool hittable_list::bounding_box(double t0, double t1, aabb& box) const {
+bool hittable_list::bounding_box(double t0, double t1, aabb& output_box) const {
     if (list_size < 1) return false;
 
     aabb temp_box;
@@ -33,11 +33,11 @@ bool hittable_list::bounding_box(double t0, double t1, aabb& box) const {
     if (!first_true)
         return false;
     else
-        box = temp_box;
+        output_box = temp_box;
 
     for (int i = 1; i < list_size; i++) {
         if (list[i]->bounding_box(t0, t1, temp_box))
-            box = surrounding_box(box, temp_box);
+            output_box = surrounding_box(output_box, temp_box);
         else
             return false;
     }

--- a/src/TheNextWeek/moving_sphere.h
+++ b/src/TheNextWeek/moving_sphere.h
@@ -23,7 +23,7 @@ class moving_sphere: public hittable  {
           : center0(cen0), center1(cen1), time0(t0), time1(t1), radius(r), mat_ptr(m)
         {};
         virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const;
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
         vec3 center(double time) const;
         vec3 center0, center1;
         double time0, time1;
@@ -36,11 +36,11 @@ vec3 moving_sphere::center(double time) const{
 }
 
 
-bool moving_sphere::bounding_box(double t0, double t1, aabb& box) const {
-        aabb box0(center(t0) - vec3(radius, radius, radius), center(t0) + vec3(radius, radius, radius));
-        aabb box1(center(t1) - vec3(radius, radius, radius), center(t1) + vec3(radius, radius, radius));
-        box = surrounding_box(box0, box1);
-        return true;
+bool moving_sphere::bounding_box(double t0, double t1, aabb& output_box) const {
+    aabb box0(center(t0) - vec3(radius, radius, radius), center(t0) + vec3(radius, radius, radius));
+    aabb box1(center(t1) - vec3(radius, radius, radius), center(t1) + vec3(radius, radius, radius));
+    output_box = surrounding_box(box0, box1);
+    return true;
 }
 
 

--- a/src/TheNextWeek/sphere.h
+++ b/src/TheNextWeek/sphere.h
@@ -20,15 +20,17 @@ class sphere: public hittable  {
         sphere() {}
         sphere(vec3 cen, double r, material *m) : center(cen), radius(r), mat_ptr(m)  {};
         virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const;
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
         vec3 center;
         double radius;
         material *mat_ptr;
 };
 
 
-bool sphere::bounding_box(double t0, double t1, aabb& box) const {
-    box = aabb(center - vec3(radius, radius, radius), center + vec3(radius, radius, radius));
+bool sphere::bounding_box(double t0, double t1, aabb& output_box) const {
+    output_box = aabb(
+        center - vec3(radius, radius, radius),
+        center + vec3(radius, radius, radius));
     return true;
 }
 

--- a/src/TheRestOfYourLife/aarect.h
+++ b/src/TheRestOfYourLife/aarect.h
@@ -22,12 +22,14 @@ class xy_rect: public hittable  {
             : x0(_x0), x1(_x1), y0(_y0), y1(_y1), k(_k), mp(mat)
         {};
         virtual bool hit(const ray& r, double t0, double t1, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const {
-               box =  aabb(vec3(x0,y0, k-0.0001), vec3(x1, y1, k+0.0001));
-               return true; }
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+            output_box =  aabb(vec3(x0,y0, k-0.0001), vec3(x1, y1, k+0.0001));
+            return true;
+        }
         material  *mp;
         double x0, x1, y0, y1, k;
 };
+
 
 class xz_rect: public hittable  {
     public:
@@ -36,8 +38,8 @@ class xz_rect: public hittable  {
             : x0(_x0), x1(_x1), z0(_z0), z1(_z1), k(_k), mp(mat)
         {};
         virtual bool hit(const ray& r, double t0, double t1, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const {
-            box =  aabb(vec3(x0,k-0.0001,z0), vec3(x1, k+0.0001, z1));
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+            output_box =  aabb(vec3(x0,k-0.0001,z0), vec3(x1, k+0.0001, z1));
             return true;
         }
         virtual double  pdf_value(const vec3& o, const vec3& v) const {
@@ -59,6 +61,7 @@ class xz_rect: public hittable  {
         double x0, x1, z0, z1, k;
 };
 
+
 class yz_rect: public hittable  {
     public:
         yz_rect() {}
@@ -66,15 +69,12 @@ class yz_rect: public hittable  {
             : y0(_y0), y1(_y1), z0(_z0), z1(_z1), k(_k), mp(mat)
         {};
         virtual bool hit(const ray& r, double t0, double t1, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const {
-               box =  aabb(vec3(k-0.0001, y0, z0), vec3(k+0.0001, y1, z1));
-               return true; }
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+            output_box =  aabb(vec3(k-0.0001, y0, z0), vec3(k+0.0001, y1, z1));
+            return true; }
         material  *mp;
         double y0, y1, z0, z1, k;
 };
-
-
-
 
 bool xy_rect::hit(const ray& r, double t0, double t1, hit_record& rec) const {
     auto t = (k-r.origin().z()) / r.direction().z();
@@ -92,7 +92,6 @@ bool xy_rect::hit(const ray& r, double t0, double t1, hit_record& rec) const {
     rec.normal = vec3(0, 0, 1);
     return true;
 }
-
 
 bool xz_rect::hit(const ray& r, double t0, double t1, hit_record& rec) const {
     auto t = (k-r.origin().y()) / r.direction().y();

--- a/src/TheRestOfYourLife/box.h
+++ b/src/TheRestOfYourLife/box.h
@@ -21,9 +21,10 @@ class box: public hittable  {
         box() {}
         box(const vec3& p0, const vec3& p1, material *ptr);
         virtual bool hit(const ray& r, double t0, double t1, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const {
-               box =  aabb(pmin, pmax);
-               return true; }
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+            output_box =  aabb(pmin, pmax);
+            return true;
+        }
         vec3 pmin, pmax;
         hittable *list_ptr;
 };

--- a/src/TheRestOfYourLife/bvh.h
+++ b/src/TheRestOfYourLife/bvh.h
@@ -20,15 +20,15 @@ class bvh_node : public hittable  {
         bvh_node() {}
         bvh_node(hittable **l, int n, double time0, double time1);
         virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const;
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
         hittable *left;
         hittable *right;
         aabb box;
 };
 
 
-bool bvh_node::bounding_box(double t0, double t1, aabb& b) const {
-    b = box;
+bool bvh_node::bounding_box(double t0, double t1, aabb& output_box) const {
+    output_box = box;
     return true;
 }
 
@@ -58,7 +58,6 @@ bool bvh_node::hit(const ray& r, double t_min, double t_max, hit_record& rec) co
     else return false;
 }
 
-
 int box_x_compare (const void * a, const void * b) {
     aabb box_left, box_right;
     hittable *ah = *(hittable**)a;
@@ -83,6 +82,7 @@ int box_y_compare (const void * a, const void * b)
     else
         return 1;
 }
+
 int box_z_compare (const void * a, const void * b)
 {
     aabb box_left, box_right;
@@ -102,10 +102,10 @@ bvh_node::bvh_node(hittable **l, int n, double time0, double time1) {
     auto *left_area = new double[n];
     auto *right_area = new double[n];
     aabb main_box;
-    bool dummy = l[0]->bounding_box(time0,time1,main_box);
+    bool dummy = l[0]->bounding_box(time0, time1, main_box);
     for (int i = 1; i < n; i++) {
         aabb new_box;
-        bool dummy = l[i]->bounding_box(time0,time1,new_box);
+        bool dummy = l[i]->bounding_box(time0, time1, new_box);
         main_box = surrounding_box(new_box, main_box);
     }
     int axis = main_box.longest_axis();
@@ -116,7 +116,7 @@ bvh_node::bvh_node(hittable **l, int n, double time0, double time1) {
     else
         qsort(l, n, sizeof(hittable *), box_z_compare);
     for (int i = 0; i < n; i++)
-        bool dummy = l[i]->bounding_box(time0,time1,boxes[i]);
+        bool dummy = l[i]->bounding_box(time0, time1, boxes[i]);
     left_area[0] = boxes[0].area();
     aabb left_box = boxes[0];
     for (int i = 1; i < n-1; i++) {

--- a/src/TheRestOfYourLife/constant_medium.h
+++ b/src/TheRestOfYourLife/constant_medium.h
@@ -25,8 +25,8 @@ class constant_medium : public hittable  {
             phase_function = new isotropic(a);
         }
         virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const {
-            return boundary->bounding_box(t0, t1, box);
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+            return boundary->bounding_box(t0, t1, output_box);
         }
         hittable *boundary;
         double density;

--- a/src/TheRestOfYourLife/hittable.h
+++ b/src/TheRestOfYourLife/hittable.h
@@ -41,7 +41,7 @@ struct hit_record
 class hittable  {
     public:
         virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec) const = 0;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const = 0;
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const = 0;
         virtual double pdf_value(const vec3& o, const vec3& v) const  {return 0.0;}
         virtual vec3 random(const vec3& o) const {return vec3(1, 0, 0);}
 };
@@ -57,8 +57,8 @@ class flip_normals : public hittable {
             else
                 return false;
         }
-        virtual bool bounding_box(double t0, double t1, aabb& box) const {
-            return ptr->bounding_box(t0, t1, box);
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+            return ptr->bounding_box(t0, t1, output_box);
         }
         hittable *ptr;
 };
@@ -67,7 +67,7 @@ class translate : public hittable {
     public:
         translate(hittable *p, const vec3& displacement) : ptr(p), offset(displacement) {}
         virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const;
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
         hittable *ptr;
         vec3 offset;
 };
@@ -82,9 +82,11 @@ bool translate::hit(const ray& r, double t_min, double t_max, hit_record& rec) c
         return false;
 }
 
-bool translate::bounding_box(double t0, double t1, aabb& box) const {
-    if (ptr->bounding_box(t0, t1, box)) {
-        box = aabb(box.min() + offset, box.max()+offset);
+bool translate::bounding_box(double t0, double t1, aabb& output_box) const {
+    if (ptr->bounding_box(t0, t1, output_box)) {
+        output_box = aabb(
+            output_box.min() + offset,
+            output_box.max() + offset);
         return true;
     }
     else
@@ -95,8 +97,10 @@ class rotate_y : public hittable {
     public:
         rotate_y(hittable *p, double angle);
         virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const {
-            box = bbox; return hasbox;}
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
+            output_box = bbox;
+            return hasbox;
+        }
         hittable *ptr;
         double sin_theta;
         double cos_theta;

--- a/src/TheRestOfYourLife/hittable_list.h
+++ b/src/TheRestOfYourLife/hittable_list.h
@@ -20,7 +20,7 @@ class hittable_list: public hittable  {
         hittable_list() {}
         hittable_list(hittable **l, int n) {list = l; list_size = n; }
         virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const;
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
         virtual double pdf_value(const vec3& o, const vec3& v) const;
         virtual vec3 random(const vec3& o) const;
 
@@ -42,17 +42,17 @@ vec3 hittable_list::random(const vec3& o) const {
 }
 
 
-bool hittable_list::bounding_box(double t0, double t1, aabb& box) const {
+bool hittable_list::bounding_box(double t0, double t1, aabb& output_box) const {
     if (list_size < 1) return false;
     aabb temp_box;
     bool first_true = list[0]->bounding_box(t0, t1, temp_box);
     if (!first_true)
         return false;
     else
-        box = temp_box;
+        output_box = temp_box;
     for (int i = 1; i < list_size; i++) {
         if(list[0]->bounding_box(t0, t1, temp_box)) {
-            box = surrounding_box(box, temp_box);
+            output_box = surrounding_box(output_box, temp_box);
         }
         else
             return false;

--- a/src/TheRestOfYourLife/moving_sphere.h
+++ b/src/TheRestOfYourLife/moving_sphere.h
@@ -18,9 +18,11 @@
 class moving_sphere: public hittable  {
     public:
         moving_sphere() {}
-        moving_sphere(vec3 cen0, vec3 cen1, double t0, double t1, double r, material *m) : center0(cen0), center1(cen1), time0(t0),time1(t1), radius(r), mat_ptr(m)  {};
+        moving_sphere(vec3 cen0, vec3 cen1, double t0, double t1, double r, material *m)
+            : center0(cen0), center1(cen1), time0(t0),time1(t1), radius(r), mat_ptr(m)
+        {};
         virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const;
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
         vec3 center(double time) const;
         vec3 center0, center1;
         double time0, time1;
@@ -32,14 +34,16 @@ vec3 moving_sphere::center(double time) const{
     return center0 + ((time - time0) / (time1 - time0))*(center1 - center0);
 }
 
-
-bool moving_sphere::bounding_box(double t0, double t1, aabb& box) const {
-        aabb box0(center(t0) - vec3(radius, radius, radius), center(t0) + vec3(radius, radius, radius));
-        aabb box1(center(t1) - vec3(radius, radius, radius), center(t1) + vec3(radius, radius, radius));
-        box = surrounding_box(box0, box1);
-        return true;
+bool moving_sphere::bounding_box(double t0, double t1, aabb& output_box) const {
+    aabb box0(
+        center(t0) - vec3(radius, radius, radius),
+        center(t0) + vec3(radius, radius, radius));
+    aabb box1(
+        center(t1) - vec3(radius, radius, radius),
+        center(t1) + vec3(radius, radius, radius));
+    output_box = surrounding_box(box0, box1);
+    return true;
 }
-
 
 
 // replace "center" with "center(r.time())"

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -23,7 +23,7 @@ class sphere: public hittable  {
         sphere() {}
         sphere(vec3 cen, double r, material *m) : center(cen), radius(r), mat_ptr(m)  {};
         virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
-        virtual bool bounding_box(double t0, double t1, aabb& box) const;
+        virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
         virtual double  pdf_value(const vec3& o, const vec3& v) const;
         virtual vec3 random(const vec3& o) const;
         vec3 center;
@@ -51,8 +51,10 @@ vec3 sphere::random(const vec3& o) const {
 }
 
 
-bool sphere::bounding_box(double t0, double t1, aabb& box) const {
-    box = aabb(center - vec3(radius, radius, radius), center + vec3(radius, radius, radius));
+bool sphere::bounding_box(double t0, double t1, aabb& output_box) const {
+    output_box = aabb(
+        center - vec3(radius, radius, radius),
+        center + vec3(radius, radius, radius));
     return true;
 }
 


### PR DESCRIPTION
The original name was confusing versus the member variable, and also
obscured the fact that it was an out variable. Along the way, I also
fixed formatting.

Resolves #95