### PR TITLE
NextWeek: fix bad code in Perlin noise() function

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -1093,9 +1093,11 @@ code to make it all happen:
                 auto u = p.x() - floor(p.x());
                 auto v = p.y() - floor(p.y());
                 auto w = p.z() - floor(p.z());
-                auto i = static_cast<int>(floor(p.x()));
-                auto j = static_cast<int>(floor(p.y()));
-                auto k = static_cast<int>(floor(p.z()));
+
+                auto i = static_cast<int>(4*p.x()) & 255;
+                auto j = static_cast<int>(4*p.y()) & 255;
+                auto k = static_cast<int>(4*p.z()) & 255;
+
                 return ranfloat[perm_x[i] ^ perm_y[j] ^ perm_z[k]];
             }
 


### PR DESCRIPTION
The original code for the first version of the Perlin noise() function
in _The Next Week_ was incorrect. This returns the code to the original
behavior, but using static_cast instead of the original C-style cast.

Resolves #396