### PR TITLE
Clean up C++ std headers

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -161,7 +161,7 @@ Here’s the top part of my `vec3` class:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #include <iostream>
-    #include <math.h>
+    #include <cmath>
 
     class vec3 {
         public:
@@ -761,6 +761,7 @@ file.
     #define RTWEEKEND_H
 
     #include <limits>
+    #include <cmath>
 
     // Constants
 
@@ -793,13 +794,10 @@ And the new main:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #include "common/rtweekend.h"
-    #include "float.h"
     #include "hittable_list.h"
     #include "sphere.h"
 
     #include <iostream>
-    #include <limits>
-
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
     vec3 ray_color(const ray& r, hittable *world) {

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -1308,7 +1308,7 @@ turbulence and is a sum of repeated calls to noise:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </div>
 
-Here `fabs()` is the `math.h` absolute value function.
+Here `fabs()` is the absolute value function defined in `<cmath>`.
 
 <div class='together'>
 Used directly, turbulence gives a sort of camouflage netting appearance:
@@ -1388,7 +1388,7 @@ unit radius sphere on the origin is:
 </div>
 
 <div class='together'>
-We need to invert that. Because of the lovely `math.h` function `atan2()` which takes any number
+We need to invert that. Because of the lovely `<cmath>` function `atan2()` which takes any number
 proportional to sine and cosine and returns the angle, we can pass in $x$ and $y$ (the
 $\cos(\theta)$ cancel):
 

--- a/src/InOneWeekend/main.cc
+++ b/src/InOneWeekend/main.cc
@@ -15,9 +15,7 @@
 #include "material.h"
 #include "sphere.h"
 
-#include <float.h>
 #include <iostream>
-#include <limits>
 
 
 vec3 ray_color(const ray& r, hittable *world, int depth) {

--- a/src/TheNextWeek/constant_medium.h
+++ b/src/TheNextWeek/constant_medium.h
@@ -16,8 +16,6 @@
 #include "material.h"
 #include "texture.h"
 
-#include <float.h>
-
 
 class constant_medium : public hittable  {
     public:

--- a/src/TheNextWeek/hittable.h
+++ b/src/TheNextWeek/hittable.h
@@ -12,10 +12,7 @@
 //==================================================================================================
 
 #include "common/rtweekend.h"
-#include "common/vec3.h"
 #include "aabb.h"
-
-#include <float.h>
 
 
 class material;

--- a/src/TheNextWeek/main.cc
+++ b/src/TheNextWeek/main.cc
@@ -23,9 +23,7 @@
 #include "surface_texture.h"
 #include "texture.h"
 
-#include <float.h>
 #include <iostream>
-#include <limits>
 
 
 vec3 ray_color(const ray& r, hittable *world, int depth) {

--- a/src/TheRestOfYourLife/constant_medium.h
+++ b/src/TheRestOfYourLife/constant_medium.h
@@ -16,8 +16,6 @@
 #include "material.h"
 #include "texture.h"
 
-#include <float.h>
-
 
 class constant_medium : public hittable  {
     public:

--- a/src/TheRestOfYourLife/hittable.h
+++ b/src/TheRestOfYourLife/hittable.h
@@ -15,8 +15,6 @@
 #include "common/vec3.h"
 #include "aabb.h"
 
-#include <float.h>
-
 
 class material;
 

--- a/src/TheRestOfYourLife/main.cc
+++ b/src/TheRestOfYourLife/main.cc
@@ -23,9 +23,7 @@
 #include "surface_texture.h"
 #include "texture.h"
 
-#include <float.h>
 #include <iostream>
-#include <limits>
 
 
 vec3 ray_color(const ray& r, hittable *world, hittable *light_shape, int depth) {

--- a/src/common/rtweekend.h
+++ b/src/common/rtweekend.h
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include <limits>
+#include <cmath>
 
 
 // Constants

--- a/src/common/vec3.h
+++ b/src/common/vec3.h
@@ -14,7 +14,6 @@
 #include "common/rtweekend.h"
 
 #include <iostream>
-#include <math.h>
 
 
 class vec3 {


### PR DESCRIPTION
- Got rid of float.h includes. Don't need these, since we're using
  infinity instead of FLT_MAX, defined in <limits>.
- <limits> included once in rtweekend.h.
- Include <cmath> once in rtweekend.h, vec3.h. Eliminates "math.h"
  everywhere else.

Resolves #19