### PR TITLE
Mem alloc simple

### DIFF
--- a/src/InOneWeekend/hittable.h
+++ b/src/InOneWeekend/hittable.h
@@ -26,15 +26,7 @@ struct hit_record {
 
 class hittable {
     public:
-        hittable(material *m) : mat_ptr(m) {};
-        ~hittable() {
-            delete mat_ptr;
-        }
-
         virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec) const = 0;
-
-    protected:
-        material *mat_ptr;
 };
 
 #endif

--- a/src/InOneWeekend/hittable.h
+++ b/src/InOneWeekend/hittable.h
@@ -14,15 +14,15 @@
 #include "common/rtweekend.h"
 #include "ray.h"
 
-
 class material;
 
 struct hit_record {
     double t;
     vec3 p;
     vec3 normal;
-    material *mat_ptr;
+    material *mat;
 };
+
 
 class hittable {
     public:

--- a/src/InOneWeekend/hittable_list.h
+++ b/src/InOneWeekend/hittable_list.h
@@ -13,22 +13,40 @@
 
 #include "hittable.h"
 
+#include <vector>
+
 
 class hittable_list: public hittable  {
     public:
         hittable_list() {}
-        hittable_list(hittable **l, int n) { list = l; list_size = n; }
-        virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
-        hittable **list;
-        int list_size;
+        ~hittable_list();
+        virtual bool hit(
+            const ray& r, double tmin, double tmax, hit_record& rec) const;
+
+        void add(hittable*);
+
+        std::vector<hittable*> objects;
 };
 
-bool hittable_list::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
+hittable_list::~hittable_list() {
+    for (auto objectPtr : objects) {
+        delete objectPtr;
+    }
+}
+
+void hittable_list::add(hittable* objectPtr) {
+    objects.push_back(objectPtr);
+}
+
+bool hittable_list::hit(
+    const ray& r, double t_min, double t_max, hit_record& rec
+) const {
     hit_record temp_rec;
     bool hit_anything = false;
     double closest_so_far = t_max;
-    for (int i = 0; i < list_size; i++) {
-        if (list[i]->hit(r, t_min, closest_so_far, temp_rec)) {
+
+    for (auto objectPtr : objects) {
+        if (objectPtr->hit(r, t_min, closest_so_far, temp_rec)) {
             hit_anything = true;
             closest_so_far = temp_rec.t;
             rec = temp_rec;

--- a/src/InOneWeekend/hittable_list.h
+++ b/src/InOneWeekend/hittable_list.h
@@ -29,13 +29,13 @@ class hittable_list: public hittable  {
 };
 
 hittable_list::~hittable_list() {
-    for (auto objectPtr : objects) {
-        delete objectPtr;
+    for (auto object_ptr : objects) {
+        delete object_ptr;
     }
 }
 
-void hittable_list::add(hittable* objectPtr) {
-    objects.push_back(objectPtr);
+void hittable_list::add(hittable* object_ptr) {
+    objects.push_back(object_ptr);
 }
 
 bool hittable_list::hit(
@@ -45,8 +45,8 @@ bool hittable_list::hit(
     bool hit_anything = false;
     double closest_so_far = t_max;
 
-    for (auto objectPtr : objects) {
-        if (objectPtr->hit(r, t_min, closest_so_far, temp_rec)) {
+    for (auto object_ptr : objects) {
+        if (object_ptr->hit(r, t_min, closest_so_far, temp_rec)) {
             hit_anything = true;
             closest_so_far = temp_rec.t;
             rec = temp_rec;

--- a/src/InOneWeekend/main.cc
+++ b/src/InOneWeekend/main.cc
@@ -38,43 +38,47 @@ vec3 ray_color(const ray& r, hittable *world, int depth) {
 
 hittable *random_scene() {
     int n = 500;
-    hittable **list = new hittable*[n+1];
-    list[0] = new sphere(vec3(0,-1000,0), 1000, new lambertian(vec3(0.5, 0.5, 0.5)));
-    int i = 1;
+    hittable_list *scene = new hittable_list();
+
+    scene->add(
+        new sphere(vec3(0,-1000,0), 1000, new lambertian(vec3(0.5, 0.5, 0.5))));
+
     for (int a = -11; a < 11; a++) {
         for (int b = -11; b < 11; b++) {
             auto choose_mat = random_double();
             vec3 center(a+0.9*random_double(),0.2,b+0.9*random_double());
             if ((center-vec3(4,0.2,0)).length() > 0.9) {
                 if (choose_mat < 0.8) {  // diffuse
-                    list[i++] = new sphere(
+                    scene->add(new sphere(
                         center, 0.2,
                         new lambertian(vec3(random_double()*random_double(),
                                             random_double()*random_double(),
                                             random_double()*random_double()))
-                    );
+                    ));
                 }
                 else if (choose_mat < 0.95) { // metal
-                    list[i++] = new sphere(
+                    scene->add(new sphere(
                         center, 0.2,
                         new metal(vec3(0.5*(1 + random_double()),
                                        0.5*(1 + random_double()),
                                        0.5*(1 + random_double())),
                                   0.5*random_double())
-                    );
+                    ));
                 }
                 else {  // glass
-                    list[i++] = new sphere(center, 0.2, new dielectric(1.5));
+                    scene->add(new sphere(center, 0.2, new dielectric(1.5)));
                 }
             }
         }
     }
 
-    list[i++] = new sphere(vec3(0, 1, 0), 1.0, new dielectric(1.5));
-    list[i++] = new sphere(vec3(-4, 1, 0), 1.0, new lambertian(vec3(0.4, 0.2, 0.1)));
-    list[i++] = new sphere(vec3(4, 1, 0), 1.0, new metal(vec3(0.7, 0.6, 0.5), 0.0));
+    scene->add(new sphere(vec3(0, 1, 0), 1.0, new dielectric(1.5)));
+    scene->add(new sphere(
+        vec3(-4, 1, 0), 1.0, new lambertian(vec3(0.4, 0.2, 0.1))));
+    scene->add(new sphere(
+        vec3(4, 1, 0), 1.0, new metal(vec3(0.7, 0.6, 0.5), 0.0)));
 
-    return new hittable_list(list,i);
+    return scene;
 }
 
 

--- a/src/InOneWeekend/main.cc
+++ b/src/InOneWeekend/main.cc
@@ -18,14 +18,14 @@
 #include <iostream>
 
 
-vec3 ray_color(const ray& r, hittable &world, int depth) {
+vec3 ray_color(const ray& r, hittable_list &world, int depth) {
     hit_record rec;
     if (world.hit(r, 0.001, infinity, rec)) {
         if (depth <= 0)
             return vec3(0,0,0);
         ray scattered;
         vec3 attenuation;
-        if (rec.mat_ptr->scatter(r, rec, attenuation, scattered))
+        if (rec.mat->scatter(r, rec, attenuation, scattered))
             return attenuation * ray_color(scattered, world, depth-1);
         return vec3(0,0,0);
     }
@@ -39,8 +39,7 @@ vec3 ray_color(const ray& r, hittable &world, int depth) {
 void create_random_scene(hittable_list &scene) {
     int n = 500;
 
-    scene.add(
-        new sphere(vec3(0,-1000,0), 1000, new lambertian(vec3(0.5, 0.5, 0.5))));
+    scene.add(new sphere(vec3(0,-1000,0), 1000), new lambertian(vec3(0.5, 0.5, 0.5)));
 
     for (int a = -11; a < 11; a++) {
         for (int b = -11; b < 11; b++) {
@@ -65,14 +64,14 @@ void create_random_scene(hittable_list &scene) {
                 else {  // glass
                     mat = new dielectric(1.5);
                 }
-                scene.add(new sphere(center, radius, mat));
+                scene.add(new sphere(center, radius), mat);
             }
         }
     }
 
-    scene.add(new sphere(vec3( 0, 1, 0), 1.0, new dielectric(1.5)));
-    scene.add(new sphere(vec3(-4, 1, 0), 1.0, new lambertian(vec3(0.4, 0.2, 0.1))));
-    scene.add(new sphere(vec3( 4, 1, 0), 1.0, new metal(vec3(0.7, 0.6, 0.5), 0.0)));
+    scene.add(new sphere(vec3( 0, 1, 0), 1.0), new dielectric(1.5));
+    scene.add(new sphere(vec3(-4, 1, 0), 1.0), new lambertian(vec3(0.4, 0.2, 0.1)));
+    scene.add(new sphere(vec3( 4, 1, 0), 1.0), new metal(vec3(0.7, 0.6, 0.5), 0.0));
 }
 
 

--- a/src/InOneWeekend/sphere.h
+++ b/src/InOneWeekend/sphere.h
@@ -18,16 +18,12 @@
 class sphere: public hittable  {
     public:
         sphere() {}
-        sphere(vec3 cen, double r, material *m) : center(cen), radius(r), mat_ptr(m) {};
-        ~sphere() {
-            delete mat_ptr;
-        }
+        sphere(vec3 cen, double r) : center(cen), radius(r) {};
 
         virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
 
         vec3 center;
         double radius;
-        material *mat_ptr;
 };
 
 
@@ -45,7 +41,6 @@ bool sphere::hit(const ray& r, double t_min, double t_max, hit_record& rec) cons
             rec.t = temp;
             rec.p = r.point_at_parameter(rec.t);
             rec.normal = (rec.p - center) / radius;
-            rec.mat_ptr = mat_ptr;
             return true;
         }
         temp = (-half_b + root) / a;
@@ -53,7 +48,6 @@ bool sphere::hit(const ray& r, double t_min, double t_max, hit_record& rec) cons
             rec.t = temp;
             rec.p = r.point_at_parameter(rec.t);
             rec.normal = (rec.p - center) / radius;
-            rec.mat_ptr = mat_ptr;
             return true;
         }
     }

--- a/src/InOneWeekend/sphere.h
+++ b/src/InOneWeekend/sphere.h
@@ -18,8 +18,13 @@
 class sphere: public hittable  {
     public:
         sphere() {}
-        sphere(vec3 cen, double r, material *m) : center(cen), radius(r), mat_ptr(m)  {};
+        sphere(vec3 cen, double r, material *m) : center(cen), radius(r), mat_ptr(m) {};
+        ~sphere() {
+            delete mat_ptr;
+        }
+
         virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
+
         vec3 center;
         double radius;
         material *mat_ptr;


### PR DESCRIPTION
*DRAFT*
This is a sketch of revised memory management, using simple `new`/`delete` operators, and a scheme where objects and materials have a single clear owner that frees memory on destruction.

If a single material instance is used for more than one `hittable`, it will end up in a double-free on destruction. If we went with this approach, we would need to note this limitation in the text. We _could_ deploy additional machinery to guard against sharing (like doing our own ref counting), but that's going way off track, I think, particularly in the face of better mechanisms like `std::shared_ptr`.