### PR TITLE
Hitvec.2

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -617,8 +617,7 @@ $\vec{\mathbf{N}}$:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         if (discriminant < 0) {
             return -1.0;
-        }
-        else {
+        } else {
             return (-b - sqrt(discriminant) ) / (2.0*a);
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -683,8 +682,7 @@ Using these observations, we can now simplify the sphere-intersection code to th
 
     if (discriminant < 0) {
         return -1.0;
-    }
-    else {
+    } else {
         return (-half_b - sqrt(discriminant) ) / a;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -792,27 +790,35 @@ And a list of objects:
     #define HITTABLE_LIST_H
 
     #include "hittable.h"
+    #include <vector>
 
     class hittable_list: public hittable {
         public:
             hittable_list() {}
-            hittable_list(hittable **l, int n) {list = l; list_size = n; }
+            hittable_list(hittable* object) { add(object); }
+
+            void clear()               { objects.clear(); }
+            void add(hittable* object) { objects.push_back(object); }
+
             virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
-            hittable **list;
-            int list_size;
+
+        public:
+            std::vector<hittable*> objects;
     };
 
     bool hittable_list::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
         hit_record temp_rec;
         bool hit_anything = false;
-        double closest_so_far = t_max;
-        for (int i = 0; i < list_size; i++) {
-            if (list[i]->hit(r, t_min, closest_so_far, temp_rec)) {
+        auto closest_so_far = t_max;
+
+        for (auto object : objects) {
+            if (object->hit(r, t_min, closest_so_far, temp_rec)) {
                 hit_anything = true;
                 closest_so_far = temp_rec.t;
                 rec = temp_rec;
             }
         }
+
         return hit_anything;
     }
 
@@ -820,6 +826,11 @@ And a list of objects:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [hittable-list-initial]: <kbd>[hittable_list.h]</kbd> The hittable_list class]
 </div>
+
+If you're unfamiliar with C++'s `std::vector`, this is a generic array-like collection of an
+arbitrary type. Above, we use a collection of pointers to `hittable`. `std::vector` automatically
+grows as more values are added: `objects.push_back(object)` adds a value to the end of the
+`std::vector` member variable `objects`.
 
 <div class='together'></div>
 We need some math constants that we conveniently define in their own header file. For now we only
@@ -876,10 +887,10 @@ And the new main:
     #include <iostream>
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-    vec3 ray_color(const ray& r, hittable *world) {
+    vec3 ray_color(const ray& r, hittable& world) {
         hit_record rec;
-        if (world->hit(r, 0.0, infinity, rec)) {
-            return 0.5*vec3(rec.normal.x()+1, rec.normal.y()+1, rec.normal.z()+1);
+        if (world.hit(r, 0.0, infinity, rec)) {
+            return 0.5 * (rec.normal + vec3(1,1,1));
         }
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -893,7 +904,9 @@ And the new main:
     int main() {
         int nx = 200;
         int ny = 100;
+
         std::cout << "P3\n" << nx << ' ' << ny << "\n255\n";
+
         vec3 lower_left_corner(-2.0, -1.0, -1.0);
         vec3 horizontal(4.0, 0.0, 0.0);
         vec3 vertical(0.0, 2.0, 0.0);
@@ -901,10 +914,9 @@ And the new main:
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        hittable *list[2];
-        list[0] = new sphere(vec3(0,0,-1), 0.5);
-        list[1] = new sphere(vec3(0,-100.5,-1), 100);
-        hittable *world = new hittable_list(list,2);
+        hittable_list world;
+        world.add(new sphere(vec3(0,0,-1), 0.5));
+        world.add(new sphere(vec3(0,-100.5,-1), 100));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         for (int j = ny-1; j >= 0; --j) {
@@ -1077,12 +1089,12 @@ Main is also changed:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         int num_samples = 100;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
         std::cout << "P3\n" << nx << " " << ny << "\n255\n";
 
-        hittable *list[2];
-        list[0] = new sphere(vec3(0,0,-1), 0.5);
-        list[1] = new sphere(vec3(0,-100.5,-1), 100);
-        hittable *world = new hittable_list(list,2);
+        hittable_list world;
+        world.add(new sphere(vec3(0,0,-1), 0.5));
+        world.add(new sphere(vec3(0,-100.5,-1), 100));
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         camera cam;
@@ -1196,9 +1208,9 @@ range from -1 to +1. Reject this point and try again if the point is outside the
 Then update the `ray_color()` function to use the new random direction generator:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    vec3 ray_color(const ray& r, hittable *world) {
+    vec3 ray_color(const ray& r, hittable& world) {
         hit_record rec;
-        if (world->hit(r, 0.0, infinity, rec)) {
+        if (world.hit(r, 0.0, infinity, rec)) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             vec3 target = rec.p + rec.normal + random_in_unit_sphere();
             return 0.5 * ray_color(ray(rec.p, target - rec.p), world);
@@ -1220,9 +1232,10 @@ time — long enough to blow the stack. To guard against that, let's limit the m
 depth, returning no light contribution at the maximum depth:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-    vec3 ray_color(const ray& r, hittable *world, int depth) {
+    vec3 ray_color(const ray& r, hittable& world, int depth) {
         hit_record rec;
-        if (world->hit(r, 0.0, infinity, rec)) {
+        if (world.hit(r, 0.0, infinity, rec)) {
+            // If we've exceeded the ray bounce limit, no more light is gathered.
             if (depth <= 0)
                 return vec3(0,0,0);
             vec3 target = rec.p + rec.normal + random_in_unit_sphere();
@@ -1242,6 +1255,7 @@ depth, returning no light contribution at the maximum depth:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         int max_depth = 50;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
         ...
         for (int j = ny-1; j >= 0; --j) {
             std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;
@@ -1316,7 +1330,7 @@ off of not at exactly $t=0$, but instead at $t=-0.0000001$ or $t=0.00000001$ or 
 point approximation the sphere intersector gives us. So we need to ignore hits very near zero:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    if (world->hit(r, 0.001, infinity, rec)) {
+    if (world.hit(r, 0.001, infinity, rec)) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [reflect-tolerance]: <kbd>[main.cc]</kbd> Calculating reflected ray origins with tolerance]
 
@@ -1357,9 +1371,10 @@ This `random_unit_vector()` is a drop-in replacement for the existing `random_in
 function.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    vec3 ray_color(const ray& r, hittable *world, int depth) {
+    vec3 ray_color(const ray& r, hittable& world, int depth) {
         hit_record rec;
-        if (world->hit(r, 0.0, infinity, rec)) {
+        if (world.hit(r, 0.0, infinity, rec)) {
+            // If we've exceeded the ray bounce limit, no more light is gathered.
             if (depth <= 0)
                 return vec3(0,0,0);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -1432,9 +1447,10 @@ this diffuse method (before adopting Lambertian diffuse).
 Plugging the new formula into the `ray_color()` function:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    vec3 ray_color(const ray& r, hittable *world, int depth) {
+    vec3 ray_color(const ray& r, hittable& world, int depth) {
         hit_record rec;
-        if (world->hit(r, 0.0, infinity, rec)) {
+        if (world.hit(r, 0.0, infinity, rec)) {
+            // If we've exceeded the ray bounce limit, no more light is gathered.
             if (depth <= 0)
                 return vec3(0,0,0);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -1660,10 +1676,11 @@ The metal material just reflects rays using that formula:
 We need to modify the color function to use this:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    vec3 ray_color(const ray& r, hittable *world, int depth) {
+    vec3 ray_color(const ray& r, hittable& world, int depth) {
         hit_record rec;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        if (world->hit(r, 0.001, infinity, rec)) {
+        if (world.hit(r, 0.001, infinity, rec)) {
+            // If we've exceeded the ray bounce limit, no more light is gathered.
             if (depth <= 0)
                 return vec3(0,0,0);
             ray scattered;
@@ -1696,12 +1713,11 @@ metal spheres:
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        hittable *list[4];
-        list[0] = new sphere(vec3(0,0,-1), 0.5, new lambertian(vec3(0.7, 0.3, 0.3)));
-        list[1] = new sphere(vec3(0,-100.5,-1), 100, new lambertian(vec3(0.8, 0.8, 0.0)));
-        list[2] = new sphere(vec3(1,0,-1), 0.5, new metal(vec3(0.8, 0.6, 0.2)));
-        list[3] = new sphere(vec3(-1,0,-1), 0.5, new metal(vec3(0.8, 0.8, 0.8)));
-        hittable *world = new hittable_list(list,4);
+        hittable_list world;
+        world.add(new sphere(vec3(0,0,-1), 0.5, new lambertian(vec3(0.7, 0.3, 0.3))));
+        world.add(new sphere(vec3(0,-100.5,-1), 100, new lambertian(vec3(0.8, 0.8, 0.0))));
+        world.add(new sphere(vec3(1,0,-1), 0.5, new metal(vec3(0.8, 0.6, 0.2))));
+        world.add(new sphere(vec3(-1,0,-1), 0.5, new metal(vec3(0.8, 0.8, 0.8))));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         camera cam;
@@ -2068,9 +2084,9 @@ When calling it with camera `cam(90, double(nx)/ny)` and these spheres:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     auto R = cos(pi/4);
-    list[0] = new sphere(vec3(-R,0,-1), R, new lambertian(vec3(0, 0, 1)));
-    list[1] = new sphere(vec3( R,0,-1), R, new lambertian(vec3(1, 0, 0)));
-    hittable *world = new hittable_list(list,2);
+    hittable_list world;
+    world.add(new sphere(vec3(-R,0,-1), R, new lambertian(vec3(0, 0, 1))));
+    world.add(new sphere(vec3( R,0,-1), R, new lambertian(vec3(1, 0, 0))));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-wide-angle]: <kbd>[main.cc]</kbd> Scene with wide-angle camera]
 
@@ -2307,38 +2323,45 @@ Where Next?
 First let’s make the image on the cover of this book -- lots of random spheres:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    hittable *random_scene() {
-        int n = 500;
-        hittable **list = new hittable*[n+1];
-        list[0] =  new sphere(vec3(0,-1000,0), 1000, new lambertian(vec3(0.5, 0.5, 0.5)));
+    hittable_list random_scene() {
+        hittable_list objects;
+
+        objects.add(new sphere(vec3(0,-1000,0), 1000, new lambertian(vec3(0.5, 0.5, 0.5))));
+
         int i = 1;
         for (int a = -11; a < 11; a++) {
             for (int b = -11; b < 11; b++) {
                 auto choose_mat = random_double();
                 vec3 center(a + 0.9*random_double(), 0.2, b + 0.9*random_double());
-                if ((center-vec3(4,0.2,0)).length() > 0.9) {
+                if ((center - vec3(4, .2, 0)).length() > 0.9) {
                     if (choose_mat < 0.8) {
                         // diffuse
                         auto albedo = vec3::random() * vec3::random();
-                        list[i++] = new sphere(center, 0.2, new lambertian(albedo));
+                        objects.add(new sphere(center, 0.2, new lambertian(albedo)));
                     } else if (choose_mat < 0.95) {
                         // metal
                         auto albedo = vec3::random(.5, 1);
                         auto fuzz = random_double(0, .5);
-                        list[i++] = new sphere(center, 0.2, new metal(albedo, fuzz));
+                        objects.add(new sphere(center, 0.2, new metal(albedo, fuzz)));
                     } else {
                         // glass
-                        list[i++] = new sphere(center, 0.2, new dielectric(1.5));
+                        objects.add(new sphere(center, 0.2, new dielectric(1.5)));
                     }
                 }
             }
         }
 
-        list[i++] = new sphere(vec3(0, 1, 0), 1.0, new dielectric(1.5));
-        list[i++] = new sphere(vec3(-4, 1, 0), 1.0, new lambertian(vec3(0.4, 0.2, 0.1)));
-        list[i++] = new sphere(vec3(4, 1, 0), 1.0, new metal(vec3(0.7, 0.6, 0.5), 0.0));
+        objects.add(new sphere(vec3(0, 1, 0), 1.0, new dielectric(1.5)));
+        objects.add(new sphere(vec3(-4, 1, 0), 1.0, new lambertian(vec3(0.4, 0.2, 0.1))));
+        objects.add(new sphere(vec3(4, 1, 0), 1.0, new metal(vec3(0.7, 0.6, 0.5), 0.0)));
 
-        return new hittable_list(list,i);
+        return objects;
+    }
+
+    int main() {
+        ...
+        auto world = random_scene();
+        ...
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-final]: <kbd>[main.cc]</kbd> Final scene]

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -2333,7 +2333,7 @@ First let’s make the image on the cover of this book -- lots of random spheres
             for (int b = -11; b < 11; b++) {
                 auto choose_mat = random_double();
                 vec3 center(a + 0.9*random_double(), 0.2, b + 0.9*random_double());
-                if ((center - vec3(4, .2, 0)).length() > 0.9) {
+                if ((center - vec3(4, 0.2, 0)).length() > 0.9) {
                     if (choose_mat < 0.8) {
                         // diffuse
                         auto albedo = vec3::random() * vec3::random();

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -764,6 +764,9 @@ one recursion would probably help a little, but I figure the whole method will g
 This yields:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    #include <algorithm>
+    ...
+
     bvh_node::bvh_node(std::vector<hittable*>& objects, int n, double time0, double time1) {
         int axis = random_int(0,2);
         auto comparator = (axis == 0) ? box_x_compare

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -814,7 +814,7 @@ axis index argument. Then define axis-specific comparison functions that use the
 function.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    bool box_compare(const hittable* a, const hittable* b, int axis) {
+    inline bool box_compare(const hittable* a, const hittable* b, int axis) {
         aabb box_a;
         aabb box_b;
 

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -692,7 +692,6 @@ a class:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class bvh_node : public hittable {
         public:
-            bvh_node() = delete;   // Disallow uninitialized BVH nodes
             bvh_node(hittable_list& list, double time0, double time1)
                 : bvh_node(list.objects, 0, 0, time0, time1)
             {}

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -263,10 +263,11 @@ closing again at time 1.) Each sphere moves from its center $\mathbf{C}$ at time
 $\mathbf{C} + (0, r/2, 0)$ at time $t=1$, where $r$ is a random number in $[0,1)$:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    hittable *random_scene() {
-        int n = 50000;
-        hittable **list = new hittable*[n+1];
-        list[0] =  new sphere(vec3(0,-1000,0), 1000, new lambertian(checker));
+    hittable_list random_scene() {
+        hittable_list world;
+
+        world.add(new sphere(vec3(0,-1000,0), 1000, new lambertian(checker)));
+
         int i = 1;
         for (int a = -10; a < 10; a++) {
             for (int b = -10; b < 10; b++) {
@@ -276,28 +277,28 @@ $\mathbf{C} + (0, r/2, 0)$ at time $t=1$, where $r$ is a random number in $[0,1)
                     if (choose_mat < 0.8) {
                         // diffuse
                         auto albedo = vec3::random() * vec3::random();
-                        list[i++] = new moving_sphere(
+                        world.add(new moving_sphere(
                             center, center + vec3(0, random_double(0,.5), 0), 0.0, 1.0, 0.2,
                             new lambertian(new constant_texture(albedo))
-                        );
+                        ));
                     } else if (choose_mat < 0.95) {
                         // metal
                         auto albedo = vec3::random(.5, 1);
                         auto fuzz = random_double(0, .5);
-                        list[i++] = new sphere(center, 0.2, new metal(albedo, fuzz));
+                        world.add(new sphere(center, 0.2, new metal(albedo, fuzz)));
                     } else {
                         // glass
-                        list[i++] = new sphere(center, 0.2, new dielectric(1.5));
+                        world.add(new sphere(center, 0.2, new dielectric(1.5)));
                     }
                 }
             }
         }
 
-        list[i++] = new sphere(vec3(0, 1, 0), 1.0, new dielectric(1.5));
-        list[i++] = new sphere(vec3(-4, 1, 0), 1.0, new lambertian(vec3(0.4, 0.2, 0.1)));
-        list[i++] = new sphere(vec3(4, 1, 0), 1.0, new metal(vec3(0.7, 0.6, 0.5), 0.0));
+        world.add(new sphere(vec3(0, 1, 0), 1.0, new dielectric(1.5)));
+        world.add(new sphere(vec3(-4, 1, 0), 1.0, new lambertian(vec3(0.4, 0.2, 0.1))));
+        world.add(new sphere(vec3(4, 1, 0), 1.0, new metal(vec3(0.7, 0.6, 0.5), 0.0)));
 
-        return new hittable_list(list,i);
+        return world;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-spheres-moving]:
@@ -641,20 +642,23 @@ the fly because it is only usually called at BVH construction.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     bool hittable_list::bounding_box(double t0, double t1, aabb& output_box) const {
-        if (list_size < 1) return false;
+        if (objects.empty()) return false;
+
         aabb temp_box;
-        bool first_true = list[0]->bounding_box(t0, t1, temp_box);
+        bool first_true = objects[0]->bounding_box(t0, t1, temp_box);
+
         if (!first_true)
             return false;
         else
             output_box = temp_box;
-        for (int i = 1; i < list_size; i++) {
-            if(list[i]->bounding_box(t0, t1, temp_box)) {
+
+        for (auto object : objects) {
+            if (objects[i]->bounding_box(t0, t1, temp_box))
                 output_box = surrounding_box(output_box, temp_box);
-            }
             else
                 return false;
         }
+
         return true;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -689,8 +693,14 @@ a class:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class bvh_node : public hittable {
         public:
-            bvh_node() {}
-            bvh_node(hittable **l, int n, double time0, double time1);
+            bvh_node() = delete;   // Disallow uninitialized BVH nodes
+            bvh_node(hittable_list& list, double time0, double time1)
+                : bvh_node(list.objects, 0, 0, time0, time1)
+            {}
+
+            bvh_node(
+                std::vector<hittable*> &objects,
+                size_t start, size_t end, double time0, double time1);
 
             virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
             virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
@@ -756,35 +766,38 @@ one recursion would probably help a little, but I figure the whole method will g
 This yields:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    bvh_node::bvh_node(hittable **l, int n, double time0, double time1) {
+    bvh_node::bvh_node(std::vector<hittable*>& objects, int n, double time0, double time1) {
         int axis = random_int(0,2);
+        auto comparator = (axis == 0) ? box_x_compare
+                        : (axis == 1) ? box_y_compare
+                                      : box_z_compare;
 
-        if (axis == 0)
-           qsort(l, n, sizeof(hittable *), box_x_compare);
-        else if (axis == 1)
-           qsort(l, n, sizeof(hittable *), box_y_compare);
-        else
-           qsort(l, n, sizeof(hittable *), box_z_compare);
+        size_t object_span = end - start;
 
-        if (n == 1) {
-            left = right = l[0];
-        }
-        else if (n == 2) {
-            left = l[0];
-            right = l[1];
-        }
-        else {
-            left = new bvh_node(l, n/2, time0, time1);
-            right = new bvh_node(l + n/2, n - n/2, time0, time1);
+        if (object_span == 1) {
+            left = right = objects[start];
+        } else if (object_span == 2) {
+            if (comparator(objects[start], objects[start+1])) {
+                left = objects[start];
+                right = objects[start+1];
+            } else {
+                left = objects[start+1];
+                right = objects[start];
+            }
+        } else {
+            std::sort(objects.begin() + start, objects.begin() + end, comparator);
+
+            auto mid = start + object_span/2;
+            left = new bvh_node(objects, start, mid, time0, time1);
+            right = new bvh_node(objects, mid, end, time0, time1);
         }
 
         aabb box_left, box_right;
 
-        if (!left->bounding_box(time0, time1, box_left) ||
-            !right->bounding_box(time0, time1, box_right)) {
-
-            std::cerr << "no bounding box in bvh_node constructor\n";
-        }
+        if (  !left->bounding_box (time0, time1, box_left)
+           || !right->bounding_box(time0, time1, box_right)
+        )
+            std::cerr << "No bounding box in bvh_node constructor.\n";
 
         box = surrounding_box(box_left, box_right);
     }
@@ -796,26 +809,30 @@ The check for whether there is a bounding box at all is in case you sent in some
 infinite plane that doesn’t have a bounding box. We don’t have any of those primitives, so it
 shouldn’t happen until you add such a thing.
 
-The compare function has to take void pointers which you cast. This is old-school C and reminded me
-why C++ was invented. I had to really mess with this to get all the pointer junk right. If you like
-this part, you have a future as a systems person!
+<div class='together'>
+Now we need to implement the box comparison functions, used by `std::sort()`. To do this, create a
+generic comparator returns true if the first argument is less than the second, given an additional
+axis index argument. Then define axis-specific comparison functions that use the generic comparison
+function.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    int box_x_compare (const void * a, const void * b) {
-        aabb box_left, box_right;
-        hittable *ah = *(hittable**)a;
-        hittable *bh = *(hittable**)b;
+    bool box_compare(const hittable* a, const hittable* b, int axis) {
+        aabb box_a;
+        aabb box_b;
 
-        if (!ah->bounding_box(0,0, box_left) || !bh->bounding_box(0,0, box_right))
-            std::cerr << "no bounding box in bvh_node constructor\n";
+        if (!a->bounding_box(0,0, box_a) || !b->bounding_box(0,0, box_b))
+            std::cerr << "No bounding box in bvh_node constructor.\n";
 
-        if (box_left.min().x() - box_right.min().x() < 0.0)
-            return -1;
-        else
-            return 1;
+        return box_a.min().e[axis] < box_b.min().e[axis];
     }
+
+
+    bool box_x_compare (const hittable* a, const hittable* b) { return box_compare(a, b, 0); }
+    bool box_y_compare (const hittable* a, const hittable* b) { return box_compare(a, b, 1); }
+    bool box_z_compare (const hittable* a, const hittable* b) { return box_compare(a, b, 2); }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [bvh-x-comp]: <kbd>[bvh.h]</kbd> BVH comparison function, X-axis]
+</div>
 
 
 
@@ -942,16 +959,16 @@ We get:
 If we add a new scene:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    hittable *two_spheres() {
+    hittable_list two_spheres() {
+        hittable_list objects;
+
         texture *checker = new checker_texture(
-            new constant_texture(vec3(0.2, 0.3, 0.1)),
-            new constant_texture(vec3(0.9, 0.9, 0.9))
-        );
-        int n = 50;
-        hittable **list = new hitable*[n+1];
-        list[0] = new sphere(vec3(0,-10, 0), 10, new lambertian(checker));
-        1ist[1] = new sphere(vec3(0, 10, 0), 10, new lambertian(checker));
-        return new hittable_list(list,2);
+            new constant_texture(vec3(0.2,0.3, 0.1)), new constant_texture(vec3(0.9, 0.9, 0.9)));
+
+        objects.add(new sphere(vec3(0,-10, 0), 10, new lambertian(checker)));
+        objects.add(new sphere(vec3(0, 10, 0), 10, new lambertian(checker)));
+
+        return objects;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-two-checker]: <kbd>[main.cc]</kbd> Scene with two checkered spheres]
@@ -1082,12 +1099,14 @@ colors:
 We can use that texture on some spheres:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    hittable *two_perlin_spheres() {
+    hittable_list two_perlin_spheres() {
+        hittable_list objects;
+
         texture *pertext = new noise_texture();
-        hittable **list = new hittable*[2];
-        list[0] = new sphere(vec3(0,-1000, 0), 1000, new lambertian(pertext));
-        list[1] = new sphere(vec3(0, 2, 0), 2, new lambertian(pertext));
-        return new hittable_list(list, 2);
+        objects.add(new sphere(vec3(0,-1000, 0), 1000, new lambertian(pertext)));
+        objects.add(new sphere(vec3(0, 2, 0), 2, new lambertian(pertext)));
+
+        return objects;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-perlin]: <kbd>[main.cc]</kbd> Scene with two Perlin-textured spheres]
@@ -1530,9 +1549,15 @@ standard projection will do for our purposes), and then assign it to a diffuse m
 is:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    int nx, ny, nn;
-    unsigned char *tex_data = stbi_load("earthmap.jpg", &nx, &ny, &nn, 0);
-    material *mat = new lambertian(new image_texture(tex_data, nx, ny));
+    hittable_list earth() {
+        int nx, ny, nn;
+        unsigned char *texture_data = stbi_load("earthmap.jpg", &nx, &ny, &nn, 0);
+
+        auto earth_surface = new lambertian(new image_texture(texture_data, nx, ny));
+        auto globe = new sphere(vec3(0,0,0), 2, earth_surface);
+
+        return hittable_list(globe);
+    }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [stbi-load-use]: <kbd>[main.cc]</kbd> Using stbi_load() to load an image]
 </div>
@@ -1604,9 +1629,15 @@ class return black:
 Next, let’s make the background black in our `ray_color` function, and pay attention to emitted:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    vec3 ray_color(const ray& r, hittable *world, int depth) {
+    vec3 ray_color(const ray& r, hittable& world, int depth) {
         hit_record rec;
-        if (depth <= 0 || !world->hit(r, 0.001, infinity, rec))
+
+        // If we've exceeded the ray bounce limit, no more light is gathered.
+        if (depth <= 0)
+            return vec3(0,0,0);
+
+        // If the ray hits nothing, return the background color.
+        if (!world.hit(r, 0.001, infinity, rec))
             return vec3(0,0,0);
 
         ray scattered;
@@ -1704,16 +1735,18 @@ And the hit function is:
 If we set up a rectangle as a light:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    hittable *simple_light() {
-        texture *pertext = new noise_texture(4);
-        hittable **list = new hittable*[4];
-        list[0] = new sphere(vec3(0,-1000, 0), 1000, new lambertian(pertext));
-        list[1] = new sphere(vec3(0, 2, 0), 2, new lambertian(pertext));
-        list[2] = new sphere(vec3(0, 7, 0), 2,
-            new diffuse_light(new constant_texture(vec3(4,4,4))));
-        list[3] = new xy_rect(3, 5, 1, 3, -2,
-            new diffuse_light(new constant_texture(vec3(4,4,4))));
-        return new hittable_list(list,4);
+    hittable_list simple_light() {
+        hittable_list objects;
+
+        auto pertext = new noise_texture(4);
+        objects.add(new sphere(vec3(0,-1000, 0), 1000, new lambertian(pertext)));
+        objects.add(new sphere(vec3(0,2,0), 2, new lambertian(pertext)));
+
+        auto difflight = new diffuse_light(new constant_texture(vec3(4,4,4)));
+        objects.add(new sphere(vec3(0,7,0), 2, difflight));
+        objects.add(new xy_rect(3, 5, 1, 3, -2, difflight));
+
+        return objects;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [rect-light]: <kbd>[main.cc]</kbd> A simple rectangle light]
@@ -1825,21 +1858,21 @@ With unsurprising hit functions:
 Let’s make the 5 walls and the light of the box:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    hittable *cornell_box() {
-        hittable **list = new hitable*[5];
-        int i = 0;
-        material *red = new lambertian(new constant_texture(vec3(0.65, 0.05, 0.05)));
-        material *white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
-        material *green = new lambertian(new constant_texture(vec3(0.12, 0.45, 0.15)));
-        material *light = new diffuse_light(new constant_texture(vec3(15, 15, 15)));
+    hittable_list cornell_box() {
+        hittable_list objects;
 
-        list[i++] = new yz_rect(0, 555, 0, 555, 555, green);
-        list[i++] = new yz_rect(0, 555, 0, 555, 0, red);
-        list[i++] = new xz_rect(213, 343, 227, 332, 554, light);
-        list[i++] = new xz_rect(0, 555, 0, 555, 0, white);
-        list[i++] = new xy_rect(0, 555, 0, 555, 555, white);
+        auto red = new lambertian(new constant_texture(vec3(0.65, 0.05, 0.05)));
+        auto white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
+        auto green = new lambertian(new constant_texture(vec3(0.12, 0.45, 0.15)));
+        auto light = new diffuse_light(new constant_texture(vec3(15, 15, 15)));
 
-        return new hittable_list(list,i);
+        objects.add(new yz_rect(0, 555, 0, 555, 555, green));
+        objects.add(new yz_rect(0, 555, 0, 555, 0, red));
+        objects.add(new xz_rect(213, 343, 227, 332, 554, light));
+        objects.add(new xz_rect(0, 555, 0, 555, 0, white));
+        objects.add(new xy_rect(0, 555, 0, 555, 555, white));
+
+        return objects;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [cornell-box-empty]: <kbd>[main.cc]</kbd> Cornell box scene, empty]
@@ -1901,28 +1934,28 @@ another hittable, but reverses the normals:
 This makes Cornell:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    hittable *cornell_box() {
-        hittable **list = new hittable*[6];
-        int i = 0;
+    hittable_list cornell_box() {
+        hittable_list objects;
+
         material *red = new lambertian(new constant_texture(vec3(0.65, 0.05, 0.05)));
         material *white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
         material *green = new lambertian(new constant_texture(vec3(0.12, 0.45, 0.15)));
         material *light = new diffuse_light(new constant_texture(vec3(15, 15, 15)));
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        list[i++] = new flip_normals(new yz_rect(0, 555, 0, 555, 555, green));
+        objects.add(new flip_normals(new yz_rect(0, 555, 0, 555, 555, green)));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-        list[i++] = new yz_rect(0, 555, 0, 555, 0, red);
-        list[i++] = new xz_rect(213, 343, 227, 332, 554, light);
+        objects.add(new yz_rect(0, 555, 0, 555, 0, red));
+        objects.add(new xz_rect(213, 343, 227, 332, 554, light));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        list[i++] = new flip_normals(new xz_rect(0, 555, 0, 555, 555, white));
+        objects.add(new flip_normals(new xz_rect(0, 555, 0, 555, 555, white)));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-        list[i++] = new xz_rect(0, 555, 0, 555, 0, white);
+        objects.add(new xz_rect(0, 555, 0, 555, 0, white));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        list[i++] = new flip_normals(new xy_rect(0, 555, 0, 555, 555, white));
+        objects.add(new flip_normals(new xy_rect(0, 555, 0, 555, 555, white)));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-        return new hittable_list(list,i);
+        return objects;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [cornell-box-flipped]: <kbd>[main.cc]</kbd> Empty Cornell box with flipped rectangles]
@@ -1983,8 +2016,8 @@ make an axis-aligned block primitive that holds 6 rectangles:
 Now we can add two blocks (but not rotated)
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    list[i++] = new box(vec3(130, 0, 65), vec3(295, 165, 230), white);
-    list[i++] = new box(vec3(265, 0, 295), vec3(430, 330, 460), white);
+    objects.add(new box(vec3(130, 0, 65), vec3(295, 165, 230), white));
+    objects.add(new box(vec3(265, 0, 295), vec3(430, 330, 460), white));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [add-boxes]: <kbd>[main.cc]</kbd> Adding box objects]
 
@@ -2185,14 +2218,15 @@ And the hit function:
 And the changes to Cornell are:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    list[i++] = new translate(
-                    new rotate_y(new box(vec3(0,0,0), vec3(165,165,165), white), -18),
-                    vec3(130,0,65)
-                );
-    list[i++] = new translate(
-                    new rotate_y(new box(vec3(0,0,0), vec3(165,330,165), white), 15),
-                    vec3(265,0,295)
-                );
+    hittable* box1 = new box(vec3(0, 0, 0), vec3(165, 330, 165), white);
+    box1 = new rotate_y(box1,  15);
+    box1 = new translate(box1, vec3(265,0,295));
+    objects.add(box1);
+
+    hittable* box2 = new box(vec3(0,0,0), vec3(165,165,165), white);
+    box2 = new rotate_y(box2, -18);
+    box2 = new translate(box2, vec3(130,0,65));
+    objects.add(box2);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-rot-y]: <kbd>[main.cc]</kbd> Cornell scene with Y-rotated boxes]
 </div>
@@ -2343,34 +2377,33 @@ If we replace the two blocks with smoke and fog (dark and light particles) and m
 (and dimmer so it doesn’t blow out the scene) for faster convergence:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    hittable *cornell_smoke() {
-        hittable **list = new hittable*[8];
-        int i = 0;
-        material *red = new lambertian(new constant_texture(vec3(0.65, 0.05, 0.05)));
-        material *white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
-        material *green = new lambertian(new constant_texture(vec3(0.12, 0.45, 0.15)));
-        material *light = new diffuse_light(new constant_texture(vec3(7, 7, 7)));
+    hittable_list cornell_smoke() {
+        hittable_list objects;
 
-        list[i++] = new flip_normals(new yz_rect(0, 555, 0, 555, 555, green));
-        list[i++] = new yz_rect(0, 555, 0, 555, 0, red);
-        list[i++] = new xz_rect(113, 443, 127, 432, 554, light);
-        list[i++] = new flip_normals(new xz_rect(0, 555, 0, 555, 555, white));
-        list[i++] = new xz_rect(0, 555, 0, 555, 0, white);
-        list[i++] = new flip_normals(new xy_rect(0, 555, 0, 555, 555, white));
+        auto red = new lambertian(new constant_texture(vec3(0.65, 0.05, 0.05)));
+        auto white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
+        auto green = new lambertian(new constant_texture(vec3(0.12, 0.45, 0.15)));
+        auto light = new diffuse_light(new constant_texture(vec3(7, 7, 7)));
 
-        hittable *b1 = new translate(
-            new rotate_y(new box(vec3(0, 0, 0), vec3(165, 165, 165), white), -18),
-            vec3(130,0,65)
-        );
-        hittable *b2 = new translate(
-            new rotate_y(new box(vec3(0, 0, 0), vec3(165, 330, 165), white),  15),
-            vec3(265,0,295)
-        );
+        objects.add(new flip_normals(new yz_rect(0, 555, 0, 555, 555, green)));
+        objects.add(new yz_rect(0, 555, 0, 555, 0, red));
+        objects.add(new xz_rect(113, 443, 127, 432, 554, light));
+        objects.add(new flip_normals(new xz_rect(0, 555, 0, 555, 555, white)));
+        objects.add(new xz_rect(0, 555, 0, 555, 0, white));
+        objects.add(new flip_normals(new xy_rect(0, 555, 0, 555, 555, white)));
 
-        list[i++] = new constant_medium(b1, 0.01, new constant_texture(vec3(1.0, 1.0, 1.0)));
-        list[i++] = new constant_medium(b2, 0.01, new constant_texture(vec3(0.0, 0.0, 0.0)));
+        hittable* box1 = new box(vec3(0,0,0), vec3(165,330,165), white);
+        box1 = new rotate_y(box1,  15);
+        box1 = new translate(box1, vec3(265,0,295));
 
-        return new hittable_list(list,i);
+        hittable* box2 = new box(vec3(0,0,0), vec3(165,165,165), white);
+        box2 = new rotate_y(box2, -18);
+        box2 = new translate(box2, vec3(130,0,65));
+
+        objects.add(new constant_medium(box1, 0.01, new constant_texture(vec3(0,0,0))));
+        objects.add(new constant_medium(box2, 0.01, new constant_texture(vec3(1,1,1))));
+
+        return objects;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [cornell-smoke]: <kbd>[main.cc]</kbd> Cornell box, with smoke]
@@ -2394,16 +2427,13 @@ subsurface material is). The biggest limitation left in the renderer is no shado
 why we get caustics and subsurface for free. It’s a double-edged design decision.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    hittable *final() {
-        int nb = 20;
-        hittable **list = new hittable*[30];
-        hittable **boxlist = new hittable*[10000];
-        hittable **boxlist2 = new hittable*[10000];
-        material *white = new lambertian( new constant_texture(vec3(0.73, 0.73, 0.73)));
-        material *ground = new lambertian( new constant_texture(vec3(0.48, 0.83, 0.53)));
-        int b = 0;
-        for (int i = 0; i < nb; i++) {
-            for (int j = 0; j < nb; j++) {
+    hittable_list final_scene() {
+        hittable_list boxes1;
+        auto ground = new lambertian(new constant_texture(vec3(0.48, 0.83, 0.53)));
+
+        const int boxes_per_side = 20;
+        for (int i = 0; i < boxes_per_side; i++) {
+            for (int j = 0; j < boxes_per_side; j++) {
                 auto w = 100.0;
                 auto x0 = -1000.0 + i*w;
                 auto z0 = -1000.0 + j*w;
@@ -2411,42 +2441,50 @@ why we get caustics and subsurface for free. It’s a double-edged design decisi
                 auto x1 = x0 + w;
                 auto y1 = random_double(1,101);
                 auto z1 = z0 + w;
-                boxlist[b++] = new box(vec3(x0,y0,z0), vec3(x1,y1,z1), ground);
+                boxes1.add(new box(vec3(x0,y0,z0), vec3(x1,y1,z1), ground));
             }
         }
-        int l = 0;
-        list[l++] = new bvh_node(boxlist, b, 0, 1);
+
+        hittable_list objects;
+
+        objects.add(new bvh_node(boxes1, 0, 1));
+
         material *light = new diffuse_light(new constant_texture(vec3(7, 7, 7)));
-        list[l++] = new xz_rect(123, 423, 147, 412, 554, light);
+        objects.add(new xz_rect(123, 423, 147, 412, 554, light));
+
         vec3 center(400, 400, 200);
-        list[l++] = new moving_sphere(center, center+vec3(30, 0, 0),
-            0, 1, 50, new lambertian(new constant_texture(vec3(0.7, 0.3, 0.1))));
-        list[l++] = new sphere(vec3(260, 150, 45), 50, new dielectric(1.5));
-        list[l++] = new sphere(vec3(0, 150, 145), 50,
-            new metal(vec3(0.8, 0.8, 0.9), 10.0));
+        objects.add(new moving_sphere(
+            center, center+vec3(30, 0, 0), 0, 1, 50,
+            new lambertian(new constant_texture(vec3(0.7, 0.3, 0.1)))
+        ));
+
+        objects.add(new sphere(vec3(260, 150, 45), 50, new dielectric(1.5)));
+        objects.add(new sphere(vec3(0, 150, 145), 50, new metal(vec3(0.8, 0.8, 0.9), 10.0)));
+
         hittable *boundary = new sphere(vec3(360, 150, 145), 70, new dielectric(1.5));
-        list[l++] = boundary;
-        list[l++] = new constant_medium(boundary, 0.2,
-            new constant_texture(vec3(0.2, 0.4, 0.9)));
+        objects.add(boundary);
+        objects.add(new constant_medium(boundary, 0.2, new constant_texture(vec3(0.2, 0.4, 0.9))));
         boundary = new sphere(vec3(0, 0, 0), 5000, new dielectric(1.5));
-        list[l++] = new constant_medium(boundary, 0.0001,
-            new constant_texture(vec3(1.0, 1.0, 1.0)));
+        objects.add(new constant_medium(boundary, .0001, new constant_texture(vec3(1,1,1))));
+
         int nx, ny, nn;
         unsigned char *tex_data = stbi_load("earthmap.jpg", &nx, &ny, &nn, 0);
-        material *emat =  new lambertian(new image_texture(tex_data, nx, ny));
-        list[l++] = new sphere(vec3(400, 200, 400), 100, emat);
+        material *emat = new lambertian(new image_texture(tex_data, nx, ny));
+        objects.add(new sphere(vec3(400,200, 400), 100, emat));
         texture *pertext = new noise_texture(0.1);
-        list[l++] =  new sphere(vec3(220, 280, 300), 80, new lambertian(pertext));
+        objects.add(new sphere(vec3(220,280, 300), 80, new lambertian(pertext)));
 
         int ns = 1000;
+        hittable_list boxes2;
+        material *white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
         for (int j = 0; j < ns; j++) {
-            boxlist2[j] = new sphere(vec3::random(0,165), 10, white);
+            boxes2.add(new sphere(vec3::random(0,165), 10, white));
         }
 
-        list[l++] = new translate(
-            new rotate_y(new bvh_node(boxlist2, ns, 0.0, 1.0), 15), vec3(-100,270,395));
+        objects.add(new translate(
+            new rotate_y(new bvh_node(boxes2, 0.0, 1.0), 15), vec3(-100,270,395)));
 
-        return new hittable_list(list,l);
+        return objects;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-final]: <kbd>[main.cc]</kbd> Final scene]

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -649,14 +649,13 @@ the fly because it is only usually called at BVH construction.
 
         if (!first_true)
             return false;
-        else
-            output_box = temp_box;
+
+        output_box = temp_box;
 
         for (auto object : objects) {
-            if (objects[i]->bounding_box(t0, t1, temp_box))
-                output_box = surrounding_box(output_box, temp_box);
-            else
+            if (!objects[i]->bounding_box(t0, t1, temp_box))
                 return false;
+            output_box = surrounding_box(output_box, temp_box);
         }
 
         return true;

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -2174,8 +2174,7 @@ think both tactics would work fine, but I will go with instrumenting `hittable_l
 
     vec3 hittable_list::random(const vec3& o) const {
         auto int_size = static_cast<int>(objects.size());
-        auto index = static_cast<size_t>(random_int(0, int_size-1));
-        return objects[index]->random(o);
+        return objects[random_int(0, int_size-1)]->random(o);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [density-mixture]: <kbd>[hittable_list.h]</kbd> Creating a mixture of densities]

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -728,33 +728,43 @@ Let’s do simple refactoring and temporarily remove all materials that aren’t
 our Cornell Box scene again, and let’s generate the camera in the function that generates the model:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    void cornell_box(hittable **scene, camera **cam, double aspect) {
-        material *red = new lambertian( new constant_texture(vec3(0.65, 0.05, 0.05)) );
-        material *white = new lambertian( new constant_texture(vec3(0.73, 0.73, 0.73)) );
-        material *green = new lambertian( new constant_texture(vec3(0.12, 0.45, 0.15)) );
-        material *light = new diffuse_light( new constant_texture(vec3(15, 15, 15)) );
+    hittable_list cornell_box(camera& cam, double aspect) {
+        hittable_list world;
 
-        hittable **list = new hittable*[8];
-        int i = 0;
-        list[i++] = new flip_normals(new yz_rect(0, 555, 0, 555, 555, green));
-        list[i++] = new yz_rect(0, 555, 0, 555, 0, red);
-        list[i++] = new xz_rect(213, 343, 227, 332, 554, light);
-        list[i++] = new flip_normals(new xz_rect(0, 555, 0, 555, 555, white));
-        list[i++] = new xz_rect(0, 555, 0, 555, 0, white);
-        list[i++] = new flip_normals(new xy_rect(0, 555, 0, 555, 555, white));
-        list[i++] = new translate(new rotate_y(
-            new box(vec3(0, 0, 0), vec3(165, 165, 165), white), -18), vec3(130,0,65));
-        list[i++] = new translate(new rotate_y(
-            new box(vec3(0, 0, 0), vec3(165, 330, 165), white),  15), vec3(265,0,295));
-        *scene = new hittable_list(list,i);
+        auto *red   = new lambertian(new constant_texture(vec3(0.65, 0.05, 0.05)));
+        auto *white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
+        auto *green = new lambertian(new constant_texture(vec3(0.12, 0.45, 0.15)));
+        auto *light = new diffuse_light(new constant_texture(vec3(15, 15, 15)));
+
+        world.add(new flip_normals(new yz_rect(0, 555, 0, 555, 555, green)));
+        world.add(new yz_rect(0, 555, 0, 555, 0, red));
+        world.add(new xz_rect(213, 343, 227, 332, 554, light));
+        world.add(new flip_normals(new xz_rect(0, 555, 0, 555, 555, white)));
+        world.add(new xz_rect(0, 555, 0, 555, 0, white));
+        world.add(new flip_normals(new xy_rect(0, 555, 0, 555, 555, white)));
+
+        hittable* box1 = new box(vec3(0,0,0), vec3(165,330,165), white);
+        box1 = new rotate_y(box1, 15);
+        box1 = new translate(box1, vec3(265,0,295));
+        world.add(box1);
+
+        hittable* box2 = new box(vec3(0,0,0), vec3(165,165,165), white);
+        box2 = new rotate_y(box2, -18);
+        box2 = new translate(box2, vec3(130,0,65);
+        world.add(box2);
 
         vec3 lookfrom(278, 278, -800);
         vec3 lookat(278, 278, 0);
+        vec3 up(0, 1, 0);
         auto dist_to_focus = 10.0;
         auto aperture = 0.0;
         auto vfov = 40.0;
-        *cam = new camera(
-            lookfrom, lookat, vec3(0,1,0), vfov, aspect, aperture, dist_to_focus, 0.0, 1.0);
+        auto t0 = 0.0;
+        auto t1 = 1.0;
+
+        cam = camera(lookfrom, lookat, up, vfov, aspect, aperture, dist_to_focus, t0, t1);
+
+        return world;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [cornell-box]: <kbd>[main.cc]</kbd> Cornell box, refactored]
@@ -837,14 +847,22 @@ And _Lambertian_ material becomes:
 And the color function gets a minor modification:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    vec3 ray_color(const ray& r, hittable *world, int depth) {
+    vec3 ray_color(const ray& r, hittable& world, int depth) {
         hit_record rec;
-        if (depth <= 0 || !world->hit(r, 0.001, infinity, rec))
+
+        // If we've exceeded the ray bounce limit, no more light is gathered.
+        if (depth <= 0)
+            return vec3(0,0,0);
+
+        // If the ray hits nothing, return the background color.
+        if (!world.hit(r, 0.001, infinity, rec))
             return vec3(0,0,0);
 
         ray scattered;
         vec3 attenuation;
         vec3 emitted = rec.mat_ptr->emitted(rec.u, rec.v, rec.p);
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         double pdf;
         vec3 albedo;
 
@@ -854,6 +872,7 @@ And the color function gets a minor modification:
         return emitted
              + albedo * rec.mat_ptr->scattering_pdf(r, rec, scattered)
                       * ray_color(scattered, world, depth-1) / pdf;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-impsample]: <kbd>[main.cc]</kbd>
@@ -1284,7 +1303,13 @@ that math and get the concept, we can add it (see the highlighted region):
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     vec3 ray_color(const ray& r, hittable *world, int depth) {
         hit_record rec;
-        if (depth <= 0 || !world->hit(r, 0,001, infinity, rec))
+
+        // If we've exceeded the ray bounce limit, no more light is gathered.
+        if (depth <= 0)
+            return vec3(0,0,0);
+
+        // If the ray hits nothing, return the background color.
+        if (!world.hit(r, 0.001, infinity, rec))
             return vec3(0,0,0);
 
         ray scattered;
@@ -1445,7 +1470,13 @@ change variable `pdf` to some other variable name to avoid a name conflict with 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     vec3 ray_color(const ray& r, hittable *world, int depth) {
         hit_record rec;
-        if (depth <= 0 || !world->hit(r, 0.001, infinity, rec))
+
+        // If we've exceeded the ray bounce limit, no more light is gathered.
+        if (depth <= 0)
+            return vec3(0,0,0);
+
+        // If the ray hits nothing, return the background color.
+        if (!world.hit(r, 0.001, infinity, rec))
             return vec3(0,0,0);
 
         ray scattered;
@@ -1564,7 +1595,13 @@ And then change `ray_color()`:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     vec3 ray_color(const ray& r, hittable *world, int depth) {
         hit_record rec;
-        if (depth <= 0 || !world->hit(r, 0.001, infinity, rec))
+
+        // If we've exceeded the ray bounce limit, no more light is gathered.
+        if (depth <= 0)
+            return vec3(0,0,0);
+
+        // If the ray hits nothing, return the background color.
+        if (!world.hit(r, 0.001, infinity, rec))
             return vec3(0,0,0);
 
         ray scattered;
@@ -1630,7 +1667,13 @@ And plugging it into `ray_color()`:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     vec3 ray_color(const ray& r, hittable *world, hittable *light_shape, int depth) {
         hit_record rec;
-        if (depth <= 0 || !world->hit(r, 0.001, infinity, rec))
+
+        // If we've exceeded the ray bounce limit, no more light is gathered.
+        if (depth <= 0)
+            return vec3(0,0,0);
+
+        // If the ray hits nothing, return the background color.
+        if (!world.hit(r, 0.001, infinity, rec))
             return vec3(0,0,0);
 
         ray scattered;
@@ -1813,9 +1856,14 @@ And `ray_color()` changes are small:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     vec3 ray_color(const ray& r, hittable *world, hittable *light_shape, int depth) {
         hit_record rec;
-        if (depth <= 0 || !world->hit(r, 0.001, infinity, rec))
+
+        // If we've exceeded the ray bounce limit, no more light is gathered.
+        if (depth <= 0)
             return vec3(0,0,0);
 
+        // If the ray hits nothing, return the background color.
+        if (!world.hit(r, 0.001, infinity, rec))
+            return vec3(0,0,0);
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         scatter_record srec;
@@ -1876,7 +1924,13 @@ just like it did before.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     vec3 ray_color(const ray& r, hittable *world, hittable *light_shape, int depth) {
         hit_record rec;
-        if (depth <= 0 || !world->hit(r, 0.001, infinity, rec))
+
+        // If we've exceeded the ray bounce limit, no more light is gathered.
+        if (depth <= 0)
+            return vec3(0,0,0);
+
+        // If the ray hits nothing, return the background color.
+        if (!world.hit(r, 0.001, infinity, rec))
             return vec3(0,0,0);
 
         scatter_record srec;
@@ -1910,37 +1964,46 @@ just like it did before.
 We also need to change the block to metal.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    void cornell_box(hittable **scene, camera **cam, double aspect) {
-        int i = 0;
-        hittable **list = new hittable*[8];
-        material *red = new lambertian( new constant_texture(vec3(0.65, 0.05, 0.05)) );
-        material *white = new lambertian( new constant_texture(vec3(0.73, 0.73, 0.73)) );
-        material *green = new lambertian( new constant_texture(vec3(0.12, 0.45, 0.15)) );
-        material *light = new diffuse_light( new constant_texture(vec3(15, 15, 15)) );
-        list[i++] = new flip_normals(new yz_rect(0, 555, 0, 555, 555, green));
-        list[i++] = new yz_rect(0, 555, 0, 555, 0, red);
-        list[i++] = new flip_normals(new xz_rect(213, 343, 227, 332, 554, light));
-        list[i++] = new flip_normals(new xz_rect(0, 555, 0, 555, 555, white));
-        list[i++] = new xz_rect(0, 555, 0, 555, 0, white);
-        list[i++] = new flip_normals(new xy_rect(0, 555, 0, 555, 555, white));
-        list[i++] = new translate(
-            new rotate_y(new box(vec3(0, 0, 0), vec3(165, 165, 165), white),  -18),
-            vec3(130,0,65));
+    hittable_list cornell_box(camera& cam, double aspect) {
+        hittable_list world;
+
+        auto *red   = new lambertian(new constant_texture(vec3(0.65, 0.05, 0.05)));
+        auto *white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
+        auto *green = new lambertian(new constant_texture(vec3(0.12, 0.45, 0.15)));
+        auto *light = new diffuse_light(new constant_texture(vec3(15, 15, 15)));
+
+        world.add(new flip_normals(new yz_rect(0, 555, 0, 555, 555, green)));
+        world.add(new yz_rect(0, 555, 0, 555, 0, red));
+        world.add(new xz_rect(213, 343, 227, 332, 554, light));
+        world.add(new flip_normals(new xz_rect(0, 555, 0, 555, 555, white)));
+        world.add(new xz_rect(0, 555, 0, 555, 0, white));
+        world.add(new flip_normals(new xy_rect(0, 555, 0, 555, 555, white)));
+
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         material *aluminum = new metal(vec3(0.8, 0.85, 0.88), 0.0);
-        list[i++] = new translate(
-            new rotate_y(new box(vec3(0, 0, 0), vec3(165, 330, 165), aluminum),  15),
-            vec3(265,0,295));
+        hittable* box1 = new box(vec3(0,0,0), vec3(165,330,165), aluminum);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-        *scene = new hittable_list(list,i);
+        box1 = new rotate_y(box1, 15);
+        box1 = new translate(box1, vec3(265,0,295));
+        world.add(box1);
+
+        hittable* box2 = new box(vec3(0,0,0), vec3(165,165,165), white);
+        box2 = new rotate_y(box2, -18);
+        box2 = new translate(box2, vec3(130,0,65);
+        world.add(box2);
 
         vec3 lookfrom(278, 278, -800);
-        vec3 lookat(278,278,0);
+        vec3 lookat(278, 278, 0);
+        vec3 up(0, 1, 0);
         auto dist_to_focus = 10.0;
         auto aperture = 0.0;
         auto vfov = 40.0;
-        *cam = new camera(
-            lookfrom, lookat, vec3(0,1,0), vfov, aspect, aperture, dist_to_focus, 0.0, 1.0);
+        auto t0 = 0.0;
+        auto t1 = 1.0;
+
+        cam = camera(lookfrom, lookat, up, vfov, aspect, aperture, dist_to_focus, t0, t1);
+
+        return world;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-cornell-al]: <kbd>[main.cc]</kbd> Cornell box scene with aluminum material]
@@ -2100,31 +2163,31 @@ think both tactics would work fine, but I will go with instrumenting `hittable_l
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     double hittable_list::pdf_value(const vec3& o, const vec3& v) const {
-        auto weight = 1.0/list_size;
+        auto weight = 1.0/objects.size();
         auto sum = 0.0;
-        for (int i = 0; i < list_size; i++)
-            sum += weight*list[i]->pdf_value(o, v);
+
+        for (auto object : objects)
+            sum += weight * object->pdf_value(o, v);
+
         return sum;
     }
 
     vec3 hittable_list::random(const vec3& o) const {
-        int index = random_int(0, list_size-1);
-        return list[ index ]->random(o);
+        auto int_size = static_cast<int>(objects.size());
+        auto index = static_cast<size_t>(random_int(0, int_size-1));
+        return objects[index]->random(o);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [density-mixture]: <kbd>[hittable_list.h]</kbd> Creating a mixture of densities]
 </div>
 
 <div class='together'>
-We assemble a list to pass in to `ray_color()`.
+We assemble a list to pass to `ray_color()` `from main()`:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    hittable *light_shape = new xz_rect(213, 343, 227, 332, 554, 0);
-    hittable *glass_sphere = new sphere(vec3(190, 90, 190), 90, 0);
-    hittable *a[2];
-    a[0] = light_shape;
-    a[1] = glass_sphere;
-    hittable_list hlist(a,2);
+    hittable_list lights;
+    lights.add(new xz_rect(213, 343, 227, 332, 554, 0));
+    lights.add(new sphere(vec3(190, 90, 190), 90, 0));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-density-mixture]: <kbd>[main.cc]</kbd> Updating the scene]
 </div>

--- a/src/InOneWeekend/hittable_list.h
+++ b/src/InOneWeekend/hittable_list.h
@@ -12,29 +12,39 @@
 //==============================================================================================
 
 #include "hittable.h"
+#include <vector>
 
 
 class hittable_list: public hittable  {
     public:
         hittable_list() {}
-        hittable_list(hittable **l, int n) { list = l; list_size = n; }
+        hittable_list(hittable* object) { add(object); }
+
+        void clear()               { objects.clear(); }
+        void add(hittable* object) { objects.push_back(object); }
+
         virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
-        hittable **list;
-        int list_size;
+
+    public:
+        std::vector<hittable*> objects;
 };
+
 
 bool hittable_list::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
     hit_record temp_rec;
-    bool hit_anything = false;
-    double closest_so_far = t_max;
-    for (int i = 0; i < list_size; i++) {
-        if (list[i]->hit(r, t_min, closest_so_far, temp_rec)) {
+    auto hit_anything = false;
+    auto closest_so_far = t_max;
+
+    for (auto object : objects) {
+        if (object->hit(r, t_min, closest_so_far, temp_rec)) {
             hit_anything = true;
             closest_so_far = temp_rec.t;
             rec = temp_rec;
         }
     }
+
     return hit_anything;
 }
+
 
 #endif

--- a/src/InOneWeekend/main.cc
+++ b/src/InOneWeekend/main.cc
@@ -48,7 +48,7 @@ hittable_list random_scene() {
         for (int b = -11; b < 11; b++) {
             auto choose_mat = random_double();
             vec3 center(a + 0.9*random_double(), 0.2, b + 0.9*random_double());
-            if ((center - vec3(4, .2, 0)).length() > 0.9) {
+            if ((center - vec3(4, 0.2, 0)).length() > 0.9) {
                 if (choose_mat < 0.8) {
                     // diffuse
                     auto albedo = vec3::random() * vec3::random();

--- a/src/TheNextWeek/box.h
+++ b/src/TheNextWeek/box.h
@@ -19,35 +19,35 @@
 class box: public hittable  {
     public:
         box() {}
-
         box(const vec3& p0, const vec3& p1, material *ptr);
 
         virtual bool hit(const ray& r, double t0, double t1, hit_record& rec) const;
 
         virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
-            output_box = aabb(pmin, pmax);
+            output_box = aabb(box_min, box_max);
             return true;
         }
 
-        vec3 pmin, pmax;
-        hittable *list_ptr;
+        vec3 box_min;
+        vec3 box_max;
+        hittable_list sides;
 };
 
 box::box(const vec3& p0, const vec3& p1, material *ptr) {
-    pmin = p0;
-    pmax = p1;
-    hittable **list = new hittable*[6];
-    list[0] = new xy_rect(p0.x(), p1.x(), p0.y(), p1.y(), p1.z(), ptr);
-    list[1] = new flip_normals(new xy_rect(p0.x(), p1.x(), p0.y(), p1.y(), p0.z(), ptr));
-    list[2] = new xz_rect(p0.x(), p1.x(), p0.z(), p1.z(), p1.y(), ptr);
-    list[3] = new flip_normals(new xz_rect(p0.x(), p1.x(), p0.z(), p1.z(), p0.y(), ptr));
-    list[4] = new yz_rect(p0.y(), p1.y(), p0.z(), p1.z(), p1.x(), ptr);
-    list[5] = new flip_normals(new yz_rect(p0.y(), p1.y(), p0.z(), p1.z(), p0.x(), ptr));
-    list_ptr = new hittable_list(list,6);
+    box_min = p0;
+    box_max = p1;
+
+    sides.add(new xy_rect(p0.x(), p1.x(), p0.y(), p1.y(), p1.z(), ptr));
+    sides.add(new flip_normals(new xy_rect(p0.x(), p1.x(), p0.y(), p1.y(), p0.z(), ptr)));
+    sides.add(new xz_rect(p0.x(), p1.x(), p0.z(), p1.z(), p1.y(), ptr));
+    sides.add(new flip_normals(new xz_rect(p0.x(), p1.x(), p0.z(), p1.z(), p0.y(), ptr)));
+    sides.add(new yz_rect(p0.y(), p1.y(), p0.z(), p1.z(), p1.x(), ptr));
+    sides.add(new flip_normals(new yz_rect(p0.y(), p1.y(), p0.z(), p1.z(), p0.x(), ptr)));
 }
 
 bool box::hit(const ray& r, double t0, double t1, hit_record& rec) const {
-    return list_ptr->hit(r, t0, t1, rec);
+    return sides.hit(r, t0, t1, rec);
 }
+
 
 #endif

--- a/src/TheNextWeek/bvh.h
+++ b/src/TheNextWeek/bvh.h
@@ -13,12 +13,20 @@
 
 #include "common/rtweekend.h"
 #include "hittable.h"
+#include <algorithm>
 
 
 class bvh_node : public hittable  {
     public:
-        bvh_node() {}
-        bvh_node(hittable **l, int n, double time0, double time1);
+        bvh_node() = delete;
+
+        bvh_node::bvh_node(hittable_list& list, double time0, double time1)
+            : bvh_node(list.objects, 0, list.objects.size(), time0, time1)
+        {}
+
+        bvh_node(
+            std::vector<hittable*>& objects,
+            size_t start, size_t end, double time0, double time1);
 
         virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec) const;
         virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
@@ -28,10 +36,61 @@ class bvh_node : public hittable  {
         aabb box;
 };
 
-bool bvh_node::bounding_box(double t0, double t1, aabb& output_box) const {
-    output_box = box;
-    return true;
+
+bool box_compare(const hittable* a, const hittable* b, int axis) {
+    aabb box_a;
+    aabb box_b;
+
+    if (!a->bounding_box(0,0, box_a) || !b->bounding_box(0,0, box_b))
+        std::cerr << "No bounding box in bvh_node constructor.\n";
+
+    return box_a.min().e[axis] < box_b.min().e[axis];
 }
+
+
+bool box_x_compare (const hittable* a, const hittable* b) { return box_compare(a, b, 0); }
+bool box_y_compare (const hittable* a, const hittable* b) { return box_compare(a, b, 1); }
+bool box_z_compare (const hittable* a, const hittable* b) { return box_compare(a, b, 2); }
+
+
+bvh_node::bvh_node(
+    std::vector<hittable*>& objects, size_t start, size_t end, double time0, double time1
+) {
+    int axis = random_int(0,2);
+    auto comparator = (axis == 0) ? box_x_compare
+                    : (axis == 1) ? box_y_compare
+                                  : box_z_compare;
+
+    size_t object_span = end - start;
+
+    if (object_span == 1) {
+        left = right = objects[start];
+    } else if (object_span == 2) {
+        if (comparator(objects[start], objects[start+1])) {
+            left = objects[start];
+            right = objects[start+1];
+        } else {
+            left = objects[start+1];
+            right = objects[start];
+        }
+    } else {
+        std::sort(objects.begin() + start, objects.begin() + end, comparator);
+
+        auto mid = start + object_span/2;
+        left = new bvh_node(objects, start, mid, time0, time1);
+        right = new bvh_node(objects, mid, end, time0, time1);
+    }
+
+    aabb box_left, box_right;
+
+    if (  !left->bounding_box (time0, time1, box_left)
+       || !right->bounding_box(time0, time1, box_right)
+    )
+        std::cerr << "No bounding box in bvh_node constructor.\n";
+
+    box = surrounding_box(box_left, box_right);
+}
+
 
 bool bvh_node::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
     if (!box.hit(r, t_min, t_max))
@@ -43,80 +102,11 @@ bool bvh_node::hit(const ray& r, double t_min, double t_max, hit_record& rec) co
     return hit_left || hit_right;
 }
 
-int box_x_compare (const void * a, const void * b) {
-    aabb box_left, box_right;
-    hittable *ah = *(hittable**)a;
-    hittable *bh = *(hittable**)b;
 
-    if (!ah->bounding_box(0,0, box_left) || !bh->bounding_box(0,0, box_right))
-        std::cerr << "no bounding box in bvh_node constructor\n";
-
-    if (box_left.min().x() - box_right.min().x() < 0.0)
-        return -1;
-    else
-        return 1;
+bool bvh_node::bounding_box(double t0, double t1, aabb& output_box) const {
+    output_box = box;
+    return true;
 }
 
-int box_y_compare (const void * a, const void * b)
-{
-    aabb box_left, box_right;
-    hittable *ah = *(hittable**)a;
-    hittable *bh = *(hittable**)b;
-
-    if (!ah->bounding_box(0,0, box_left) || !bh->bounding_box(0,0, box_right))
-        std::cerr << "no bounding box in bvh_node constructor\n";
-
-    if (box_left.min().y() - box_right.min().y() < 0.0)
-        return -1;
-    else
-        return 1;
-}
-
-int box_z_compare (const void * a, const void * b)
-{
-    aabb box_left, box_right;
-    hittable *ah = *(hittable**)a;
-    hittable *bh = *(hittable**)b;
-
-    if (!ah->bounding_box(0,0, box_left) || !bh->bounding_box(0,0, box_right))
-        std::cerr << "no bounding box in bvh_node constructor\n";
-
-    if (box_left.min().z() - box_right.min().z() < 0.0)
-        return -1;
-    else
-        return 1;
-}
-
-bvh_node::bvh_node(hittable **l, int n, double time0, double time1) {
-    int axis = random_int(0,2);
-
-    if (axis == 0)
-        qsort(l, n, sizeof(hittable *), box_x_compare);
-    else if (axis == 1)
-        qsort(l, n, sizeof(hittable *), box_y_compare);
-    else
-        qsort(l, n, sizeof(hittable *), box_z_compare);
-
-    if (n == 1) {
-        left = right = l[0];
-    }
-    else if (n == 2) {
-        left = l[0];
-        right = l[1];
-    }
-    else {
-        left = new bvh_node(l, n/2, time0, time1);
-        right = new bvh_node(l + n/2, n - n/2, time0, time1);
-    }
-
-    aabb box_left, box_right;
-
-    if (  !left->bounding_box (time0, time1, box_left)
-       || !right->bounding_box(time0, time1, box_right)
-    )
-        std::cerr << "no bounding box in bvh_node constructor\n";
-
-    box = surrounding_box(box_left, box_right);
-}
 
 #endif

--- a/src/TheNextWeek/bvh.h
+++ b/src/TheNextWeek/bvh.h
@@ -35,7 +35,7 @@ class bvh_node : public hittable  {
 };
 
 
-bool box_compare(const hittable* a, const hittable* b, int axis) {
+inline bool box_compare(const hittable* a, const hittable* b, int axis) {
     aabb box_a;
     aabb box_b;
 

--- a/src/TheNextWeek/bvh.h
+++ b/src/TheNextWeek/bvh.h
@@ -29,6 +29,7 @@ class bvh_node : public hittable  {
         virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec) const;
         virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
 
+    public:
         hittable *left;
         hittable *right;
         aabb box;

--- a/src/TheNextWeek/bvh.h
+++ b/src/TheNextWeek/bvh.h
@@ -18,8 +18,6 @@
 
 class bvh_node : public hittable  {
     public:
-        bvh_node() = delete;
-
         bvh_node::bvh_node(hittable_list& list, double time0, double time1)
             : bvh_node(list.objects, 0, list.objects.size(), time0, time1)
         {}

--- a/src/TheNextWeek/hittable_list.h
+++ b/src/TheNextWeek/hittable_list.h
@@ -11,34 +11,56 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
 #include "hittable.h"
+#include <vector>
 
 
 class hittable_list: public hittable  {
     public:
         hittable_list() {}
-        hittable_list(hittable **l, int n) {list = l; list_size = n; }
+        hittable_list(hittable* object) { add(object); }
+
+        void clear()               { objects.clear(); }
+        void add(hittable* object) { objects.push_back(object); }
+
         virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
         virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
 
-        hittable **list;
-        int list_size;
+    public:
+        std::vector<hittable*> objects;
 };
 
+
+bool hittable_list::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
+    hit_record temp_rec;
+    auto hit_anything = false;
+    auto closest_so_far = t_max;
+
+    for (auto object : objects) {
+        if (object->hit(r, t_min, closest_so_far, temp_rec)) {
+            hit_anything = true;
+            closest_so_far = temp_rec.t;
+            rec = temp_rec;
+        }
+    }
+
+    return hit_anything;
+}
+
+
 bool hittable_list::bounding_box(double t0, double t1, aabb& output_box) const {
-    if (list_size < 1) return false;
+    if (objects.empty()) return false;
 
     aabb temp_box;
-    bool first_true = list[0]->bounding_box(t0, t1, temp_box);
+    bool first_true = objects[0]->bounding_box(t0, t1, temp_box);
 
     if (!first_true)
         return false;
     else
         output_box = temp_box;
 
-    for (int i = 1; i < list_size; i++) {
-        if (list[i]->bounding_box(t0, t1, temp_box))
+    for (auto object : objects) {
+        if (object->bounding_box(t0, t1, temp_box))
             output_box = surrounding_box(output_box, temp_box);
         else
             return false;
@@ -47,19 +69,5 @@ bool hittable_list::bounding_box(double t0, double t1, aabb& output_box) const {
     return true;
 }
 
-bool hittable_list::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
-    hit_record temp_rec;
-    bool hit_anything = false;
-    double closest_so_far = t_max;
-
-    for (int i = 0; i < list_size; i++) {
-        if (list[i]->hit(r, t_min, closest_so_far, temp_rec)) {
-            hit_anything = true;
-            closest_so_far = temp_rec.t;
-            rec = temp_rec;
-        }
-    }
-    return hit_anything;
-}
 
 #endif

--- a/src/TheNextWeek/hittable_list.h
+++ b/src/TheNextWeek/hittable_list.h
@@ -56,14 +56,13 @@ bool hittable_list::bounding_box(double t0, double t1, aabb& output_box) const {
 
     if (!first_true)
         return false;
-    else
-        output_box = temp_box;
+
+    output_box = temp_box;
 
     for (auto object : objects) {
-        if (object->bounding_box(t0, t1, temp_box))
-            output_box = surrounding_box(output_box, temp_box);
-        else
+        if (!object->bounding_box(t0, t1, temp_box))
             return false;
+        output_box = surrounding_box(output_box, temp_box);
     }
 
     return true;

--- a/src/TheNextWeek/main.cc
+++ b/src/TheNextWeek/main.cc
@@ -20,239 +20,41 @@
 #include "material.h"
 #include "moving_sphere.h"
 #include "sphere.h"
-
 #include <iostream>
 
 
-vec3 ray_color(const ray& r, hittable *world, int depth) {
+vec3 ray_color(const ray& r, hittable& world, int depth) {
     hit_record rec;
-    if (depth <= 0 || !world->hit(r, 0.001, infinity, rec))
+
+    // If we've exceeded the ray bounce limit, no more light is gathered.
+    if (depth <= 0)
         return vec3(0,0,0);
+
+    // If the ray hits nothing, return the background color.
+    if (!world.hit(r, 0.001, infinity, rec))
+        return vec3(0.5,0.5,0.5);
 
     ray scattered;
     vec3 attenuation;
     vec3 emitted = rec.mat_ptr->emitted(rec.u, rec.v, rec.p);
+
     if (!rec.mat_ptr->scatter(r, rec, attenuation, scattered))
         return emitted;
 
     return emitted + attenuation * ray_color(scattered, world, depth-1);
 }
 
-hittable *earth() {
-    int nx, ny, nn;
-    //unsigned char *tex_data = stbi_load("tiled.jpg", &nx, &ny, &nn, 0);
-    unsigned char *tex_data = stbi_load("earthmap.jpg", &nx, &ny, &nn, 0);
-    material *mat = new lambertian(new image_texture(tex_data, nx, ny));
-    return new sphere(vec3(0, 0, 0), 2, mat);
-}
 
-hittable *two_spheres() {
-    texture *checker = new checker_texture(
-        new constant_texture(vec3(0.2,0.3, 0.1)), new constant_texture(vec3(0.9, 0.9, 0.9)));
-    size_t n = 50;
-    hittable **list = new hittable*[n+1];
-    list[0] = new sphere(vec3(0,-10, 0), 10, new lambertian(checker));
-    list[1] = new sphere(vec3(0, 10, 0), 10, new lambertian(checker));
+hittable_list random_scene() {
+    hittable_list objects;
 
-    return new hittable_list(list,2);
-}
-
-hittable *final() {
-    int nb = 20;
-    hittable **list = new hittable*[30];
-    hittable **boxlist = new hittable*[10000];
-    hittable **boxlist2 = new hittable*[10000];
-    material *white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
-    material *ground = new lambertian(new constant_texture(vec3(0.48, 0.83, 0.53)));
-    int b = 0;
-    for (int i = 0; i < nb; i++) {
-        for (int j = 0; j < nb; j++) {
-            auto w = 100.0;
-            auto x0 = -1000.0 + i*w;
-            auto z0 = -1000.0 + j*w;
-            auto y0 = 0.0;
-            auto x1 = x0 + w;
-            auto y1 = random_double(1,101);
-            auto z1 = z0 + w;
-            boxlist[b++] = new box(vec3(x0,y0,z0), vec3(x1,y1,z1), ground);
-        }
-    }
-    int l = 0;
-    list[l++] = new bvh_node(boxlist, b, 0, 1);
-    material *light = new diffuse_light(new constant_texture(vec3(7, 7, 7)));
-    list[l++] = new xz_rect(123, 423, 147, 412, 554, light);
-    vec3 center(400, 400, 200);
-    list[l++] = new moving_sphere(
-        center, center+vec3(30, 0, 0), 0, 1, 50,
-        new lambertian(new constant_texture(vec3(0.7, 0.3, 0.1)))
-    );
-    list[l++] = new sphere(vec3(260, 150, 45), 50, new dielectric(1.5));
-    list[l++] = new sphere(vec3(0, 150, 145), 50, new metal(vec3(0.8, 0.8, 0.9), 10.0));
-    hittable *boundary = new sphere(vec3(360, 150, 145), 70, new dielectric(1.5));
-    list[l++] = boundary;
-    list[l++] = new constant_medium(boundary, 0.2, new constant_texture(vec3(0.2, 0.4, 0.9)));
-    boundary = new sphere(vec3(0, 0, 0), 5000, new dielectric(1.5));
-    list[l++] = new constant_medium(boundary, .0001, new constant_texture(vec3(1.0, 1.0, 1.0)));
-    int nx, ny, nn;
-    unsigned char *tex_data = stbi_load("earthmap.jpg", &nx, &ny, &nn, 0);
-    material *emat = new lambertian(new image_texture(tex_data, nx, ny));
-    list[l++] = new sphere(vec3(400,200, 400), 100, emat);
-    texture *pertext = new noise_texture(0.1);
-    list[l++] = new sphere(vec3(220,280, 300), 80, new lambertian(pertext));
-
-    int ns = 1000;
-    for (int j = 0; j < ns; j++) {
-        boxlist2[j] = new sphere(vec3::random(0,165), 10, white);
-    }
-
-    list[l++] = new translate(
-        new rotate_y(new bvh_node(boxlist2, ns, 0.0, 1.0), 15), vec3(-100,270,395));
-
-    return new hittable_list(list,l);
-}
-
-hittable *cornell_final() {
-    hittable **list = new hittable*[30];
-    hittable **boxlist = new hittable*[10000];
-    texture *pertext = new noise_texture(0.1);
-    int nx, ny, nn;
-    unsigned char *tex_data = stbi_load("earthmap.jpg", &nx, &ny, &nn, 0);
-    material *mat = new lambertian(new image_texture(tex_data, nx, ny));
-    int i = 0;
-    material *red = new lambertian(new constant_texture(vec3(0.65, 0.05, 0.05)));
-    material *white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
-    material *green = new lambertian(new constant_texture(vec3(0.12, 0.45, 0.15)));
-    material *light = new diffuse_light(new constant_texture(vec3(7, 7, 7)));
-    //list[i++] = new sphere(vec3(260, 50, 145), 50,mat);
-    list[i++] = new flip_normals(new yz_rect(0, 555, 0, 555, 555, green));
-    list[i++] = new yz_rect(0, 555, 0, 555, 0, red);
-    list[i++] = new xz_rect(123, 423, 147, 412, 554, light);
-    list[i++] = new flip_normals(new xz_rect(0, 555, 0, 555, 555, white));
-    list[i++] = new xz_rect(0, 555, 0, 555, 0, white);
-    list[i++] = new flip_normals(new xy_rect(0, 555, 0, 555, 555, white));
-    /*
-    hittable *boundary = new sphere(vec3(160, 50, 345), 50, new dielectric(1.5));
-    list[i++] = boundary;
-    list[i++] = new constant_medium(boundary, 0.2, new constant_texture(vec3(0.2, 0.4, 0.9)));
-    list[i++] = new sphere(vec3(460, 50, 105), 50, new dielectric(1.5));
-    list[i++] = new sphere(vec3(120, 50, 205), 50, new lambertian(pertext));
-    int ns = 10000;
-    for (int j = 0; j < ns; j++) {
-        boxlist[j] = new sphere(
-            vec3(random_double(0,165), random_double(0,330), random_double(0,165)), 10, white);
-    }
-    list[i++] = new translate(
-        new rotate_y(new bvh_node(boxlist, ns, 0.0, 1.0), 15), vec3(265,0,295));
-    */
-    hittable *boundary2 = new translate(
-        new rotate_y(new box(vec3(0, 0, 0), vec3(165, 165, 165), new dielectric(1.5)), -18),
-        vec3(130,0,65)
-    );
-    list[i++] = boundary2;
-    list[i++] = new constant_medium(boundary2, 0.2, new constant_texture(vec3(0.9, 0.9, 0.9)));
-    return new hittable_list(list,i);
-}
-
-hittable *cornell_balls() {
-    hittable **list = new hittable*[9];
-    int i = 0;
-    material *red = new lambertian(new constant_texture(vec3(0.65, 0.05, 0.05)));
-    material *white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
-    material *green = new lambertian(new constant_texture(vec3(0.12, 0.45, 0.15)));
-    material *light = new diffuse_light(new constant_texture(vec3(5, 5, 5)));
-    list[i++] = new flip_normals(new yz_rect(0, 555, 0, 555, 555, green));
-    list[i++] = new yz_rect(0, 555, 0, 555, 0, red);
-    list[i++] = new xz_rect(113, 443, 127, 432, 554, light);
-    list[i++] = new flip_normals(new xz_rect(0, 555, 0, 555, 555, white));
-    list[i++] = new xz_rect(0, 555, 0, 555, 0, white);
-    list[i++] = new flip_normals(new xy_rect(0, 555, 0, 555, 555, white));
-    hittable *boundary = new sphere(vec3(160, 100, 145), 100, new dielectric(1.5));
-    list[i++] = boundary;
-    list[i++] = new constant_medium(boundary, 0.1, new constant_texture(vec3(1.0, 1.0, 1.0)));
-    list[i++] = new translate(
-        new rotate_y(new box(vec3(0, 0, 0), vec3(165, 330, 165), white), 15),
-        vec3(265,0,295)
-    );
-    return new hittable_list(list,i);
-}
-
-hittable *cornell_smoke() {
-    hittable **list = new hittable*[8];
-    int i = 0;
-    material *red = new lambertian(new constant_texture(vec3(0.65, 0.05, 0.05)));
-    material *white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
-    material *green = new lambertian(new constant_texture(vec3(0.12, 0.45, 0.15)));
-    material *light = new diffuse_light(new constant_texture(vec3(7, 7, 7)));
-    list[i++] = new flip_normals(new yz_rect(0, 555, 0, 555, 555, green));
-    list[i++] = new yz_rect(0, 555, 0, 555, 0, red);
-    list[i++] = new xz_rect(113, 443, 127, 432, 554, light);
-    list[i++] = new flip_normals(new xz_rect(0, 555, 0, 555, 555, white));
-    list[i++] = new xz_rect(0, 555, 0, 555, 0, white);
-    list[i++] = new flip_normals(new xy_rect(0, 555, 0, 555, 555, white));
-    hittable *b1 = new translate(
-        new rotate_y(new box(vec3(0, 0, 0), vec3(165, 165, 165), white), -18),
-        vec3(130,0,65)
-    );
-    hittable *b2 = new translate(
-        new rotate_y(new box(vec3(0, 0, 0), vec3(165, 330, 165), white),  15),
-        vec3(265,0,295)
-    );
-    list[i++] = new constant_medium(b1, 0.01, new constant_texture(vec3(1.0, 1.0, 1.0)));
-    list[i++] = new constant_medium(b2, 0.01, new constant_texture(vec3(0.0, 0.0, 0.0)));
-    return new hittable_list(list,i);
-}
-
-hittable *cornell_box() {
-    hittable **list = new hittable*[8];
-    int i = 0;
-    material *red = new lambertian(new constant_texture(vec3(0.65, 0.05, 0.05)));
-    material *white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
-    material *green = new lambertian(new constant_texture(vec3(0.12, 0.45, 0.15)));
-    material *light = new diffuse_light(new constant_texture(vec3(15, 15, 15)));
-    list[i++] = new flip_normals(new yz_rect(0, 555, 0, 555, 555, green));
-    list[i++] = new yz_rect(0, 555, 0, 555, 0, red);
-    list[i++] = new xz_rect(213, 343, 227, 332, 554, light);
-    list[i++] = new flip_normals(new xz_rect(0, 555, 0, 555, 555, white));
-    list[i++] = new xz_rect(0, 555, 0, 555, 0, white);
-    list[i++] = new flip_normals(new xy_rect(0, 555, 0, 555, 555, white));
-    list[i++] = new translate(
-        new rotate_y(new box(vec3(0, 0, 0), vec3(165, 165, 165), white), -18),
-        vec3(130,0,65)
-    );
-    list[i++] = new translate(
-        new rotate_y(new box(vec3(0, 0, 0), vec3(165, 330, 165), white),  15),
-        vec3(265,0,295)
-    );
-    return new hittable_list(list,i);
-}
-
-hittable *two_perlin_spheres() {
-    texture *pertext = new noise_texture(4);
-    hittable **list = new hittable*[2];
-    list[0] = new sphere(vec3(0,-1000, 0), 1000, new lambertian(pertext));
-    list[1] = new sphere(vec3(0, 2, 0), 2, new lambertian(pertext));
-    return new hittable_list(list,2);
-}
-
-hittable *simple_light() {
-    texture *pertext = new noise_texture(4);
-    hittable **list = new hittable*[4];
-    list[0] = new sphere(vec3(0,-1000, 0), 1000, new lambertian(pertext));
-    list[1] = new sphere(vec3(0,2,0), 2, new lambertian(pertext));
-    list[2] = new sphere(vec3(0,7,0), 2, new diffuse_light(new constant_texture(vec3(4,4,4))));
-    list[3] = new xy_rect(3, 5, 1, 3, -2, new diffuse_light(new constant_texture(vec3(4,4,4))));
-    return new hittable_list(list,4);
-}
-
-hittable *random_scene() {
-    size_t n = 50000;
-    hittable **list = new hittable*[n+1];
     texture *checker = new checker_texture(
         new constant_texture(vec3(0.2, 0.3, 0.1)),
         new constant_texture(vec3(0.9, 0.9, 0.9))
     );
-    list[0] = new sphere(vec3(0,-1000,0), 1000, new lambertian(checker));
-    int i = 1;
+
+    objects.add(new sphere(vec3(0,-1000,0), 1000, new lambertian(checker)));
+
     for (int a = -10; a < 10; a++) {
         for (int b = -10; b < 10; b++) {
             auto choose_mat = random_double();
@@ -261,31 +63,264 @@ hittable *random_scene() {
                 if (choose_mat < 0.8) {
                     // diffuse
                     auto albedo = vec3::random() * vec3::random();
-                    list[i++] = new moving_sphere(
+                    objects.add(new moving_sphere(
                         center, center + vec3(0, random_double(0,.5), 0), 0.0, 1.0, 0.2,
                         new lambertian(new constant_texture(albedo))
-                    );
+                    ));
                 } else if (choose_mat < 0.95) {
                     // metal
                     auto albedo = vec3::random(.5, 1);
                     auto fuzz = random_double(0, .5);
-                    list[i++] = new sphere(center, 0.2, new metal(albedo, fuzz));
+                    objects.add(new sphere(center, 0.2, new metal(albedo, fuzz)));
                 } else {
                     // glass
-                    list[i++] = new sphere(center, 0.2, new dielectric(1.5));
+                    objects.add(new sphere(center, 0.2, new dielectric(1.5)));
                 }
             }
         }
     }
 
-    list[i++] = new sphere(vec3(0, 1, 0), 1.0, new dielectric(1.5));
-    list[i++] = new sphere(
-        vec3(-4, 1, 0), 1.0, new lambertian(new constant_texture(vec3(0.4, 0.2, 0.1))));
-    list[i++] = new sphere(vec3(4, 1, 0), 1.0, new metal(vec3(0.7, 0.6, 0.5), 0.0));
+    objects.add(new sphere(vec3(0, 1, 0), 1.0, new dielectric(1.5)));
+    objects.add(new sphere(
+        vec3(-4, 1, 0), 1.0, new lambertian(new constant_texture(vec3(0.4, 0.2, 0.1)))));
+    objects.add(new sphere(vec3(4, 1, 0), 1.0, new metal(vec3(0.7, 0.6, 0.5), 0.0)));
 
-    //return new hittable_list(list,i);
-    return new bvh_node(list, i, 0.0, 1.0);
+    return new bvh_node(objects, 0.0, 1.0);
 }
+
+
+hittable_list two_spheres() {
+    hittable_list objects;
+
+    texture *checker = new checker_texture(
+        new constant_texture(vec3(0.2,0.3, 0.1)), new constant_texture(vec3(0.9, 0.9, 0.9)));
+
+    objects.add(new sphere(vec3(0,-10, 0), 10, new lambertian(checker)));
+    objects.add(new sphere(vec3(0, 10, 0), 10, new lambertian(checker)));
+
+    return objects;
+}
+
+
+hittable_list two_perlin_spheres() {
+    hittable_list objects;
+
+    texture *pertext = new noise_texture(4);
+    objects.add(new sphere(vec3(0,-1000, 0), 1000, new lambertian(pertext)));
+    objects.add(new sphere(vec3(0, 2, 0), 2, new lambertian(pertext)));
+
+    return objects;
+}
+
+
+hittable_list earth() {
+    int nx, ny, nn;
+    unsigned char *texture_data = stbi_load("earthmap.jpg", &nx, &ny, &nn, 0);
+
+    auto earth_surface = new lambertian(new image_texture(texture_data, nx, ny));
+    auto globe = new sphere(vec3(0,0,0), 2, earth_surface);
+
+    return hittable_list(globe);
+}
+
+
+hittable_list simple_light() {
+    hittable_list objects;
+
+    auto pertext = new noise_texture(4);
+    objects.add(new sphere(vec3(0,-1000, 0), 1000, new lambertian(pertext)));
+    objects.add(new sphere(vec3(0,2,0), 2, new lambertian(pertext)));
+
+    auto difflight = new diffuse_light(new constant_texture(vec3(4,4,4)));
+    objects.add(new sphere(vec3(0,7,0), 2, difflight));
+    objects.add(new xy_rect(3, 5, 1, 3, -2, difflight));
+
+    return objects;
+}
+
+
+hittable_list cornell_box() {
+    hittable_list objects;
+
+    auto red = new lambertian(new constant_texture(vec3(0.65, 0.05, 0.05)));
+    auto white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
+    auto green = new lambertian(new constant_texture(vec3(0.12, 0.45, 0.15)));
+    auto light = new diffuse_light(new constant_texture(vec3(15, 15, 15)));
+
+    objects.add(new flip_normals(new yz_rect(0, 555, 0, 555, 555, green)));
+    objects.add(new yz_rect(0, 555, 0, 555, 0, red));
+    objects.add(new xz_rect(213, 343, 227, 332, 554, light));
+    objects.add(new flip_normals(new xz_rect(0, 555, 0, 555, 555, white)));
+    objects.add(new xz_rect(0, 555, 0, 555, 0, white));
+    objects.add(new flip_normals(new xy_rect(0, 555, 0, 555, 555, white)));
+
+    hittable* box1 = new box(vec3(0, 0, 0), vec3(165, 330, 165), white);
+    box1 = new rotate_y(box1,  15);
+    box1 = new translate(box1, vec3(265,0,295));
+    objects.add(box1);
+
+    hittable* box2 = new box(vec3(0,0,0), vec3(165,165,165), white);
+    box2 = new rotate_y(box2, -18);
+    box2 = new translate(box2, vec3(130,0,65));
+    objects.add(box2);
+
+    return objects;
+}
+
+
+hittable_list cornell_balls() {
+    hittable_list objects;
+
+    auto red = new lambertian(new constant_texture(vec3(0.65, 0.05, 0.05)));
+    auto white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
+    auto green = new lambertian(new constant_texture(vec3(0.12, 0.45, 0.15)));
+    auto light = new diffuse_light(new constant_texture(vec3(5, 5, 5)));
+
+    objects.add(new flip_normals(new yz_rect(0, 555, 0, 555, 555, green)));
+    objects.add(new yz_rect(0, 555, 0, 555, 0, red));
+    objects.add(new xz_rect(113, 443, 127, 432, 554, light));
+    objects.add(new flip_normals(new xz_rect(0, 555, 0, 555, 555, white)));
+    objects.add(new xz_rect(0, 555, 0, 555, 0, white));
+    objects.add(new flip_normals(new xy_rect(0, 555, 0, 555, 555, white)));
+
+    hittable* boundary = new sphere(vec3(160, 100, 145), 100, new dielectric(1.5));
+    objects.add(boundary);
+    objects.add(new constant_medium(boundary, 0.1, new constant_texture(vec3(1.0, 1.0, 1.0))));
+
+    hittable* box1 = new box(vec3(0, 0, 0), vec3(165, 330, 165), white);
+    box1 = new rotate_y(box1, 15);
+    box1 = new translate(box1, vec3(265,0,295));
+    objects.add(box1);
+
+    return objects;
+}
+
+
+hittable_list cornell_smoke() {
+    hittable_list objects;
+
+    auto red = new lambertian(new constant_texture(vec3(0.65, 0.05, 0.05)));
+    auto white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
+    auto green = new lambertian(new constant_texture(vec3(0.12, 0.45, 0.15)));
+    auto light = new diffuse_light(new constant_texture(vec3(7, 7, 7)));
+
+    objects.add(new flip_normals(new yz_rect(0, 555, 0, 555, 555, green)));
+    objects.add(new yz_rect(0, 555, 0, 555, 0, red));
+    objects.add(new xz_rect(113, 443, 127, 432, 554, light));
+    objects.add(new flip_normals(new xz_rect(0, 555, 0, 555, 555, white)));
+    objects.add(new xz_rect(0, 555, 0, 555, 0, white));
+    objects.add(new flip_normals(new xy_rect(0, 555, 0, 555, 555, white)));
+
+    hittable* box1 = new box(vec3(0,0,0), vec3(165,330,165), white);
+    box1 = new rotate_y(box1,  15);
+    box1 = new translate(box1, vec3(265,0,295));
+
+    hittable* box2 = new box(vec3(0,0,0), vec3(165,165,165), white);
+    box2 = new rotate_y(box2, -18);
+    box2 = new translate(box2, vec3(130,0,65));
+
+    objects.add(new constant_medium(box1, 0.01, new constant_texture(vec3(0,0,0))));
+    objects.add(new constant_medium(box2, 0.01, new constant_texture(vec3(1,1,1))));
+
+    return objects;
+}
+
+
+hittable_list cornell_final() {
+    hittable_list objects;
+
+    texture* pertext = new noise_texture(0.1);
+
+    int nx, ny, nn;
+    unsigned char* tex_data = stbi_load("earthmap.jpg", &nx, &ny, &nn, 0);
+
+    auto mat = new lambertian(new image_texture(tex_data, nx, ny));
+
+    auto red = new lambertian(new constant_texture(vec3(0.65, 0.05, 0.05)));
+    auto white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
+    auto green = new lambertian(new constant_texture(vec3(0.12, 0.45, 0.15)));
+    auto light = new diffuse_light(new constant_texture(vec3(7, 7, 7)));
+
+    objects.add(new flip_normals(new yz_rect(0, 555, 0, 555, 555, green)));
+    objects.add(new yz_rect(0, 555, 0, 555, 0, red));
+    objects.add(new xz_rect(123, 423, 147, 412, 554, light));
+    objects.add(new flip_normals(new xz_rect(0, 555, 0, 555, 555, white)));
+    objects.add(new xz_rect(0, 555, 0, 555, 0, white));
+    objects.add(new flip_normals(new xy_rect(0, 555, 0, 555, 555, white)));
+
+    hittable* boundary2 = new box(vec3(0,0,0), vec3(165,165,165), new dielectric(1.5));
+    boundary2 = new rotate_y(boundary2, -18);
+    boundary2 = new translate(boundary2, vec3(130,0,65));
+
+    auto tex = new constant_texture(vec3(0.9, 0.9, 0.9));
+
+    objects.add(boundary2);
+    objects.add(new constant_medium(boundary2, 0.2, tex));
+
+    return objects;
+}
+
+
+hittable_list final_scene() {
+    hittable_list boxes1;
+    auto ground = new lambertian(new constant_texture(vec3(0.48, 0.83, 0.53)));
+
+    const int boxes_per_side = 20;
+    for (int i = 0; i < boxes_per_side; i++) {
+        for (int j = 0; j < boxes_per_side; j++) {
+            auto w = 100.0;
+            auto x0 = -1000.0 + i*w;
+            auto z0 = -1000.0 + j*w;
+            auto y0 = 0.0;
+            auto x1 = x0 + w;
+            auto y1 = random_double(1,101);
+            auto z1 = z0 + w;
+
+            boxes1.add(new box(vec3(x0,y0,z0), vec3(x1,y1,z1), ground));
+        }
+    }
+
+    hittable_list objects;
+
+    objects.add(new bvh_node(boxes1, 0, 1));
+
+    material *light = new diffuse_light(new constant_texture(vec3(7, 7, 7)));
+    objects.add(new xz_rect(123, 423, 147, 412, 554, light));
+
+    auto center1 = vec3(400, 400, 200);
+    auto center2 = center1 + vec3(30,0,0);
+    auto moving_sphere_material = new lambertian(new constant_texture(vec3(0.7, 0.3, 0.1)));
+    objects.add(new moving_sphere(center1, center2, 0, 1, 50, moving_sphere_material));
+
+    objects.add(new sphere(vec3(260, 150, 45), 50, new dielectric(1.5)));
+    objects.add(new sphere(vec3(0, 150, 145), 50, new metal(vec3(0.8, 0.8, 0.9), 10.0)));
+
+    hittable *boundary = new sphere(vec3(360, 150, 145), 70, new dielectric(1.5));
+    objects.add(boundary);
+    objects.add(new constant_medium(boundary, 0.2, new constant_texture(vec3(0.2, 0.4, 0.9))));
+    boundary = new sphere(vec3(0, 0, 0), 5000, new dielectric(1.5));
+    objects.add(new constant_medium(boundary, .0001, new constant_texture(vec3(1,1,1))));
+
+    int nx, ny, nn;
+    unsigned char *tex_data = stbi_load("earthmap.jpg", &nx, &ny, &nn, 0);
+    material *emat = new lambertian(new image_texture(tex_data, nx, ny));
+    objects.add(new sphere(vec3(400,200, 400), 100, emat));
+    texture *pertext = new noise_texture(0.1);
+    objects.add(new sphere(vec3(220,280, 300), 80, new lambertian(pertext)));
+
+    hittable_list boxes2;
+    auto white = new lambertian(new constant_texture(vec3(0.73, 0.73, 0.73)));
+    int ns = 1000;
+    for (int j = 0; j < ns; j++) {
+        boxes2.add(new sphere(vec3::random(0,165), 10, white));
+    }
+
+    objects.add(new translate(
+        new rotate_y(new bvh_node(boxes2, 0.0, 1.0), 15), vec3(-100,270,395)));
+
+    return objects;
+}
+
 
 int main() {
     int nx = 600;
@@ -296,16 +331,23 @@ int main() {
     std::cout << "P3\n" << nx << ' ' << ny << "\n255\n";
 
     auto R = cos(pi/4);
-    //hittable *world = random_scene();
-    //hittable *world = two_spheres();
-    //hittable *world = two_perlin_spheres();
-    //hittable *world = earth();
-    //hittable *world = simple_light();
-    hittable *world = cornell_box();
-    //hittable *world = cornell_balls();
-    //hittable *world = cornell_smoke();
-    //hittable *world = cornell_final();
-    //hittable *world = final();
+
+    hittable_list world;
+    switch (5) {
+        case 0:  world = random_scene();       break;
+        case 1:  world = two_spheres();        break;
+        case 2:  world = two_perlin_spheres(); break;
+        case 3:  world = earth();              break;
+        case 4:  world = simple_light();       break;
+
+        default:
+        case 5:  world = cornell_box();        break;
+
+        case 6:  world = cornell_balls();      break;
+        case 7:  world = cornell_smoke();      break;
+        case 8:  world = cornell_final();      break;
+        case 9:  world = final_scene();        break;
+    }
 
     vec3 lookfrom(278, 278, -800);
     //vec3 lookfrom(478, 278, -600);

--- a/src/TheRestOfYourLife/box.h
+++ b/src/TheRestOfYourLife/box.h
@@ -19,35 +19,35 @@
 class box: public hittable  {
     public:
         box() {}
-
         box(const vec3& p0, const vec3& p1, material *ptr);
 
         virtual bool hit(const ray& r, double t0, double t1, hit_record& rec) const;
 
         virtual bool bounding_box(double t0, double t1, aabb& output_box) const {
-            output_box = aabb(pmin, pmax);
+            output_box = aabb(box_min, box_max);
             return true;
         }
 
-        vec3 pmin, pmax;
-        hittable *list_ptr;
+        vec3 box_min;
+        vec3 box_max;
+        hittable_list sides;
 };
 
 box::box(const vec3& p0, const vec3& p1, material *ptr) {
-    pmin = p0;
-    pmax = p1;
-    hittable **list = new hittable*[6];
-    list[0] = new xy_rect(p0.x(), p1.x(), p0.y(), p1.y(), p1.z(), ptr);
-    list[1] = new flip_normals(new xy_rect(p0.x(), p1.x(), p0.y(), p1.y(), p0.z(), ptr));
-    list[2] = new xz_rect(p0.x(), p1.x(), p0.z(), p1.z(), p1.y(), ptr);
-    list[3] = new flip_normals(new xz_rect(p0.x(), p1.x(), p0.z(), p1.z(), p0.y(), ptr));
-    list[4] = new yz_rect(p0.y(), p1.y(), p0.z(), p1.z(), p1.x(), ptr);
-    list[5] = new flip_normals(new yz_rect(p0.y(), p1.y(), p0.z(), p1.z(), p0.x(), ptr));
-    list_ptr = new hittable_list(list,6);
+    box_min = p0;
+    box_max = p1;
+
+    sides.add(new xy_rect(p0.x(), p1.x(), p0.y(), p1.y(), p1.z(), ptr));
+    sides.add(new flip_normals(new xy_rect(p0.x(), p1.x(), p0.y(), p1.y(), p0.z(), ptr)));
+    sides.add(new xz_rect(p0.x(), p1.x(), p0.z(), p1.z(), p1.y(), ptr));
+    sides.add(new flip_normals(new xz_rect(p0.x(), p1.x(), p0.z(), p1.z(), p0.y(), ptr)));
+    sides.add(new yz_rect(p0.y(), p1.y(), p0.z(), p1.z(), p1.x(), ptr));
+    sides.add(new flip_normals(new yz_rect(p0.y(), p1.y(), p0.z(), p1.z(), p0.x(), ptr)));
 }
 
 bool box::hit(const ray& r, double t0, double t1, hit_record& rec) const {
-    return list_ptr->hit(r, t0, t1, rec);
+    return sides.hit(r, t0, t1, rec);
 }
+
 
 #endif

--- a/src/TheRestOfYourLife/bvh.h
+++ b/src/TheRestOfYourLife/bvh.h
@@ -35,7 +35,7 @@ class bvh_node : public hittable  {
 };
 
 
-bool box_compare(const hittable *a, const hittable *b, int axis) {
+inline bool box_compare(const hittable *a, const hittable *b, int axis) {
     aabb box_a;
     aabb box_b;
 

--- a/src/TheRestOfYourLife/bvh.h
+++ b/src/TheRestOfYourLife/bvh.h
@@ -13,12 +13,20 @@
 
 #include "common/rtweekend.h"
 #include "hittable.h"
+#include <algorithm>
 
 
 class bvh_node : public hittable  {
     public:
-        bvh_node() {}
-        bvh_node(hittable **l, int n, double time0, double time1);
+        bvh_node() = delete;
+
+        bvh_node::bvh_node(hittable_list &list, double time0, double time1)
+            : bvh_node(list.objects, 0, 0, time0, time1)
+        {}
+
+        bvh_node(
+            std::vector<hittable*> &objects,
+            size_t start, size_t end, double time0, double time1);
 
         virtual bool hit(const ray& r, double t_min, double t_max, hit_record& rec) const;
         virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
@@ -28,10 +36,66 @@ class bvh_node : public hittable  {
         aabb box;
 };
 
-bool bvh_node::bounding_box(double t0, double t1, aabb& output_box) const {
-    output_box = box;
-    return true;
+
+bool box_compare(const hittable *a, const hittable *b, int axis) {
+    aabb box_a;
+    aabb box_b;
+
+    if (!a->bounding_box(0,0, box_a) || !b->bounding_box(0,0, box_b))
+        std::cerr << "No bounding box in bvh_node constructor.\n";
+
+    return box_a.min().e[axis] < box_b.min().e[axis];
 }
+
+
+bool box_x_compare (const hittable *a, const hittable *b) { return box_compare(a, b, 0); }
+bool box_y_compare (const hittable *a, const hittable *b) { return box_compare(a, b, 1); }
+bool box_z_compare (const hittable *a, const hittable *b) { return box_compare(a, b, 2); }
+
+
+bvh_node::bvh_node(
+    std::vector<hittable*> &objects, size_t start, size_t end, double time0, double time1
+) {
+    if (end <= start) {
+        start = 0;
+        end = objects.size();
+    }
+
+    size_t object_span = end - start;
+
+    int axis = random_int(0,2);
+    auto comparator = (axis == 0) ? box_x_compare
+                    : (axis == 1) ? box_y_compare
+                                  : box_z_compare;
+
+    if (object_span == 1) {
+        left = right = objects[start];
+    } else if (object_span == 2) {
+        if (comparator(objects[start], objects[start+1])) {
+            left = objects[start];
+            right = objects[start+1];
+        } else {
+            left = objects[start+1];
+            right = objects[start];
+        }
+    } else {
+        std::sort(objects.begin() + start, objects.begin() + end, comparator);
+
+        auto mid = start + object_span/2;
+        left = new bvh_node(objects, start, mid, time0, time1);
+        right = new bvh_node(objects, mid, end, time0, time1);
+    }
+
+    aabb box_left, box_right;
+
+    if (  !left->bounding_box (time0, time1, box_left)
+       || !right->bounding_box(time0, time1, box_right)
+    )
+        std::cerr << "No bounding box in bvh_node constructor.\n";
+
+    box = surrounding_box(box_left, box_right);
+}
+
 
 bool bvh_node::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
     if (!box.hit(r, t_min, t_max))
@@ -43,116 +107,11 @@ bool bvh_node::hit(const ray& r, double t_min, double t_max, hit_record& rec) co
     return hit_left || hit_right;
 }
 
-int box_x_compare (const void * a, const void * b) {
-    aabb box_left, box_right;
-    hittable *ah = *(hittable**)a;
-    hittable *bh = *(hittable**)b;
 
-    if (!ah->bounding_box(0,0, box_left) || !bh->bounding_box(0,0, box_right))
-        std::cerr << "no bounding box in bvh_node constructor\n";
-
-    if (box_left.min().x() - box_right.min().x() < 0.0)
-        return -1;
-    else
-        return 1;
+bool bvh_node::bounding_box(double t0, double t1, aabb& output_box) const {
+    output_box = box;
+    return true;
 }
 
-int box_y_compare (const void * a, const void * b)
-{
-    aabb box_left, box_right;
-    hittable *ah = *(hittable**)a;
-    hittable *bh = *(hittable**)b;
-
-    if (!ah->bounding_box(0,0, box_left) || !bh->bounding_box(0,0, box_right))
-        std::cerr << "no bounding box in bvh_node constructor\n";
-
-    if (box_left.min().y() - box_right.min().y() < 0.0)
-        return -1;
-    else
-        return 1;
-}
-
-int box_z_compare (const void * a, const void * b)
-{
-    aabb box_left, box_right;
-    hittable *ah = *(hittable**)a;
-    hittable *bh = *(hittable**)b;
-
-    if (!ah->bounding_box(0,0, box_left) || !bh->bounding_box(0,0, box_right))
-        std::cerr << "no bounding box in bvh_node constructor\n";
-
-    if (box_left.min().z() - box_right.min().z() < 0.0)
-        return -1;
-    else
-        return 1;
-}
-
-bvh_node::bvh_node(hittable **l, int n, double time0, double time1) {
-    aabb *boxes = new aabb[n];
-    auto *left_area = new double[n];
-    auto *right_area = new double[n];
-    aabb main_box;
-    bool dummy = l[0]->bounding_box(time0, time1, main_box);
-    for (int i = 1; i < n; i++) {
-        aabb new_box;
-        bool dummy = l[i]->bounding_box(time0, time1, new_box);
-        main_box = surrounding_box(new_box, main_box);
-    }
-    int axis = main_box.longest_axis();
-    if (axis == 0)
-        qsort(l, n, sizeof(hittable *), box_x_compare);
-    else if (axis == 1)
-        qsort(l, n, sizeof(hittable *), box_y_compare);
-    else
-        qsort(l, n, sizeof(hittable *), box_z_compare);
-    for (int i = 0; i < n; i++)
-        bool dummy = l[i]->bounding_box(time0, time1, boxes[i]);
-    left_area[0] = boxes[0].area();
-    aabb left_box = boxes[0];
-    for (int i = 1; i < n-1; i++) {
-        left_box = surrounding_box(left_box, boxes[i]);
-        left_area[i] = left_box.area();
-    }
-    right_area[n-1] = boxes[n-1].area();
-    aabb right_box = boxes[n-1];
-    for (int i = n-2; i > 0; i--) {
-        right_box = surrounding_box(right_box, boxes[i]);
-        right_area[i] = right_box.area();
-    }
-    auto min_SAH = infinity;
-    int min_SAH_idx;
-    for (int i = 0; i < n-1; i++) {
-        auto SAH = i*left_area[i] + (n-i-1)*right_area[i+1];
-        if (SAH < min_SAH) {
-            min_SAH_idx = i;
-            min_SAH = SAH;
-        }
-    }
-
-    /*
-    if (min_SAH_idx == 0)
-        left = l[0];
-    else
-        left = new bvh_node(l, min_SAH_idx+1, time0, time1);
-    if (min_SAH_idx == n-2)
-        right = l[min_SAH_idx+1];
-    else
-        right = new bvh_node(l + min_SAH_idx+1, n - min_SAH_idx -1, time0, time1);
-    */
-
-    if (n == 1) {
-        left = right = l[0];
-    }
-    else if (n == 2) {
-        left = l[0];
-        right = l[1];
-    }
-    else {
-        left = new bvh_node(l, n/2, time0, time1);
-        right = new bvh_node(l + n/2, n - n/2, time0, time1);
-    }
-
-    box = main_box;
-}
 
 #endif

--- a/src/TheRestOfYourLife/bvh.h
+++ b/src/TheRestOfYourLife/bvh.h
@@ -52,19 +52,14 @@ bool box_z_compare (const hittable *a, const hittable *b) { return box_compare(a
 
 
 bvh_node::bvh_node(
-    std::vector<hittable*> &objects, size_t start, size_t end, double time0, double time1
+    std::vector<hittable*>& objects, size_t start, size_t end, double time0, double time1
 ) {
-    if (end <= start) {
-        start = 0;
-        end = objects.size();
-    }
-
-    size_t object_span = end - start;
-
     int axis = random_int(0,2);
     auto comparator = (axis == 0) ? box_x_compare
                     : (axis == 1) ? box_y_compare
                                   : box_z_compare;
+
+    size_t object_span = end - start;
 
     if (object_span == 1) {
         left = right = objects[start];

--- a/src/TheRestOfYourLife/bvh.h
+++ b/src/TheRestOfYourLife/bvh.h
@@ -18,8 +18,6 @@
 
 class bvh_node : public hittable  {
     public:
-        bvh_node() = delete;
-
         bvh_node::bvh_node(hittable_list &list, double time0, double time1)
             : bvh_node(list.objects, 0, 0, time0, time1)
         {}

--- a/src/TheRestOfYourLife/hittable_list.h
+++ b/src/TheRestOfYourLife/hittable_list.h
@@ -11,50 +11,58 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
 #include "hittable.h"
+#include <vector>
 
 
 class hittable_list: public hittable  {
     public:
         hittable_list() {}
-        hittable_list(hittable **l, int n) {list = l; list_size = n; }
+        hittable_list(hittable* object) { add(object); }
+
+        void clear()               { objects.clear(); }
+        void add(hittable* object) { objects.push_back(object); }
+
         virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
         virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
-        virtual double pdf_value(const vec3& o, const vec3& v) const;
-        virtual vec3 random(const vec3& o) const;
+        virtual double pdf_value(const vec3 &o, const vec3 &v) const;
+        virtual vec3 random(const vec3 &o) const;
 
-        hittable **list;
-        int list_size;
+    public:
+        std::vector<hittable*> objects;
 };
 
-double hittable_list::pdf_value(const vec3& o, const vec3& v) const {
-    auto weight = 1.0/list_size;
-    auto sum = 0.0;
-    for (int i = 0; i < list_size; i++)
-        sum += weight*list[i]->pdf_value(o, v);
-    return sum;
-}
 
-vec3 hittable_list::random(const vec3& o) const {
-    int index = random_int(0, list_size-1);
-    return list[ index ]->random(o);
+bool hittable_list::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
+    hit_record temp_rec;
+    auto hit_anything = false;
+    auto closest_so_far = t_max;
+
+    for (auto object : objects) {
+        if (object->hit(r, t_min, closest_so_far, temp_rec)) {
+            hit_anything = true;
+            closest_so_far = temp_rec.t;
+            rec = temp_rec;
+        }
+    }
+
+    return hit_anything;
 }
 
 
 bool hittable_list::bounding_box(double t0, double t1, aabb& output_box) const {
-    if (list_size < 1) return false;
+    if (objects.empty()) return false;
 
     aabb temp_box;
-    bool first_true = list[0]->bounding_box(t0, t1, temp_box);
+    bool first_true = objects[0]->bounding_box(t0, t1, temp_box);
 
     if (!first_true)
         return false;
     else
         output_box = temp_box;
 
-    for (int i = 1; i < list_size; i++) {
-        if (list[i]->bounding_box(t0, t1, temp_box))
+    for (auto object : objects) {
+        if (object->bounding_box(t0, t1, temp_box))
             output_box = surrounding_box(output_box, temp_box);
         else
             return false;
@@ -63,19 +71,23 @@ bool hittable_list::bounding_box(double t0, double t1, aabb& output_box) const {
     return true;
 }
 
-bool hittable_list::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
-    hit_record temp_rec;
-    bool hit_anything = false;
-    double closest_so_far = t_max;
 
-    for (int i = 0; i < list_size; i++) {
-        if (list[i]->hit(r, t_min, closest_so_far, temp_rec)) {
-            hit_anything = true;
-            closest_so_far = temp_rec.t;
-            rec = temp_rec;
-        }
-    }
-    return hit_anything;
+double hittable_list::pdf_value(const vec3& o, const vec3& v) const {
+    auto weight = 1.0/objects.size();
+    auto sum = 0.0;
+
+    for (auto object : objects)
+        sum += weight * object->pdf_value(o, v);
+
+    return sum;
 }
+
+
+vec3 hittable_list::random(const vec3 &o) const {
+    auto int_size = static_cast<int>(objects.size());
+    auto index = static_cast<size_t>(random_int(0, int_size-1));
+    return objects[index]->random(o);
+}
+
 
 #endif

--- a/src/TheRestOfYourLife/hittable_list.h
+++ b/src/TheRestOfYourLife/hittable_list.h
@@ -58,14 +58,13 @@ bool hittable_list::bounding_box(double t0, double t1, aabb& output_box) const {
 
     if (!first_true)
         return false;
-    else
-        output_box = temp_box;
+
+    output_box = temp_box;
 
     for (auto object : objects) {
-        if (object->bounding_box(t0, t1, temp_box))
-            output_box = surrounding_box(output_box, temp_box);
-        else
+        if (!object->bounding_box(t0, t1, temp_box))
             return false;
+        output_box = surrounding_box(output_box, temp_box);
     }
 
     return true;
@@ -85,8 +84,7 @@ double hittable_list::pdf_value(const vec3& o, const vec3& v) const {
 
 vec3 hittable_list::random(const vec3 &o) const {
     auto int_size = static_cast<int>(objects.size());
-    auto index = static_cast<size_t>(random_int(0, int_size-1));
-    return objects[index]->random(o);
+    return objects[random_int(0, int_size-1)]->random(o);
 }
 
 

--- a/src/common/camera.h
+++ b/src/common/camera.h
@@ -16,6 +16,8 @@
 
 class camera {
     public:
+        camera() : camera(vec3(0,0,-1), vec3(0,0,0), vec3(0,1,0), 40, 1, 0, 10) {}
+
         camera(
             vec3 lookfrom, vec3 lookat, vec3 vup,
             double vfov, // top to bottom, in degrees


### PR DESCRIPTION
Sorry about this change; it's pretty much a squash of my changes, after chasing a bunch of dead ends. Should have been more incremental and disciplined. Still, I'm happy with the final results.

The primary change in this is that we're now using `hittable_list` with a `std::vector<hittable*>`, which alleviates a bunch of the awkward memory allocation. This opened up a number of opportunities to simplify code.

This version still leaks memory, but would moving to shared pointers from this base would be straight-forward.

Related/motivating issues: #305, #158, #147