### PR TITLE
Move acknowledgments to single common document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@ Change Log -- Ray Tracing in One Weekend
 ----------------------------------------------------------------------------------------------------
 # v3.0.2 (in progress)
 
+### Common
+- Change: Every book source now includes from a single common acknowledgments document.
+
 ### _In One Weekend_
 - Fix: Correct typo: "consine" to "cosine"
 
 ### _The Next Week_
 - Fix: `shared_ptr` dereference and simplify code in `hittable_list::bounding_box()` (#435)
-- Fix: erroneous en-dash in code block (#439)
+- Fix: Erroneous en-dash in code block. Replace `–>` with `->` (#439)
 - Fix: Add highlight to new `hittable::bounding_box()` method (#442)
 
 

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -53,8 +53,8 @@ ptrshrl@gmail.com.
 I’ll be maintaining a site related to the book including further reading and links to resources at a
 blog https://in1weekend.blogspot.com/ related to this book.
 
-Thanks to everyone who lent a hand on this project. You can find them in the [acknowledgments][] at
-the end of this book.
+Thanks to everyone who lent a hand on this project. You can find them in the acknowledgments section
+at the end of this book.
 
 Let’s get on with it!
 
@@ -2836,73 +2836,8 @@ Have fun, and please send me your cool images!
 
 
 
-Acknowledgments
-====================================================================================================
+                               (insert acknowledgments.md.html here)
 
-<div class="credit-list"> **Original Manuscript Help**
-
-  - Dave Hart
-  - Jean Buckley
-</div>
-
-<div class="credit-list"> **Web Release**
-
-  - Berna Kabadayı
-  - Lorenzo Mancini
-  - Lori Whippler Hollasch
-  - Ronald Wotzlaw
-</div>
-
-<div class="credit-list"> **Corrections and Improvements**
-
-  - Aaryaman Vasishta
-  - Andrew Kensler
-  - Apoorva Joshi
-  - Aras Pranckevičius
-  - Becker
-  - Ben Kerl
-  - Benjamin Summerton
-  - Bennett Hardwick
-  - Dan Drummond
-  - David Chambers
-  - David Hart
-  - Eric Haines
-  - Fabio Sancinetti
-  - Filipe Scur
-  - Frank He
-  - Gerrit Wessendorf
-  - Grue Debry
-  - Ingo Wald
-  - Jason Stone
-  - Jean Buckley
-  - Joey Cho
-  - Lorenzo Mancini
-  - Marcus Ottosson
-  - Matthew Heimlich
-  - Nakata Daisuke
-  - Paul Melis
-  - Phil Cristensen
-  - Ronald Wotzlaw
-  - Shaun P. Lee
-  - Tatsuya Ogawa
-  - Thiago Ize
-  - Vahan Sosoyan
-</div>
-
-<div class="credit-list"> **Tools**
-
-  <div class="indented">
-  Thanks to the team at [Limnu][] for help on the figures.
-
-  Huge shout out to Morgan McGuire for his fantastic [Markdeep][] library.
-  </div>
-</div>
-
-
-
-[acknowledgments]: #acknowledgments
-[Limnu]: https://limnu.com/
-[Markdeep]: https://casual-effects/markdeep/
 
 
 <!-- Markdeep: https://casual-effects.com/markdeep/ -->

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -32,8 +32,8 @@ suggests you take a week rather than a weekend for this endeavor. But you can sa
 you want a weekend project. Order is not very important for the concepts presented in this book, and
 without BVH and Perlin texture you will still get a Cornell Box!
 
-Thanks to everyone who lent a hand on this project. You can find them in the [acknowledgments][] at
-the end of this book.
+Thanks to everyone who lent a hand on this project. You can find them in the acknowledgments section
+at the end of this book.
 
 
 
@@ -2768,73 +2768,8 @@ images to me at ptrshrl@gmail.com.
 
 
 
-Acknowledgments
-====================================================================================================
+                               (insert acknowledgments.md.html here)
 
-<div class="credit-list"> **Original Manuscript Help**
-
-  - Dave Hart
-  - Jean Buckley
-</div>
-
-<div class="credit-list"> **Web Release**
-
-  - Berna Kabadayı
-  - Lorenzo Mancini
-  - Lori Whippler Hollasch
-  - Ronald Wotzlaw
-</div>
-
-<div class="credit-list"> **Corrections and Improvements**
-
-  - Aaryaman Vasishta
-  - Andrew Kensler
-  - Apoorva Joshi
-  - Aras Pranckevičius
-  - Becker
-  - Ben Kerl
-  - Benjamin Summerton
-  - Bennett Hardwick
-  - Dan Drummond
-  - David Chambers
-  - David Hart
-  - Eric Haines
-  - Fabio Sancinetti
-  - Filipe Scur
-  - Frank He
-  - Gerrit Wessendorf
-  - Grue Debry
-  - Ingo Wald
-  - Jason Stone
-  - Jean Buckley
-  - Joey Cho
-  - Lorenzo Mancini
-  - Marcus Ottosson
-  - Matthew Heimlich
-  - Nakata Daisuke
-  - Paul Melis
-  - Phil Cristensen
-  - Ronald Wotzlaw
-  - Shaun P. Lee
-  - Tatsuya Ogawa
-  - Thiago Ize
-  - Vahan Sosoyan
-</div>
-
-<div class="credit-list"> **Tools**
-
-  <div class="indented">
-  Thanks to the team at [Limnu][] for help on the figures.
-
-  Huge shout out to Morgan McGuire for his fantastic [Markdeep][] library.
-  </div>
-</div>
-
-
-
-[acknowledgments]: #acknowledgments
-[Limnu]: https://limnu.com/
-[Markdeep]: https://casual-effects/markdeep/
 
 
 <!-- Markdeep: https://casual-effects.com/markdeep/ -->

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -30,8 +30,8 @@ terms you will need to study the others.
 
 As before, https://in1weekend.blogspot.com/ will have further readings and references.
 
-Thanks to everyone who lent a hand on this project. You can find them in the [acknowledgments][] at
-the end of this book.
+Thanks to everyone who lent a hand on this project. You can find them in the acknowledgments section
+at the end of this book.
 
 
 
@@ -2405,73 +2405,8 @@ Salt Lake City, March, 2016
 
 
 
-Acknowledgments
-====================================================================================================
+                               (insert acknowledgments.md.html here)
 
-<div class="credit-list"> **Original Manuscript Help**
-
-  - Dave Hart
-  - Jean Buckley
-</div>
-
-<div class="credit-list"> **Web Release**
-
-  - Berna Kabadayı
-  - Lorenzo Mancini
-  - Lori Whippler Hollasch
-  - Ronald Wotzlaw
-</div>
-
-<div class="credit-list"> **Corrections and Improvements**
-
-  - Aaryaman Vasishta
-  - Andrew Kensler
-  - Apoorva Joshi
-  - Aras Pranckevičius
-  - Becker
-  - Ben Kerl
-  - Benjamin Summerton
-  - Bennett Hardwick
-  - Dan Drummond
-  - David Chambers
-  - David Hart
-  - Eric Haines
-  - Fabio Sancinetti
-  - Filipe Scur
-  - Frank He
-  - Gerrit Wessendorf
-  - Grue Debry
-  - Ingo Wald
-  - Jason Stone
-  - Jean Buckley
-  - Joey Cho
-  - Lorenzo Mancini
-  - Marcus Ottosson
-  - Matthew Heimlich
-  - Nakata Daisuke
-  - Paul Melis
-  - Phil Cristensen
-  - Ronald Wotzlaw
-  - Shaun P. Lee
-  - Tatsuya Ogawa
-  - Thiago Ize
-  - Vahan Sosoyan
-</div>
-
-<div class="credit-list"> **Tools**
-
-  <div class="indented">
-  Thanks to the team at [Limnu][] for help on the figures.
-
-  Huge shout out to Morgan McGuire for his fantastic [Markdeep][] library.
-  </div>
-</div>
-
-
-
-[acknowledgments]: #acknowledgments
-[Limnu]: https://limnu.com
-[Markdeep]: https://casual-effects/markdeep/
 
 
 <!-- Markdeep: https://casual-effects.com/markdeep/ -->

--- a/books/acknowledgments.md.html
+++ b/books/acknowledgments.md.html
@@ -1,0 +1,76 @@
+<meta charset="utf-8">
+<!-- Markdeep: https://casual-effects.com/markdeep/ -->
+
+Acknowledgments
+====================================================================================================
+
+<div class="credit-list"> **Original Manuscript Help**
+
+  - Dave Hart
+  - Jean Buckley
+</div>
+
+<div class="credit-list"> **Web Release**
+
+  - Berna Kabadayı
+  - Lorenzo Mancini
+  - Lori Whippler Hollasch
+  - Ronald Wotzlaw
+</div>
+
+<div class="credit-list"> **Corrections and Improvements**
+
+  - Aaryaman Vasishta
+  - Andrew Kensler
+  - Apoorva Joshi
+  - Aras Pranckevičius
+  - Becker
+  - Ben Kerl
+  - Benjamin Summerton
+  - Bennett Hardwick
+  - Dan Drummond
+  - David Chambers
+  - David Hart
+  - Eric Haines
+  - Fabio Sancinetti
+  - Filipe Scur
+  - Frank He
+  - Gerrit Wessendorf
+  - Grue Debry
+  - Ingo Wald
+  - Jason Stone
+  - Jean Buckley
+  - Joey Cho
+  - Lorenzo Mancini
+  - Marcus Ottosson
+  - Matthew Heimlich
+  - Nakata Daisuke
+  - Paul Melis
+  - Phil Cristensen
+  - Ronald Wotzlaw
+  - Shaun P. Lee
+  - Tatsuya Ogawa
+  - Thiago Ize
+  - Vahan Sosoyan
+</div>
+
+<div class="credit-list"> **Tools**
+
+  <div class="indented">
+  Thanks to the team at [Limnu](https://limnu.com/) for help on the figures.
+
+  These books are entirely written in Morgan McGuire's fantastic and free
+  [Markdeep](https://casual-effects.com/markdeep/) library. To see what this looks like, view the
+  page source from your browser.
+
+  </div>
+</div>
+
+
+
+<!-- Markdeep: https://casual-effects.com/markdeep/ -->
+<link rel='stylesheet' href='../style/book.css'>
+<style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
+<script src="markdeep.min.js"></script>
+<script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>
+<script>window.alreadyProcessedMarkdeep||(document.body.style.visibility="visible")</script>


### PR DESCRIPTION
The prior version had an identical acknowledgments section copy and
pasted to the end of each book, a solution that was both tedious and
error prone.

This change uses Markdeep's include directive to import the section
from a new single `acknowledgments.md.html` file.

Additionally, this change uses Markdeep's auto reference, so that
`[acknowledgments](#acknowledgements)` is now replaced with the text
"acknowledgments section", which Markdeep auto links.