### PR TITLE
Remove obsolete paragraph about using qsort

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -769,11 +769,6 @@ list along one axis. I’ll go for simplicity:
 
 </div>
 
-I used the old-school C `qsort` rather than the C++ sort because I need a different compare operator
-depending on axis, and `qsort` takes a compare function rather than using the less-than operator. I
-pass in a pointer to pointer -- this is just C for “array of pointers” because a pointer in C can
-also just be a pointer to the first element of an array.
-
 <div class='together'>
 When the list coming in is two elements, I put one in each subtree and end the recursion. The
 traverse algorithm should be smooth and not have to check for null pointers, so if I just have one


### PR DESCRIPTION
We're using `std::sort` now.

Resolves #462