### PR TITLE
Listing [random-in-unit-sphere] caption filename

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1388,7 +1388,7 @@ range from -1 to +1. Reject this point and try again if the point is outside the
         }
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [random-in-unit-sphere]: <kbd>[material.h]</kbd> The random_in_unit_sphere() function]
+    [Listing [random-in-unit-sphere]: <kbd>[vec3.h]</kbd> The random_in_unit_sphere() function]
 </div>
 
 <div class='together'>


### PR DESCRIPTION
Incorrectly listed the `random_in_unit_sphere()` function as being from
source file `material.h`, rather than `common/vec3.h`.

Resolves #353