### PR TITLE
Add src/common to include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,12 +80,4 @@ add_executable(pi                src/TheRestOfYourLife/pi.cc                ${CO
 add_executable(sphere_importance src/TheRestOfYourLife/sphere_importance.cc ${COMMON_ALL})
 add_executable(sphere_plot       src/TheRestOfYourLife/sphere_plot.cc       ${COMMON_ALL})
 
-target_include_directories(inOneWeekend      PRIVATE src)
-target_include_directories(theNextWeek       PRIVATE src)
-target_include_directories(theRestOfYourLife PRIVATE src)
-target_include_directories(cos_cubed         PRIVATE src)
-target_include_directories(cos_density       PRIVATE src)
-target_include_directories(integrate_x_sq    PRIVATE src)
-target_include_directories(pi                PRIVATE src)
-target_include_directories(sphere_importance PRIVATE src)
-target_include_directories(sphere_plot       PRIVATE src)
+include_directories(src/common)

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -319,7 +319,7 @@ tastes. The second part of the header file contains vector utility functions:
 Now we can change our main to use this:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include "common/vec3.h"
+    #include "vec3.h"
 
     #include <iostream>
 
@@ -370,7 +370,7 @@ The function $p(t)$ in more verbose code form I call `ray::at(t)`:
     #ifndef RAY_H
     #define RAY_H
 
-    #include "common/vec3.h"
+    #include "vec3.h"
 
     class ray {
         public:
@@ -742,8 +742,8 @@ And here’s the sphere:
     #ifndef SPHERE_H
     #define SPHERE_H
 
-    #include "common/vec3.h"
     #include "hittable.h"
+    #include "vec3.h"
 
     class sphere: public hittable {
         public:
@@ -1064,19 +1064,20 @@ file.
 
     // Common Headers
 
-    #include "common/ray.h"
-    #include "common/vec3.h"
+    #include "ray.h"
+    #include "vec3.h"
 
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [rtweekend-initial]: <kbd>[common/rtweekend.h]</kbd> The rtweekend.h common header]
+    [Listing [rtweekend-initial]: <kbd>[rtweekend.h]</kbd> The rtweekend.h common header]
 </div>
 
 <div class='together'>
 And the new main:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include "common/rtweekend.h"
+    #include "rtweekend.h"
+
     #include "hittable_list.h"
     #include "sphere.h"
 
@@ -1164,7 +1165,7 @@ $0 ≤ r < 1$. The “less than” before the 1 is important as we will sometime
 <div class='together'>
 A simple approach to this is to use the `rand()` function that can be found in `<cstdlib>`. This
 function returns a random integer in the range 0 and `RAND_MAX`. Hence we can get a real random
-number as desired with the following code snippet, added to `common/rtweekend.h`:
+number as desired with the following code snippet, added to `rtweekend.h`:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #include <cstdlib>
@@ -1219,7 +1220,7 @@ before:
     #ifndef CAMERA_H
     #define CAMERA_H
 
-    #include "common/rtweekend.h"
+    #include "rtweekend.h"
 
     class camera {
         public:
@@ -1712,7 +1713,7 @@ that the pointer is to a class, which the “class material” in the hittable c
     #ifndef HITTABLE_H
     #define HITTABLE_H
 
-    #include "common/rtweekend.h"
+    #include "rtweekend.h"
     #include "ray.h"
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -541,7 +541,7 @@ because in a ray tracer all cases come up eventually). With all three dimensions
 passing in the interval $t_{min}$, $t_{max}$ we get:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include "common/rtweekend.h"
+    #include "rtweekend.h"
 
     class aabb {
         public:
@@ -876,7 +876,7 @@ classes so feel free to do something different, but I am a big believer in this 
 being able to make any color a texture is great.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include "common/rtweekend.h"
+    #include "rtweekend.h"
 
     class texture {
         public:
@@ -1135,7 +1135,7 @@ Now if we create an actual texture that takes these floats between 0 and 1 and c
 colors:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include "common/perlin.h"
+    #include "perlin.h"
 
     class noise_texture : public texture {
         public:
@@ -1599,7 +1599,7 @@ utility `stb_image`. It reads in an image into a big array of unsigned char. The
 RGBs that each range 0..255 for black to fully-on.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include "common/texture.h"
+    #include "texture.h"
 
     class image_texture : public texture {
         public:
@@ -1640,10 +1640,10 @@ RGBs that each range 0..255 for black to fully-on.
 
 <div class='together'>
 The representation of a packed array in that order is pretty standard. Thankfully, the `stb_image`
-package makes that super simple -- just include the header `common/rtw_stb_image.h` in `main.h`:
+package makes that super simple -- just include the header `rtw_stb_image.h` in `main.h`:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include "common/rtw_stb_image.h"
+    #include "rtw_stb_image.h"
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [incl-stb-img]: Including the STB image package]
 </div>

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -66,7 +66,7 @@ Since the $r$ cancels out, we can pick whatever is computationally convenient. L
 centered at the origin:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include "common/rtweekend.h"
+    #include "rtweekend.h"
 
     #include <iostream>
     #include <iomanip>
@@ -96,7 +96,7 @@ On my computer, this gives me the answer `Estimate of Pi = 3.0880000000`
 If we change the program to run forever and just print out a running estimate:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include "common/rtweekend.h"
+    #include "rtweekend.h"
 
     #include <iostream>
     #include <iomanip>
@@ -139,7 +139,7 @@ This changes the sample generation, but we need to know how many samples we are 
 because we need to know the grid. Let’s take a hundred million and try it both ways:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include "common/rtweekend.h"
+    #include "rtweekend.h"
 
     #include <iostream>
     #include <iomanip>
@@ -213,7 +213,7 @@ $$ I = 2 \cdot \text{average}(x^2, 0, 2) $$
 This suggests a MC approach:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include "common/rtweekend.h"
+    #include "rtweekend.h"
 
     #include <iostream>
     #include <iomanip>
@@ -1074,7 +1074,7 @@ We can save a little algebra on specific cases by noting
 Let’s also start generating them as random vectors:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include "common/rtweekend.h"
+    #include "rtweekend.h"
 
     #include <iostream>
     #include <math.h>
@@ -2310,7 +2310,7 @@ for `NaN`s is that any `if` test with a `NaN` in it is false. Using this trick, 
             << static_cast<int>(256 * clamp(b, 0.0, 0.999)) << '\n';
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [write-color-nan]: <kbd>[common/vec3.h]</kbd> NaN-tolerant write_color function]
+    [Listing [write-color-nan]: <kbd>[vec3.h]</kbd> NaN-tolerant write_color function]
 </div>
 
 <div class='together'>

--- a/src/InOneWeekend/hittable.h
+++ b/src/InOneWeekend/hittable.h
@@ -11,7 +11,7 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
 
 
 class material;

--- a/src/InOneWeekend/hittable_list.h
+++ b/src/InOneWeekend/hittable_list.h
@@ -11,8 +11,10 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
+
 #include "hittable.h"
+
 #include <memory>
 #include <vector>
 

--- a/src/InOneWeekend/main.cc
+++ b/src/InOneWeekend/main.cc
@@ -9,11 +9,13 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
-#include "common/camera.h"
+#include "rtweekend.h"
+
+#include "camera.h"
 #include "hittable_list.h"
 #include "material.h"
 #include "sphere.h"
+
 #include <iostream>
 
 

--- a/src/InOneWeekend/material.h
+++ b/src/InOneWeekend/material.h
@@ -11,7 +11,7 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
 
 
 struct hit_record;

--- a/src/InOneWeekend/sphere.h
+++ b/src/InOneWeekend/sphere.h
@@ -11,7 +11,8 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
+
 #include "hittable.h"
 
 

--- a/src/TheNextWeek/aarect.h
+++ b/src/TheNextWeek/aarect.h
@@ -11,7 +11,8 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
+
 #include "hittable.h"
 
 

--- a/src/TheNextWeek/box.h
+++ b/src/TheNextWeek/box.h
@@ -11,7 +11,8 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
+
 #include "aarect.h"
 #include "hittable_list.h"
 

--- a/src/TheNextWeek/bvh.h
+++ b/src/TheNextWeek/bvh.h
@@ -11,8 +11,10 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
+
 #include "hittable.h"
+
 #include <algorithm>
 
 

--- a/src/TheNextWeek/constant_medium.h
+++ b/src/TheNextWeek/constant_medium.h
@@ -11,10 +11,11 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
-#include "common/texture.h"
+#include "rtweekend.h"
+
 #include "hittable.h"
 #include "material.h"
+#include "texture.h"
 
 
 class constant_medium : public hittable  {

--- a/src/TheNextWeek/hittable.h
+++ b/src/TheNextWeek/hittable.h
@@ -11,8 +11,9 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
-#include "common/aabb.h"
+#include "rtweekend.h"
+
+#include "aabb.h"
 
 
 class material;

--- a/src/TheNextWeek/hittable_list.h
+++ b/src/TheNextWeek/hittable_list.h
@@ -11,8 +11,10 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
+
 #include "hittable.h"
+
 #include <vector>
 
 

--- a/src/TheNextWeek/main.cc
+++ b/src/TheNextWeek/main.cc
@@ -9,17 +9,19 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
-#include "common/camera.h"
-#include "common/rtw_stb_image.h"
-#include "common/texture.h"
+#include "rtweekend.h"
+
 #include "box.h"
 #include "bvh.h"
+#include "camera.h"
 #include "constant_medium.h"
 #include "hittable_list.h"
 #include "material.h"
 #include "moving_sphere.h"
+#include "rtw_stb_image.h"
 #include "sphere.h"
+#include "texture.h"
+
 #include <iostream>
 
 

--- a/src/TheNextWeek/material.h
+++ b/src/TheNextWeek/material.h
@@ -11,9 +11,10 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
-#include "common/texture.h"
+#include "rtweekend.h"
+
 #include "hittable.h"
+#include "texture.h"
 
 
 double schlick(double cosine, double ref_idx) {

--- a/src/TheNextWeek/moving_sphere.h
+++ b/src/TheNextWeek/moving_sphere.h
@@ -11,7 +11,8 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
+
 #include "hittable.h"
 
 

--- a/src/TheNextWeek/sphere.h
+++ b/src/TheNextWeek/sphere.h
@@ -11,7 +11,8 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
+
 #include "hittable.h"
 
 

--- a/src/TheRestOfYourLife/aarect.h
+++ b/src/TheRestOfYourLife/aarect.h
@@ -11,7 +11,8 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
+
 #include "hittable.h"
 
 

--- a/src/TheRestOfYourLife/box.h
+++ b/src/TheRestOfYourLife/box.h
@@ -11,7 +11,8 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
+
 #include "aarect.h"
 #include "hittable_list.h"
 

--- a/src/TheRestOfYourLife/bvh.h
+++ b/src/TheRestOfYourLife/bvh.h
@@ -11,8 +11,10 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
+
 #include "hittable.h"
+
 #include <algorithm>
 
 

--- a/src/TheRestOfYourLife/cos_cubed.cc
+++ b/src/TheRestOfYourLife/cos_cubed.cc
@@ -9,7 +9,7 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
 
 #include <iostream>
 #include <iomanip>

--- a/src/TheRestOfYourLife/cos_density.cc
+++ b/src/TheRestOfYourLife/cos_density.cc
@@ -9,7 +9,7 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
 
 #include <iostream>
 #include <iomanip>

--- a/src/TheRestOfYourLife/hittable.h
+++ b/src/TheRestOfYourLife/hittable.h
@@ -11,8 +11,9 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
-#include "common/aabb.h"
+#include "rtweekend.h"
+
+#include "aabb.h"
 
 
 class material;

--- a/src/TheRestOfYourLife/hittable_list.h
+++ b/src/TheRestOfYourLife/hittable_list.h
@@ -11,8 +11,10 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
+
 #include "hittable.h"
+
 #include <vector>
 
 

--- a/src/TheRestOfYourLife/integrate_x_sq.cc
+++ b/src/TheRestOfYourLife/integrate_x_sq.cc
@@ -9,7 +9,7 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
 
 #include <iostream>
 #include <iomanip>

--- a/src/TheRestOfYourLife/main.cc
+++ b/src/TheRestOfYourLife/main.cc
@@ -9,13 +9,15 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
-#include "common/camera.h"
+#include "rtweekend.h"
+
 #include "aarect.h"
 #include "box.h"
+#include "camera.h"
 #include "hittable_list.h"
 #include "material.h"
 #include "sphere.h"
+
 #include <iostream>
 
 

--- a/src/TheRestOfYourLife/material.h
+++ b/src/TheRestOfYourLife/material.h
@@ -11,9 +11,10 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
-#include "common/texture.h"
+#include "rtweekend.h"
+
 #include "pdf.h"
+#include "texture.h"
 
 
 double schlick(double cosine, double ref_idx) {

--- a/src/TheRestOfYourLife/onb.h
+++ b/src/TheRestOfYourLife/onb.h
@@ -11,7 +11,7 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
 
 
 class onb

--- a/src/TheRestOfYourLife/pdf.h
+++ b/src/TheRestOfYourLife/pdf.h
@@ -11,7 +11,8 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
+
 #include "onb.h"
 
 

--- a/src/TheRestOfYourLife/pi.cc
+++ b/src/TheRestOfYourLife/pi.cc
@@ -9,7 +9,7 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
 
 #include <iostream>
 #include <iomanip>

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -11,7 +11,8 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
+
 #include "hittable.h"
 #include "onb.h"
 

--- a/src/TheRestOfYourLife/sphere_importance.cc
+++ b/src/TheRestOfYourLife/sphere_importance.cc
@@ -9,7 +9,7 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
 
 #include <iostream>
 #include <iomanip>

--- a/src/TheRestOfYourLife/sphere_plot.cc
+++ b/src/TheRestOfYourLife/sphere_plot.cc
@@ -9,7 +9,7 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
 
 #include <iostream>
 #include <math.h>

--- a/src/common/aabb.h
+++ b/src/common/aabb.h
@@ -11,7 +11,7 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
 
 
 class aabb {

--- a/src/common/camera.h
+++ b/src/common/camera.h
@@ -11,7 +11,7 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
 
 
 class camera {

--- a/src/common/perlin.h
+++ b/src/common/perlin.h
@@ -11,7 +11,7 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
+#include "rtweekend.h"
 
 
 

--- a/src/common/ray.h
+++ b/src/common/ray.h
@@ -11,7 +11,8 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/vec3.h"
+#include "vec3.h"
+
 
 class ray
 {

--- a/src/common/rtw_stb_image.h
+++ b/src/common/rtw_stb_image.h
@@ -11,7 +11,7 @@
 
 
 #define STB_IMAGE_IMPLEMENTATION
-#include "common/external/stb_image.h"
+#include "external/stb_image.h"
 
 
 // Restore warning levels.

--- a/src/common/rtweekend.h
+++ b/src/common/rtweekend.h
@@ -56,8 +56,8 @@ inline int random_int(int min, int max) {
 
 // Common Headers
 
-#include "common/ray.h"
-#include "common/vec3.h"
+#include "ray.h"
+#include "vec3.h"
 
 
 #endif

--- a/src/common/texture.h
+++ b/src/common/texture.h
@@ -11,8 +11,9 @@
 // along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //==============================================================================================
 
-#include "common/rtweekend.h"
-#include "common/perlin.h"
+#include "rtweekend.h"
+
+#include "perlin.h"
 
 
 class texture  {


### PR DESCRIPTION
This adds the src/common directory to the include directories, so
compilers will search there for headers in addition to the target source
directories.