### PR TITLE
Fixed the perlin_interp bug. Cleaned up src

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -1326,7 +1326,9 @@ And the interpolation becomes a bit more complicated:
 </div>
 
 <div class='together'>
-The output of the perlin interpretation can return negative values. Negative light isn't physically realizable (and doesn't make a lot of sense). Plus, negative values of light will be passed to the `sqrt()` function of our gamma function and get turned into `NaN`s. We will cast the perlin output back to between 0 and 1.
+The output of the perlin interpretation can return negative values. These negative values will be
+passed to the `sqrt()` function of our gamma function and get turned into `NaN`s. We will cast the
+perlin output back to between 0 and 1.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class noise_texture : public texture {

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -1326,6 +1326,26 @@ And the interpolation becomes a bit more complicated:
 </div>
 
 <div class='together'>
+The output of the perlin interpretation can return negative values. Negative light isn't physically realizable (and doesn't make a lot of sense). Plus, negative values of light will be passed to the `sqrt()` function of our gamma function and get turned into `NaN`s. We will cast the perlin output back to between 0 and 1.
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    class noise_texture : public texture {
+        public:
+            noise_texture() {}
+            noise_texture(double sc) : scale(sc) {}
+            virtual vec3 value(double u, double v, const vec3& p) const {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+                return vec3(1,1,1) * 0.5 * (1.0 + noise.noise(scale * p));
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+            }
+            perlin noise;
+            double scale;
+    };
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    [Listing [perlin-smoothed-2]: <kbd>[perlin.h]</kbd> Perlin smoothed, higher frequency]
+</div>
+
+<div class='together'>
 This finally gives something more reasonable looking:
 
   ![Perlin texture, shifted off integer values](../images/img.perlin-shift.jpg)
@@ -1375,7 +1395,7 @@ effect is:
             noise_texture(double sc) : scale(sc) {}
             virtual vec3 value(double u, double v, const vec3& p) const {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ none delete
-                return vec3(1,1,1) * noise.noise(scale * p);
+                return vec3(1,1,1) * 0.5 * (1.0 + noise.noise(scale * p));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 return vec3(1,1,1) * 0.5 * (1 + sin(scale*p.z() + 10*noise.turb(p)));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++

--- a/src/TheNextWeek/texture.h
+++ b/src/TheNextWeek/texture.h
@@ -58,7 +58,8 @@ class noise_texture : public texture {
         virtual vec3 value(double u, double v, const vec3& p) const {
             // return vec3(1,1,1)*0.5*(1 + noise.turb(scale * p));
             // return vec3(1,1,1)*noise.turb(scale * p);
-            return vec3(1,1,1)*0.5*(1 + sin(scale*p.x() + 5*noise.turb(scale*p)));
+            return vec3(1,1,1)*
+                0.5 * (1 + sin(scale*p.z() + 10*noise.turb(p)));
         }
 
         perlin noise;

--- a/src/TheNextWeek/texture.h
+++ b/src/TheNextWeek/texture.h
@@ -58,8 +58,7 @@ class noise_texture : public texture {
         virtual vec3 value(double u, double v, const vec3& p) const {
             // return vec3(1,1,1)*0.5*(1 + noise.turb(scale * p));
             // return vec3(1,1,1)*noise.turb(scale * p);
-            return vec3(1,1,1)*
-                0.5 * (1 + sin(scale*p.z() + 10*noise.turb(p)));
+            return vec3(1,1,1)*0.5*(1 + sin(scale*p.z() + 10*noise.turb(p)));
         }
 
         perlin noise;


### PR DESCRIPTION
There are 2 solutions presented in #92 and both solve the underlying issue.

The problem is such:

1. The `perlin_interp` function will produce negative values
2. These negative values become the luminance for the surface
3. Negative luminance isn't phy realizable, AND are getting passed to the `sqrt()` of the gamma
4. The outputs are garbled.

However, an understanding implicit in the writing of the source in the text is not made explicit.
Specifically, negative perlin values is acceptable because the `turb` value sums over multiple `perlin_interp` calls, and then takes the absolute value.

So the output of `turb` is always positive.

Both of the solutions present in #92 solve the issue of `NaN`s when caling `perlin_interp` alone, but remove most of the visual complexity of a `turb` call due to removing the negatives.

The only way to remove the `NaN`s and maintain visual complexity in `turb` is to cast perlin values back to 0...1 in the `noise` function