### PR TITLE
Use Markdeep's new chapter indirection syntax

### DIFF
--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -192,10 +192,10 @@ definitely want to stratify.
 One Dimensional MC Integration
 ====================================================================================================
 
-Integration is all about computing areas and volumes, so we could have framed Chapter 2 in an
-integral form if we wanted to make it maximally confusing. But sometimes integration is the most
-natural and clean way to formulate things. Rendering is often such a problem. Let’s look at a
-classic integral:
+Integration is all about computing areas and volumes, so we could have framed
+Chapter [A Simple Monte Carlo Program] in an integral form if we wanted to make it maximally
+confusing. But sometimes integration is the most natural and clean way to formulate things.
+Rendering is often such a problem. Let’s look at a classic integral:
 
 $$ I = \int_{0}^{2} x^2 dx $$
 
@@ -911,7 +911,8 @@ $\phi$ are:
 </div>
 
 <div class='together'>
-For uniform random numbers $r_1$ and $r_2$, the material presented in Chapter 3 leads to:
+For uniform random numbers $r_1$ and $r_2$, the material presented in
+Chapter [one Dimensional MC Integration] leads to:
 
   $$ r_1 = \int_{0}^{\phi} \frac{1}{2\pi} = \frac{\phi}{2\pi} $$
 
@@ -1950,7 +1951,7 @@ not sampled with more density.
 We could make the PDF include the block. Let’s do that instead with a glass sphere because it’s
 easier. When we sample a sphere’s solid angle uniformly from a point outside the sphere, we are
 really just sampling a cone uniformly (the cone is tangent to the sphere). Let’s say the code has
-`theta_max`. Recall from Chapter 9, that to sample $\theta$ we have:
+`theta_max`. Recall from Chapter [Generating Random Directions], that to sample $\theta$ we have:
 
   $$ r_2 = \int_{0}^{\theta} 2\pi \cdot f(t) \cdot \sin(t) dt $$
 

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -193,7 +193,7 @@ One Dimensional MC Integration
 ====================================================================================================
 
 Integration is all about computing areas and volumes, so we could have framed
-Chapter [A Simple Monte Carlo Program] in an integral form if we wanted to make it maximally
+chapter [A Simple Monte Carlo Program] in an integral form if we wanted to make it maximally
 confusing. But sometimes integration is the most natural and clean way to formulate things.
 Rendering is often such a problem. Let’s look at a classic integral:
 
@@ -911,8 +911,8 @@ $\phi$ are:
 </div>
 
 <div class='together'>
-For uniform random numbers $r_1$ and $r_2$, the material presented in
-Chapter [one Dimensional MC Integration] leads to:
+For uniform random numbers $r_1$ and $r_2$, the material presented in the
+One Dimensional MC Integration chapter leads to:
 
   $$ r_1 = \int_{0}^{\phi} \frac{1}{2\pi} = \frac{\phi}{2\pi} $$
 
@@ -1951,7 +1951,7 @@ not sampled with more density.
 We could make the PDF include the block. Let’s do that instead with a glass sphere because it’s
 easier. When we sample a sphere’s solid angle uniformly from a point outside the sphere, we are
 really just sampling a cone uniformly (the cone is tangent to the sphere). Let’s say the code has
-`theta_max`. Recall from Chapter [Generating Random Directions], that to sample $\theta$ we have:
+`theta_max`. Recall from the Generating Random Directions chapter that to sample $\theta$ we have:
 
   $$ r_2 = \int_{0}^{\theta} 2\pi \cdot f(t) \cdot \sin(t) dt $$
 


### PR DESCRIPTION
This allows you to refer to a chapter by its title, instead of by
number, which makes it easier to add/delete/move chapters without
worrying about maintaining proper chapter number references.