### PR TITLE
NextWeek: Remove spurious decl bounding_box()

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -171,7 +171,6 @@ times need not match up with the camera aperture open and close.
             {};
 
             virtual bool hit(const ray& r, double tmin, double tmax, hit_record& rec) const;
-            virtual bool bounding_box(double t0, double t1, aabb& output_box) const;
 
             vec3 center(double time) const;
 


### PR DESCRIPTION
We had a premature declaration for the virtual function
`moving_sphere::bounding_box()`. Removed it.

Fixes #405