### PR TITLE
Use references in ranged for loop for performance

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -956,7 +956,7 @@ We add a list of objects:
         bool hit_anything = false;
         auto closest_so_far = t_max;
 
-        for (auto object : objects) {
+        for (const auto& object : objects) {
             if (object->hit(r, t_min, closest_so_far, temp_rec)) {
                 hit_anything = true;
                 closest_so_far = temp_rec.t;

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -667,7 +667,7 @@ the fly because it is only usually called at BVH construction.
 
         output_box = temp_box;
 
-        for (auto object : objects) {
+        for (const auto& object : objects) {
             if (!objects[i]->bounding_box(t0, t1, temp_box))
                 return false;
             output_box = surrounding_box(output_box, temp_box);

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -2236,7 +2236,7 @@ think both tactics would work fine, but I will go with instrumenting `hittable_l
         auto weight = 1.0/objects.size();
         auto sum = 0.0;
 
-        for (auto object : objects)
+        for (const auto& object : objects)
             sum += weight * object->pdf_value(o, v);
 
         return sum;

--- a/src/InOneWeekend/hittable_list.h
+++ b/src/InOneWeekend/hittable_list.h
@@ -39,7 +39,7 @@ bool hittable_list::hit(const ray& r, double t_min, double t_max, hit_record& re
     auto hit_anything = false;
     auto closest_so_far = t_max;
 
-    for (auto object : objects) {
+    for (const auto& object : objects) {
         if (object->hit(r, t_min, closest_so_far, temp_rec)) {
             hit_anything = true;
             closest_so_far = temp_rec.t;

--- a/src/TheNextWeek/hittable_list.h
+++ b/src/TheNextWeek/hittable_list.h
@@ -39,7 +39,7 @@ bool hittable_list::hit(const ray& r, double t_min, double t_max, hit_record& re
     auto hit_anything = false;
     auto closest_so_far = t_max;
 
-    for (auto object : objects) {
+    for (const auto& object : objects) {
         if (object->hit(r, t_min, closest_so_far, temp_rec)) {
             hit_anything = true;
             closest_so_far = temp_rec.t;
@@ -62,7 +62,7 @@ bool hittable_list::bounding_box(double t0, double t1, aabb& output_box) const {
 
     output_box = temp_box;
 
-    for (auto object : objects) {
+    for (const auto& object : objects) {
         if (!object->bounding_box(t0, t1, temp_box))
             return false;
         output_box = surrounding_box(output_box, temp_box);

--- a/src/TheRestOfYourLife/hittable_list.h
+++ b/src/TheRestOfYourLife/hittable_list.h
@@ -41,7 +41,7 @@ bool hittable_list::hit(const ray& r, double t_min, double t_max, hit_record& re
     auto hit_anything = false;
     auto closest_so_far = t_max;
 
-    for (auto object : objects) {
+    for (const auto& object : objects) {
         if (object->hit(r, t_min, closest_so_far, temp_rec)) {
             hit_anything = true;
             closest_so_far = temp_rec.t;
@@ -64,7 +64,7 @@ bool hittable_list::bounding_box(double t0, double t1, aabb& output_box) const {
 
     output_box = temp_box;
 
-    for (auto object : objects) {
+    for (const auto& object : objects) {
         if (!object->bounding_box(t0, t1, temp_box))
             return false;
         output_box = surrounding_box(output_box, temp_box);
@@ -78,7 +78,7 @@ double hittable_list::pdf_value(const vec3& o, const vec3& v) const {
     auto weight = 1.0/objects.size();
     auto sum = 0.0;
 
-    for (auto object : objects)
+    for (const auto& object : objects)
         sum += weight * object->pdf_value(o, v);
 
     return sum;


### PR DESCRIPTION
Using a reference avoids making an expensive copy of a shared_ptr.
I see the following improvements on my machine when running
before/after.  Timing is in minutes.

```
InOneWeekend
  before: 4.07
  after: 1.83
TheNextWeek
  before: 2.60
  after: 1.96
TheRestOfYourLife
  before: 2.82
  after: 2.44
```
Addresses issue #336