### PR TITLE
Mem alloc shared

### DIFF
--- a/src/InOneWeekend/hittable.h
+++ b/src/InOneWeekend/hittable.h
@@ -16,17 +16,22 @@
 
 
 class material;
+class hittable;
+
+using material_ptr = std::shared_ptr<material>;
+using object_ptr = std::shared_ptr<hittable>;
 
 struct hit_record {
     double t;
     vec3 p;
     vec3 normal;
-    material *mat_ptr;
+    material_ptr mat_ptr;
 };
 
 class hittable {
     public:
         virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec) const = 0;
 };
+
 
 #endif

--- a/src/InOneWeekend/hittable_list.h
+++ b/src/InOneWeekend/hittable_list.h
@@ -13,22 +13,40 @@
 
 #include "hittable.h"
 
+#include <vector>
+
 
 class hittable_list: public hittable  {
     public:
         hittable_list() {}
-        hittable_list(hittable **l, int n) { list = l; list_size = n; }
-        virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
-        hittable **list;
-        int list_size;
+        ~hittable_list();
+        virtual bool hit(
+            const ray& r, double tmin, double tmax, hit_record& rec) const;
+
+        void add(hittable*);
+
+        std::vector<hittable*> objects;
 };
 
-bool hittable_list::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
+hittable_list::~hittable_list() {
+    for (auto objectPtr : objects) {
+        delete objectPtr;
+    }
+}
+
+void hittable_list::add(hittable* objectPtr) {
+    objects.push_back(objectPtr);
+}
+
+bool hittable_list::hit(
+    const ray& r, double t_min, double t_max, hit_record& rec
+) const {
     hit_record temp_rec;
     bool hit_anything = false;
     double closest_so_far = t_max;
-    for (int i = 0; i < list_size; i++) {
-        if (list[i]->hit(r, t_min, closest_so_far, temp_rec)) {
+
+    for (auto objectPtr : objects) {
+        if (objectPtr->hit(r, t_min, closest_so_far, temp_rec)) {
             hit_anything = true;
             closest_so_far = temp_rec.t;
             rec = temp_rec;

--- a/src/InOneWeekend/hittable_list.h
+++ b/src/InOneWeekend/hittable_list.h
@@ -19,23 +19,17 @@
 class hittable_list: public hittable  {
     public:
         hittable_list() {}
-        ~hittable_list();
+
         virtual bool hit(
             const ray& r, double tmin, double tmax, hit_record& rec) const;
 
-        void add(hittable*);
+        void add(object_ptr);
 
-        std::vector<hittable*> objects;
+        std::vector<object_ptr> objects;
 };
 
-hittable_list::~hittable_list() {
-    for (auto objectPtr : objects) {
-        delete objectPtr;
-    }
-}
-
-void hittable_list::add(hittable* objectPtr) {
-    objects.push_back(objectPtr);
+void hittable_list::add(object_ptr object) {
+    objects.push_back(object);
 }
 
 bool hittable_list::hit(

--- a/src/InOneWeekend/main.cc
+++ b/src/InOneWeekend/main.cc
@@ -38,43 +38,47 @@ vec3 ray_color(const ray& r, hittable *world, int depth) {
 
 hittable *random_scene() {
     int n = 500;
-    hittable **list = new hittable*[n+1];
-    list[0] = new sphere(vec3(0,-1000,0), 1000, new lambertian(vec3(0.5, 0.5, 0.5)));
-    int i = 1;
+    hittable_list *scene = new hittable_list();
+
+    scene->add(
+        new sphere(vec3(0,-1000,0), 1000, new lambertian(vec3(0.5, 0.5, 0.5))));
+
     for (int a = -11; a < 11; a++) {
         for (int b = -11; b < 11; b++) {
             auto choose_mat = random_double();
             vec3 center(a+0.9*random_double(),0.2,b+0.9*random_double());
             if ((center-vec3(4,0.2,0)).length() > 0.9) {
                 if (choose_mat < 0.8) {  // diffuse
-                    list[i++] = new sphere(
+                    scene->add(new sphere(
                         center, 0.2,
                         new lambertian(vec3(random_double()*random_double(),
                                             random_double()*random_double(),
                                             random_double()*random_double()))
-                    );
+                    ));
                 }
                 else if (choose_mat < 0.95) { // metal
-                    list[i++] = new sphere(
+                    scene->add(new sphere(
                         center, 0.2,
                         new metal(vec3(0.5*(1 + random_double()),
                                        0.5*(1 + random_double()),
                                        0.5*(1 + random_double())),
                                   0.5*random_double())
-                    );
+                    ));
                 }
                 else {  // glass
-                    list[i++] = new sphere(center, 0.2, new dielectric(1.5));
+                    scene->add(new sphere(center, 0.2, new dielectric(1.5)));
                 }
             }
         }
     }
 
-    list[i++] = new sphere(vec3(0, 1, 0), 1.0, new dielectric(1.5));
-    list[i++] = new sphere(vec3(-4, 1, 0), 1.0, new lambertian(vec3(0.4, 0.2, 0.1)));
-    list[i++] = new sphere(vec3(4, 1, 0), 1.0, new metal(vec3(0.7, 0.6, 0.5), 0.0));
+    scene->add(new sphere(vec3(0, 1, 0), 1.0, new dielectric(1.5)));
+    scene->add(new sphere(
+        vec3(-4, 1, 0), 1.0, new lambertian(vec3(0.4, 0.2, 0.1))));
+    scene->add(new sphere(
+        vec3(4, 1, 0), 1.0, new metal(vec3(0.7, 0.6, 0.5), 0.0)));
 
-    return new hittable_list(list,i);
+    return scene;
 }
 
 

--- a/src/InOneWeekend/material.h
+++ b/src/InOneWeekend/material.h
@@ -72,6 +72,7 @@ class material  {
 class lambertian : public material {
     public:
         lambertian(const vec3& a) : albedo(a) {}
+
         virtual bool scatter(
             const ray& r_in, const hit_record& rec, vec3& attenuation, ray& scattered
         ) const  {
@@ -88,6 +89,7 @@ class lambertian : public material {
 class metal : public material {
     public:
         metal(const vec3& a, double f) : albedo(a) { if (f < 1) fuzz = f; else fuzz = 1; }
+
         virtual bool scatter(
             const ray& r_in, const hit_record& rec, vec3& attenuation, ray& scattered
         ) const  {
@@ -96,6 +98,7 @@ class metal : public material {
             attenuation = albedo;
             return (dot(scattered.direction(), rec.normal) > 0);
         }
+
         vec3 albedo;
         double fuzz;
 };
@@ -104,6 +107,7 @@ class metal : public material {
 class dielectric : public material {
     public:
         dielectric(double ri) : ref_idx(ri) {}
+
         virtual bool scatter(
             const ray& r_in, const hit_record& rec, vec3& attenuation, ray& scattered
         ) const  {

--- a/src/InOneWeekend/sphere.h
+++ b/src/InOneWeekend/sphere.h
@@ -18,11 +18,12 @@
 class sphere: public hittable  {
     public:
         sphere() {}
-        sphere(vec3 cen, double r, material *m) : center(cen), radius(r), mat_ptr(m)  {};
+        sphere(vec3 cen, double r, material_ptr m) : center(cen), radius(r), mat_ptr(m)  {};
         virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
-        vec3 center;
-        double radius;
-        material *mat_ptr;
+
+        vec3    center;
+        double  radius;
+        material_ptr mat_ptr;
 };
 
 

--- a/src/common/rtweekend.h
+++ b/src/common/rtweekend.h
@@ -1,9 +1,10 @@
 #ifndef RTWEEKEND_H
 #define RTWEEKEND_H
 
+#include <cmath>
 #include <cstdlib>
 #include <limits>
-#include <cmath>
+#include <memory>
 
 
 // Constants


### PR DESCRIPTION
DRAFT
This is a sketch of revised memory management, using std::shared_ptr, allowing material and object (hittable) instances to be shared.

This approach has the downside of being more strongly a C++ solution, which might be a stumbling block for readers who have only a passing familiarity with C++. It's also more verbose and requires a bit more setup. However, it's robust and safe to use in a variety of ways. Finally one argument against this is that readers familiar with modern C++ memory management are free to do this on their own, just as they're encourage to write the entire program themselves.

With this approach, we should include a brief section explaining how this works for those readers who might need a quick guide.