### PR TITLE
Edit pass: fix many conjunctions

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -33,8 +33,8 @@ in a weekend. If you take longer, don’t worry about it. I use C++ as the drivi
 don’t need to. However, I suggest you do, because it’s fast, portable, and most production movie and
 video game renderers are written in C++. Note that I avoid most “modern features” of C++, but
 inheritance and operator overloading are too useful for ray tracers to pass on. I do not provide the
-code online, but the code is real, and I show all of it except for a few straightforward operators
-in the `vec3` class. I am a big believer in typing in code to learn it, but when code is available I
+code online, but the code is real and I show all of it except for a few straightforward operators in
+the `vec3` class. I am a big believer in typing in code to learn it, but when code is available I
 use it, so I only practice what I preach when the code is not available. So don’t ask!
 
 I have left that last part in because it is funny what a 180 I have done. Several readers ended up
@@ -64,7 +64,7 @@ Output an Image
 ====================================================================================================
 
 Whenever you start a renderer, you need a way to see an image. The most straightforward way is to
-write it to a file. The catch is, there are so many formats, and many of those are complex. I always
+write it to a file. The catch is, there are so many formats. Many of those are complex. I always
 start with a plain text ppm file. Here’s a nice description from Wikipedia:
 
   ![](../images/img.ppm-example.jpg)
@@ -140,7 +140,7 @@ Opening the output file (in `ToyViewer` on my Mac, but try it in your favorite v
 
 <div class='together'>
 Hooray! This is the graphics “hello world”. If your image doesn’t look like that, open the output
-file in a text editor, and see what it looks like. It should start something like this:
+file in a text editor and see what it looks like. It should start something like this:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     P3
@@ -171,7 +171,7 @@ progress of a long render, and also to possibly identify a run that's stalled ou
 loop or other problem.
 
 <div class='together'>
-Our program outputs the image to the standard output stream (`std::cout`), so leave that alone, and
+Our program outputs the image to the standard output stream (`std::cout`), so leave that alone and
 instead write to the error output stream (`std::cerr`):
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -355,9 +355,9 @@ Rays, a Simple Camera, and Background
 ====================================================================================================
 
 <div class='together'>
-The one thing that all ray tracers have is a ray class, and a computation of what color is seen
-along a ray. Let’s think of a ray as a function $\mathbf{p}(t) = \mathbf{a} + t \vec{\mathbf{b}}$.
-Here $\mathbf{p}$ is a 3D position along a line in 3D. $\mathbf{a}$ is the ray origin, and
+The one thing that all ray tracers have is a ray class and a computation of what color is seen along
+a ray. Let’s think of a ray as a function $\mathbf{p}(t) = \mathbf{a} + t \vec{\mathbf{b}}$. Here
+$\mathbf{p}$ is a 3D position along a line in 3D. $\mathbf{a}$ is the ray origin, and
 $\vec{\mathbf{b}}$ is the ray direction. The ray parameter $t$ is a real number (`double` in the
 code). Plug in a different $t$ and $p(t)$ moves the point along the ray. Add in negative $t$ and you
 can go anywhere on the 3D line. For positive $t$, you get only the parts in front of $\mathbf{a}$,
@@ -401,7 +401,7 @@ The function $p(t)$ in more verbose code form I call `ray::at(t)`:
 </div>
 
 Now we are ready to turn the corner and make a ray tracer. At the core, the ray tracer sends rays
-through pixels, and computes the color seen in the direction of those rays. The involved steps are
+through pixels and computes the color seen in the direction of those rays. The involved steps are
 (1) calculate the ray from the eye to the pixel, (2) determine which objects the ray intersects, and
 (3) compute a color for that intersection point. When first developing a ray tracer, I always do a
 simple camera for getting the code up and running. I also make a simple `color(ray)` function that
@@ -535,8 +535,8 @@ or expanding the full form of the ray $p(t)$:
 </div>
 
 <div class='together'>
-The rules of vector algebra are all that we would want here, and if we expand that equation, and
-move all the terms to the left hand side we get:
+The rules of vector algebra are all that we would want here. If we expand that equation and move all
+the terms to the left hand side we get:
 
   $$ t^2 \vec{\mathbf{b}}\cdot\vec{\mathbf{b}}
      + 2t \vec{\mathbf{b}} \cdot \vec{(\mathbf{a}-\mathbf{c})}
@@ -864,11 +864,12 @@ information:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [normals-point-against]: <kbd>[sphere.h]</kbd> Remembering the side of the surface]
 
-The decision whether to have normals always point out or to always point against the ray is based on
-whether you want to determine the side of the surface at the time of geometry or at the time of
-coloring. In this book we have more material types than we have geometry types, so we'll go for
-less work, and put the determination at geometry time. This is simply a matter of preference, and
-you'll see both implementations in the literature.
+We can set things up so that normals always point “outward” from the surface, or always point
+against the incident ray. This decision is determined by whether you want to determine the side of
+the surface at the time of geometry intersection or at the time of coloring. In this book we have
+more material types than we have geometry types, so we'll go for less work and put the determination
+at geometry time. This is simply a matter of preference, and you'll see both implementations in the
+literature.
 
 We add the `front_face` bool to the `hit_record` struct. I know that we’ll also want motion blur at
 some point, so I’ll also add a time input variable.
@@ -1029,7 +1030,7 @@ above lines can be more simply expressed using C++'s `auto` type specifier:
 
 We'll use shared pointers in our code, because it allows multiple geometries to share a common
 instance (for example, a bunch of spheres that all use the same texture map material), and because
-it makes memory management automatic, and easier to reason about.
+it makes memory management automatic and easier to reason about.
 
 `std::shared_ptr` is included with the `<memory>` header.
 
@@ -1178,10 +1179,10 @@ Antialiasing
 
 When a real camera takes a picture, there are usually no jaggies along edges because the edge pixels
 are a blend of some foreground and some background. We can get the same effect by averaging a bunch
-of samples inside each pixel. We will not bother with stratification, which is controversial, but is
+of samples inside each pixel. We will not bother with stratification. This is controversial, but is
 usual for my programs. For some ray tracers it is critical, but the kind of general one we are
-writing doesn’t benefit very much from it, and it makes the code uglier. We abstract the camera
-class a bit so we can make a cooler camera later.
+writing doesn’t benefit very much from it and it makes the code uglier. We abstract the camera class
+a bit so we can make a cooler camera later.
 
 One thing we need is a random number generator that returns real random numbers. We need a function
 that returns a canonical random number which by convention returns random real in the range
@@ -1384,7 +1385,7 @@ surfaces that look matte. One of the simplest ways to do this turns out to be ex
 ideal diffuse surfaces. (I used to do it as a lazy hack that approximates mathematically ideal
 Lambertian.)
 
-(Reader Vassillen Chizhov proved that the lazy hack is indeed just a lazy hack, and is inaccurate.
+(Reader Vassillen Chizhov proved that the lazy hack is indeed just a lazy hack and is inaccurate.
 The correct representation of ideal Lambertian isn't much more work, and is presented at the end of
 the chapter.)
 
@@ -1404,7 +1405,7 @@ $(s-p)$):
 <div class='together'>
 We need a way to pick a random point in a unit radius sphere. We’ll use what is usually the easiest
 algorithm: a rejection method. First, pick a random point in the unit cube where x, y, and z all
-range from -1 to +1. Reject this point, and try again if the point is outside the sphere.
+range from -1 to +1. Reject this point and try again if the point is outside the sphere.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class vec3 {
@@ -2030,7 +2031,7 @@ Which gives:
 </div>
 
 <div class='together'>
-We can also randomize the reflected direction by using a small sphere, and choosing a new endpoint
+We can also randomize the reflected direction by using a small sphere and choosing a new endpoint
 for the ray:
 
   ![Figure [reflect-fuzzy]: Generating fuzzed reflection rays](../images/fig.reflect-fuzzy.jpg)
@@ -2107,7 +2108,7 @@ I got this (I have not told you how to do this right or wrong yet, but soon!):
 
 Is that right? Glass balls look odd in real life. But no, it isn’t right. The world should be
 flipped upside down and no weird black stuff. I just printed out the ray straight through the middle
-of the image, and it was clearly wrong. That often does the job.
+of the image and it was clearly wrong. That often does the job.
 
 <div class='together'>
 The refraction is described by Snell’s law:
@@ -2222,7 +2223,7 @@ The value of $\sin\theta'$ cannot be greater than 1. So, if,
   $$ \frac{1.5}{1.0} \cdot \sin\theta > 1.0 $$
 
 The equality between the two sides of the equation is broken, and a solution cannot exist. If a
-solution does not exist the glass cannot refract, and must reflect the ray:
+solution does not exist, the glass cannot refract, and therefore must reflect the ray:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     if(etai_over_etat * sin_theta > 1.0) {
@@ -2386,8 +2387,8 @@ This yields our full glass material:
 
 <div class='together'>
 An interesting and easy trick with dielectric spheres is to note that if you use a negative radius,
-the geometry is unaffected, but the surface normal points inward, so it can be used as a bubble
-to make a hollow glass sphere:
+the geometry is unaffected, but the surface normal points inward. This can be used as a bubble to
+make a hollow glass sphere:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     world.add(make_shared<sphere>(vec3(0,0,-1), 0.5, make_shared<lambertian>(vec3(0.1, 0.2, 0.5))));
@@ -2507,7 +2508,7 @@ products, and we now have a complete orthonormal basis (u,v,w) to describe our c
 
 Remember that `vup`, `v`, and `w` are all in the same plane. Note that, like before when our fixed
 camera faced -Z, our arbitrary view camera faces -w. And keep in mind that we can -- but we don’t
-have to -- use world up (0,1,0) to specify vup. This is convenient, and will naturally keep your
+have to -- use world up (0,1,0) to specify vup. This is convenient and will naturally keep your
 camera horizontally level until you decide to experiment with crazy camera angles.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2606,9 +2607,9 @@ want defocus blur.
 
 <div class="together">
 A real camera has a complicated compound lens. For our code we could simulate the order: sensor,
-then lens, then aperture. Then we could figure out where to send the rays, and flip the image once
-computed (the image is projected upside down on the film). Graphics people usually use a thin lens
-approximation:
+then lens, then aperture. Then we could figure out where to send the rays, and flip the image after
+it's computed (the image is projected upside down on the film). Graphics people, however, usually
+use a thin lens approximation:
 
   ![Figure [cam-lens]: Camera lens model](../images/fig.cam-lens.jpg)
 
@@ -2803,8 +2804,8 @@ This gives:
 </div>
 
 An interesting thing you might note is the glass balls don’t really have shadows which makes them
-look like they are floating. This is not a bug (you don’t see glass balls much in real life, where
-they also look a bit strange, and indeed seem to float on cloudy days). A point on the big sphere
+look like they are floating. This is not a bug -- you don’t see glass balls much in real life, where
+they also look a bit strange, and indeed seem to float on cloudy days. A point on the big sphere
 under a glass ball still has lots of light hitting it because the sky is re-ordered rather than
 blocked.
 

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -17,7 +17,7 @@ Overview
 ====================================================================================================
 
 I’ve taught many graphics classes over the years. Often I do them in ray tracing, because you are
-forced to write all the code but you can still get cool images with no API. I decided to adapt my
+forced to write all the code, but you can still get cool images with no API. I decided to adapt my
 course notes into a how-to, to get you to a cool program as quickly as possible. It will not be a
 full-featured ray tracer, but it does have the indirect lighting which has made ray tracing a staple
 in movies. Follow these steps, and the architecture of the ray tracer you produce will be good for
@@ -33,8 +33,8 @@ in a weekend. If you take longer, don’t worry about it. I use C++ as the drivi
 don’t need to. However, I suggest you do, because it’s fast, portable, and most production movie and
 video game renderers are written in C++. Note that I avoid most “modern features” of C++, but
 inheritance and operator overloading are too useful for ray tracers to pass on. I do not provide the
-code online, but the code is real and I show all of it except for a few straightforward operators in
-the `vec3` class. I am a big believer in typing in code to learn it, but when code is available I
+code online, but the code is real, and I show all of it except for a few straightforward operators
+in the `vec3` class. I am a big believer in typing in code to learn it, but when code is available I
 use it, so I only practice what I preach when the code is not available. So don’t ask!
 
 I have left that last part in because it is funny what a 180 I have done. Several readers ended up
@@ -64,7 +64,7 @@ Output an Image
 ====================================================================================================
 
 Whenever you start a renderer, you need a way to see an image. The most straightforward way is to
-write it to a file. The catch is, there are so many formats and many of those are complex. I always
+write it to a file. The catch is, there are so many formats, and many of those are complex. I always
 start with a plain text ppm file. Here’s a nice description from Wikipedia:
 
   ![](../images/img.ppm-example.jpg)
@@ -140,7 +140,7 @@ Opening the output file (in `ToyViewer` on my Mac, but try it in your favorite v
 
 <div class='together'>
 Hooray! This is the graphics “hello world”. If your image doesn’t look like that, open the output
-file in a text editor and see what it looks like. It should start something like this:
+file in a text editor, and see what it looks like. It should start something like this:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     P3
@@ -171,7 +171,7 @@ progress of a long render, and also to possibly identify a run that's stalled ou
 loop or other problem.
 
 <div class='together'>
-Our program outputs the image to the standard output stream (`std::cout`), so leave that alone and
+Our program outputs the image to the standard output stream (`std::cout`), so leave that alone, and
 instead write to the error output stream (`std::cerr`):
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -357,7 +357,7 @@ Rays, a Simple Camera, and Background
 <div class='together'>
 The one thing that all ray tracers have is a ray class, and a computation of what color is seen
 along a ray. Let’s think of a ray as a function $\mathbf{p}(t) = \mathbf{a} + t \vec{\mathbf{b}}$.
-Here $\mathbf{p}$ is a 3D position along a line in 3D. $\mathbf{a}$ is the ray origin and
+Here $\mathbf{p}$ is a 3D position along a line in 3D. $\mathbf{a}$ is the ray origin, and
 $\vec{\mathbf{b}}$ is the ray direction. The ray parameter $t$ is a real number (`double` in the
 code). Plug in a different $t$ and $p(t)$ moves the point along the ray. Add in negative $t$ and you
 can go anywhere on the 3D line. For positive $t$, you get only the parts in front of $\mathbf{a}$,
@@ -401,7 +401,7 @@ The function $p(t)$ in more verbose code form I call `ray::at(t)`:
 </div>
 
 Now we are ready to turn the corner and make a ray tracer. At the core, the ray tracer sends rays
-through pixels and computes the color seen in the direction of those rays. The involved steps are
+through pixels, and computes the color seen in the direction of those rays. The involved steps are
 (1) calculate the ray from the eye to the pixel, (2) determine which objects the ray intersects, and
 (3) compute a color for that intersection point. When first developing a ray tracer, I always do a
 simple camera for getting the code up and running. I also make a simple `color(ray)` function that
@@ -411,7 +411,7 @@ I’ve often gotten into trouble using square images for debugging because I tra
 often, so I’ll stick with a 200×100 image. I’ll put the “eye” (or camera center if you think of a
 camera) at $(0,0,0)$. I will have the y-axis go up, and the x-axis to the right. In order to respect
 the convention of a right handed coordinate system, into the screen is the negative z-axis. I will
-traverse the screen from the lower left hand corner and use two offset vectors along the screen
+traverse the screen from the lower left hand corner, and use two offset vectors along the screen
 sides to move the ray endpoint across the screen. Note that I do not make the ray direction a unit
 length vector because I think not doing that makes for simpler and slightly faster code.
 
@@ -535,7 +535,7 @@ or expanding the full form of the ray $p(t)$:
 </div>
 
 <div class='together'>
-The rules of vector algebra are all that we would want here, and if we expand that equation and
+The rules of vector algebra are all that we would want here, and if we expand that equation, and
 move all the terms to the left hand side we get:
 
   $$ t^2 \vec{\mathbf{b}}\cdot\vec{\mathbf{b}}
@@ -715,11 +715,11 @@ Using these observations, we can now simplify the sphere-intersection code to th
 
 
 Now, how about several spheres? While it is tempting to have an array of spheres, a very clean
-solution is the make an “abstract class” for anything a ray might hit and make both a sphere and a
+solution is the make an “abstract class” for anything a ray might hit, and make both a sphere and a
 list of spheres just something you can hit. What that class should be called is something of a
 quandary -- calling it an “object” would be good if not for “object oriented” programming. “Surface”
 is often used, with the weakness being maybe we will want volumes. “hittable” emphasizes the member
-function that unites them. I don’t love any of these but I will go with “hittable”.
+function that unites them. I don’t love any of these, but I will go with “hittable”.
 
 <div class='together'>
 This `hittable` abstract class will have a hit function that takes in a ray. Most ray tracers have
@@ -864,10 +864,10 @@ information:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [normals-point-against]: <kbd>[sphere.h]</kbd> Remembering the side of the surface]
 
-The decision whether to have normals always point out or always point against the ray is based on
+The decision whether to have normals always point out or to always point against the ray is based on
 whether you want to determine the side of the surface at the time of geometry or at the time of
 coloring. In this book we have more material types than we have geometry types, so we'll go for
-less work and put the determination at geometry time. This is simply a matter of preference and
+less work, and put the determination at geometry time. This is simply a matter of preference, and
 you'll see both implementations in the literature.
 
 We add the `front_face` bool to the `hit_record` struct. I know that we’ll also want motion blur at
@@ -1029,7 +1029,7 @@ above lines can be more simply expressed using C++'s `auto` type specifier:
 
 We'll use shared pointers in our code, because it allows multiple geometries to share a common
 instance (for example, a bunch of spheres that all use the same texture map material), and because
-it makes memory management automatic and easier to reason about.
+it makes memory management automatic, and easier to reason about.
 
 `std::shared_ptr` is included with the `<memory>` header.
 
@@ -1178,10 +1178,10 @@ Antialiasing
 
 When a real camera takes a picture, there are usually no jaggies along edges because the edge pixels
 are a blend of some foreground and some background. We can get the same effect by averaging a bunch
-of samples inside each pixel. We will not bother with stratification, which is controversial but is
+of samples inside each pixel. We will not bother with stratification, which is controversial, but is
 usual for my programs. For some ray tracers it is critical, but the kind of general one we are
-writing doesn’t benefit very much from it and it makes the code uglier. We abstract the camera class
-a bit so we can make a cooler camera later.
+writing doesn’t benefit very much from it, and it makes the code uglier. We abstract the camera
+class a bit so we can make a cooler camera later.
 
 One thing we need is a random number generator that returns real random numbers. We need a function
 that returns a canonical random number which by convention returns random real in the range
@@ -1384,8 +1384,8 @@ surfaces that look matte. One of the simplest ways to do this turns out to be ex
 ideal diffuse surfaces. (I used to do it as a lazy hack that approximates mathematically ideal
 Lambertian.)
 
-(Reader Vassillen Chizhov proved that the lazy hack is indeed just a lazy hack and is inaccurate.
-The correct representation of ideal Lambertian isn't much more work and is presented at the end of
+(Reader Vassillen Chizhov proved that the lazy hack is indeed just a lazy hack, and is inaccurate.
+The correct representation of ideal Lambertian isn't much more work, and is presented at the end of
 the chapter.)
 
 <div class='together'>
@@ -1394,7 +1394,7 @@ a center of $(p + \vec{N})$ and $(p - \vec{N})$, where $\vec{N}$ is the normal o
 sphere with a center at $(p - \vec{N})$ is considered _inside_ the surface, whereas the sphere with
 center $(p + \vec{N})$ is considered _outside_ the surface. Select the tangent unit radius sphere
 that is on the same side of the surface as the ray origin. Pick a random point $s$ inside this unit
-radius sphere and send a ray from the hit point $p$ to the random point $s$ (this is the vector
+radius sphere, and send a ray from the hit point $p$ to the random point $s$ (this is the vector
 $(s-p)$):
 
   ![Figure [rand-vector]: Generating a random diffuse bounce ray](../images/fig.rand-vector.jpg)
@@ -1404,7 +1404,7 @@ $(s-p)$):
 <div class='together'>
 We need a way to pick a random point in a unit radius sphere. We’ll use what is usually the easiest
 algorithm: a rejection method. First, pick a random point in the unit cube where x, y, and z all
-range from -1 to +1. Reject this point and try again if the point is outside the sphere.
+range from -1 to +1. Reject this point, and try again if the point is outside the sphere.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class vec3 {
@@ -1869,7 +1869,7 @@ within `hit_record`. See the highlighted lines below:
 
 <div class='together'>
 For the Lambertian (diffuse) case we already have, it can either scatter always and attenuate by its
-reflectance $R$, or it can scatter with no attenuation but absorb the fraction $1-R$ of the rays. Or
+reflectance $R$, or it can scatter with no attenuation but absorb the fraction $1-R$ of the rays, or
 it could be a mixture of those strategies. For Lambertian materials we get this simple class:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2030,7 +2030,7 @@ Which gives:
 </div>
 
 <div class='together'>
-We can also randomize the reflected direction by using a small sphere and choosing a new endpoint
+We can also randomize the reflected direction by using a small sphere, and choosing a new endpoint
 for the ray:
 
   ![Figure [reflect-fuzzy]: Generating fuzzed reflection rays](../images/fig.reflect-fuzzy.jpg)
@@ -2090,7 +2090,7 @@ Dielectrics
 
 Clear materials such as water, glass, and diamonds are dielectrics. When a light ray hits them, it
 splits into a reflected ray and a refracted (transmitted) ray. We’ll handle that by randomly
-choosing between reflection or refraction and only generating one scattered ray per interaction.
+choosing between reflection or refraction, and only generating one scattered ray per interaction.
 
 <div class='together'>
 The hardest part to debug is the refracted ray. I usually first just have all the light refract if
@@ -2107,7 +2107,7 @@ I got this (I have not told you how to do this right or wrong yet, but soon!):
 
 Is that right? Glass balls look odd in real life. But no, it isn’t right. The world should be
 flipped upside down and no weird black stuff. I just printed out the ray straight through the middle
-of the image and it was clearly wrong. That often does the job.
+of the image, and it was clearly wrong. That often does the job.
 
 <div class='together'>
 The refraction is described by Snell’s law:
@@ -2208,7 +2208,7 @@ And the dielectric material that always refracts is:
 
 <div class='together'>
 That definitely doesn't look right. One troublesome practical issue is that when the ray is in the
-material with the higher refractive index, there is no real solution to Snell’s law and thus there
+material with the higher refractive index, there is no real solution to Snell’s law, and thus there
 is no refraction possible. If we refer back to Snell's law and the derivation of $\sin\theta'$:
 
   $$ \sin\theta' = \frac{\eta}{\eta'} \cdot \sin\theta $$
@@ -2221,8 +2221,8 @@ The value of $\sin\theta'$ cannot be greater than 1. So, if,
 
   $$ \frac{1.5}{1.0} \cdot \sin\theta > 1.0 $$
 
-The equality between the two sides of the equation is broken and a solution cannot exist. If a
-solution does not exist the glass cannot refract and must reflect the ray:
+The equality between the two sides of the equation is broken, and a solution cannot exist. If a
+solution does not exist the glass cannot refract, and must reflect the ray:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     if(etai_over_etat * sin_theta > 1.0) {
@@ -2386,7 +2386,7 @@ This yields our full glass material:
 
 <div class='together'>
 An interesting and easy trick with dielectric spheres is to note that if you use a negative radius,
-the geometry is unaffected but the surface normal points inward, so it can be used as a bubble
+the geometry is unaffected, but the surface normal points inward, so it can be used as a bubble
 to make a hollow glass sphere:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2507,7 +2507,7 @@ products, and we now have a complete orthonormal basis (u,v,w) to describe our c
 
 Remember that `vup`, `v`, and `w` are all in the same plane. Note that, like before when our fixed
 camera faced -Z, our arbitrary view camera faces -w. And keep in mind that we can -- but we don’t
-have to -- use world up (0,1,0) to specify vup. This is convenient and will naturally keep your
+have to -- use world up (0,1,0) to specify vup. This is convenient, and will naturally keep your
 camera horizontally level until you decide to experiment with crazy camera angles.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2606,8 +2606,8 @@ want defocus blur.
 
 <div class="together">
 A real camera has a complicated compound lens. For our code we could simulate the order: sensor,
-then lens, then aperture, and figure out where to send the rays and flip the image once computed
-(the image is projected upside down on the film). Graphics people usually use a thin lens
+then lens, then aperture. Then we could figure out where to send the rays, and flip the image once
+computed (the image is projected upside down on the film). Graphics people usually use a thin lens
 approximation:
 
   ![Figure [cam-lens]: Camera lens model](../images/fig.cam-lens.jpg)
@@ -2804,7 +2804,7 @@ This gives:
 
 An interesting thing you might note is the glass balls don’t really have shadows which makes them
 look like they are floating. This is not a bug (you don’t see glass balls much in real life, where
-they also look a bit strange and indeed seem to float on cloudy days). A point on the big sphere
+they also look a bit strange, and indeed seem to float on cloudy days). A point on the big sphere
 under a glass ball still has lots of light hitting it because the sky is re-ordered rather than
 blocked.
 
@@ -2816,16 +2816,16 @@ You now have a cool ray tracer! What next?
   2. Biasing scattered rays toward them, and then downweighting those rays to cancel out the bias.
      Both work. I am in the minority in favoring the latter approach.
 
-  3. Triangles. Most cool models are in triangle form. The model I/O is the worst and almost
+  3. Triangles. Most cool models are in triangle form. The model I/O is the worst, and almost
      everybody tries to get somebody else’s code to do this.
 
-  4. Surface textures. This lets you paste images on like wall paper. Pretty easy and a good thing
+  4. Surface textures. This lets you paste images on like wall paper. Pretty easy, and a good thing
      to do.
 
   5. Solid textures. Ken Perlin has his code online. Andrew Kensler has some very cool info at his
      blog.
 
-  6. Volumes and media. Cool stuff and will challenge your software architecture. I favor making
+  6. Volumes and media. Cool stuff, and will challenge your software architecture. I favor making
      volumes have the hittable interface and probabilistically have intersections based on density.
      Your rendering code doesn’t even have to know it has volumes with that method.
 

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -51,10 +51,10 @@ shutter is open. As long as the objects are where they should be at that time, w
 average answer with a ray that is at exactly a single time. This is fundamentally why random ray
 tracing tends to be simple.
 
-The basic idea is to generate rays at random times while the shutter is open and intersect the model
-at that one time. The way it is usually done is to have the camera move and the objects move, but
-have each ray exist at exactly one time. This way the “engine” of the ray tracer can just make sure
-the objects are where they need to be for the ray, and the intersection guts don’t change much.
+The basic idea is to generate rays at random times while the shutter is open, and intersect the
+model at that one time. The way it is usually done is to have the camera move and the objects move,
+but have each ray exist at exactly one time. This way the “engine” of the ray tracer can just make
+sure the objects are where they need to be for the ray, and the intersection guts don’t change much.
 
 <div class='together'>
 For this we will first need to have a ray store the time it exists at:
@@ -188,7 +188,7 @@ times need not match up with the camera aperture open and close.
     [Listing [moving-sphere]: <kbd>[moving_sphere.h]</kbd> A moving sphere]
 
 <div class='together'>
-An alternative to making a new moving sphere class is to just make them all move and have the
+An alternative to making a new moving sphere class is to just make them all move, and have the
 stationary ones have the same begin and end point. I’m on the fence about that trade-off between
 fewer classes and more efficient stationary spheres, so let your design taste guide you. The
 intersection code barely needs a change: `center` just needs to become a function `center(time)`:
@@ -266,7 +266,7 @@ Be sure that in the materials you have the scattered rays be at the time of the 
 
 <div class='together'>
 The code below takes the example diffuse spheres from the scene at the end of the last book, and
-makes them move during the image render. (Think of a camera with shutter opening at time 0 and then
+makes them move during the image render. (Think of a camera with shutter opening at time 0, and then
 closing again at time 1.) Each sphere moves from its center $\mathbf{C}$ at time $t=0$ to
 $\mathbf{C} + (0, r/2, 0)$ at time $t=1$, where $r$ is a random number in $[0,1)$:
 
@@ -354,10 +354,10 @@ little, and when I add rectangles and boxes we won't have to go back and refacto
 The ray-object intersection is the main time-bottleneck in a ray tracer, and the time is linear with
 the number of objects. But it’s a repeated search on the same model, so we ought to be able to make
 it a logarithmic search in the spirit of binary search. Because we are sending millions to billions
-of rays on the same model, we can do an analog of sorting the model and then each ray intersection
+of rays on the same model, we can do an analog of sorting the model, and then each ray intersection
 can be a sublinear search. The two most common families of sorting are to 1) divide the space, and
-2) divide the objects. The latter is usually much easier to code up and just as fast to run for most
-models.
+2) divide the objects. The latter is usually much easier to code up, and just as fast to run for
+most models.
 
 <div class='together'>
 The key idea of a bounding volume over a set of primitives is to find a volume that fully encloses
@@ -540,7 +540,7 @@ $(e, E)$ would be:
 <div class='together'>
 If there are any `NaN`s running around there, the compare will return false so we need to be sure
 our bounding boxes have a little padding if we care about grazing cases (and we probably should
-because in a ray tracer all cases come up eventually). With all three dimensions in a loop and
+because in a ray tracer all cases come up eventually). With all three dimensions in a loop, and
 passing in the interval $t_{min}$, $t_{max}$ we get:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -580,7 +580,7 @@ standard library `fmax()` utility. `ffmax()` is quite a bit faster because it do
 `NaN`s and other exceptions.
 
 <div class='together'>
-In reviewing this intersection method, Andrew Kensler at Pixar tried some experiments and has
+In reviewing this intersection method, Andrew Kensler at Pixar tried some experiments, and has
 proposed this version of the code which works extremely well on many compilers, and I have adopted
 it as my go-to method:
 
@@ -605,10 +605,10 @@ it as my go-to method:
 
 <div class='together'>
 We now need to add a function to compute the bounding boxes of all the hittables. Then we will make
-a hierarchy of boxes over all the primitives and the individual primitives, like spheres, will live
+a hierarchy of boxes over all the primitives, and the individual primitives--like spheres--will live
 at the leaves. That function returns a bool because not all primitives have bounding boxes (_e.g._,
 infinite planes). In addition, objects move so it takes `time1` and `time2` for the interval of the
-frame and the bounding box will bound the object moving through that interval.
+frame, and the bounding box will bound the object moving through that interval.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class hittable {
@@ -959,7 +959,7 @@ now you should replace the `vec3(...)` with `make_shared<constant_texture>(vec3(
 
 <div class='together'>
 We can create a checker texture by noting that the sign of sine and cosine just alternates in a
-regular way and if we multiply trig functions in all three dimensions, the sign of that product
+regular way, and if we multiply trig functions in all three dimensions, the sign of that product
 forms a 3D checker pattern.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1502,7 +1502,7 @@ This finally gives something more reasonable looking:
 
 <div class='together'>
 Very often, a composite noise that has multiple summed frequencies is used. This is usually called
-turbulence and is a sum of repeated calls to noise:
+turbulence, and is a sum of repeated calls to noise:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class perlin {
@@ -1585,8 +1585,8 @@ We used the hitpoint p before to index a procedure solid texture like marble. We
 image and use a 2D $(u,v)$ texture coordinate to index into the image.
 
 <div class='together'>
-A direct way to use scaled $(u,v)$ in an image is to round the u and v to integers, and use that as
-$(i,j)$ pixels. This is awkward, because we don’t want to have to change the code when we change
+A direct way to use scaled $(u,v)$ in an image is to round the $u$ and $v$ to integers, and use that
+as $(i,j)$ pixels. This is awkward, because we don’t want to have to change the code when we change
 image resolution. So instead, one of the the most universal unofficial standards in graphics is to
 use texture coordinates instead of image pixel coordinates. These are just some form of fractional
 position in the image. For example, for pixel $(i,j)$ in an $N_x$ by $N_y$ image, the image texture
@@ -1617,8 +1617,8 @@ unit radius sphere on the origin is:
 </div>
 
 <div class='together'>
-We need to invert that. Because of the lovely `<cmath>` function `atan2()` which takes any number
-proportional to sine and cosine and returns the angle, we can pass in $x$ and $y$ (the
+We need to invert that. Because of the lovely `<cmath>` function `atan2()` (which takes any number
+proportional to sine and cosine and returns the angle), we can pass in $x$ and $y$ (the
 $\cos(\theta)$ cancel):
 
   $$ \phi = \text{atan2}(y, x) $$
@@ -2114,7 +2114,7 @@ We get:
 </div>
 
 <div class='together'>
-This is very noisy because the light is small. But we have a problem: some of the walls are facing
+This is very noisy because the light is small, but we have a problem: some of the walls are facing
 the wrong way. We haven't specified that a diffuse material should behave differently on different
 faces of the object, but what if the Cornell box had a different pattern on the inside and outside
 walls? The rectangle objects are described such that their front faces are always in the
@@ -2494,7 +2494,7 @@ Volumes
 One thing it’s nice to add to a ray tracer is smoke/fog/mist. These are sometimes called _volumes_
 or _participating media_. Another feature that is nice to add is subsurface scattering, which is
 sort of like dense fog inside an object. This usually adds software architectural mayhem because
-volumes are a different animal than surfaces. But a cute technique is to make a volume a random
+volumes are a different animal than surfaces, but a cute technique is to make a volume a random
 surface. A bunch of smoke can be replaced with a surface that probabilistically might or might not
 be there at every point in the volume. This will make more sense when you see the code.
 
@@ -2631,8 +2631,8 @@ not work with toruses or shapes that contain voids. It's possible to write an im
 handles arbitrary shapes, but we'll leave that as an exercise for the reader.
 
 <div class='together'>
-If we replace the two blocks with smoke and fog (dark and light particles) and make the light bigger
-(and dimmer so it doesn’t blow out the scene) for faster convergence:
+If we replace the two blocks with smoke and fog (dark and light particles), and make the light
+bigger (and dimmer so it doesn’t blow out the scene) for faster convergence:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     hittable_list cornell_smoke() {

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -51,10 +51,10 @@ shutter is open. As long as the objects are where they should be at that time, w
 average answer with a ray that is at exactly a single time. This is fundamentally why random ray
 tracing tends to be simple.
 
-The basic idea is to generate rays at random times while the shutter is open, and intersect the
-model at that one time. The way it is usually done is to have the camera move and the objects move,
-but have each ray exist at exactly one time. This way the “engine” of the ray tracer can just make
-sure the objects are where they need to be for the ray, and the intersection guts don’t change much.
+The basic idea is to generate rays at random times while the shutter is open and intersect the model
+at that one time. The way it is usually done is to have the camera move and the objects move, but
+have each ray exist at exactly one time. This way the “engine” of the ray tracer can just make sure
+the objects are where they need to be for the ray, and the intersection guts don’t change much.
 
 <div class='together'>
 For this we will first need to have a ray store the time it exists at:
@@ -188,10 +188,10 @@ times need not match up with the camera aperture open and close.
     [Listing [moving-sphere]: <kbd>[moving_sphere.h]</kbd> A moving sphere]
 
 <div class='together'>
-An alternative to making a new moving sphere class is to just make them all move, and have the
-stationary ones have the same begin and end point. I’m on the fence about that trade-off between
-fewer classes and more efficient stationary spheres, so let your design taste guide you. The
-intersection code barely needs a change: `center` just needs to become a function `center(time)`:
+An alternative to making a new moving sphere class is to just make them all move, while stationary
+spheres have the same begin and end position. I’m on the fence about that trade-off between fewer
+classes and more efficient stationary spheres, so let your design taste guide you. The intersection
+code barely needs a change: `center` just needs to become a function `center(time)`:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     bool moving_sphere::hit(
@@ -266,9 +266,9 @@ Be sure that in the materials you have the scattered rays be at the time of the 
 
 <div class='together'>
 The code below takes the example diffuse spheres from the scene at the end of the last book, and
-makes them move during the image render. (Think of a camera with shutter opening at time 0, and then
-closing again at time 1.) Each sphere moves from its center $\mathbf{C}$ at time $t=0$ to
-$\mathbf{C} + (0, r/2, 0)$ at time $t=1$, where $r$ is a random number in $[0,1)$:
+makes them move during the image render. (Think of a camera with shutter opening at time 0 and
+closing at time 1.) Each sphere moves from its center $\mathbf{C}$ at time $t=0$ to $\mathbf{C} +
+(0, r/2, 0)$ at time $t=1$, where $r$ is a random number in $[0,1)$:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     hittable_list random_scene() {
@@ -356,8 +356,8 @@ the number of objects. But it’s a repeated search on the same model, so we oug
 it a logarithmic search in the spirit of binary search. Because we are sending millions to billions
 of rays on the same model, we can do an analog of sorting the model, and then each ray intersection
 can be a sublinear search. The two most common families of sorting are to 1) divide the space, and
-2) divide the objects. The latter is usually much easier to code up, and just as fast to run for
-most models.
+2) divide the objects. The latter is usually much easier to code up and just as fast to run for most
+models.
 
 <div class='together'>
 The key idea of a bounding volume over a set of primitives is to find a volume that fully encloses
@@ -541,7 +541,7 @@ $(e, E)$ would be:
 If there are any `NaN`s running around there, the compare will return false so we need to be sure
 our bounding boxes have a little padding if we care about grazing cases (and we probably should
 because in a ray tracer all cases come up eventually). With all three dimensions in a loop, and
-passing in the interval $t_{min}$, $t_{max}$ we get:
+passing in the interval $[t_{min}$, $t_{max}]$, we get:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #include "rtweekend.h"
@@ -580,9 +580,9 @@ standard library `fmax()` utility. `ffmax()` is quite a bit faster because it do
 `NaN`s and other exceptions.
 
 <div class='together'>
-In reviewing this intersection method, Andrew Kensler at Pixar tried some experiments, and has
-proposed this version of the code which works extremely well on many compilers, and I have adopted
-it as my go-to method:
+In reviewing this intersection method, Andrew Kensler at Pixar tried some experiments and proposed
+the following version of the code. It works extremely well on many compilers, and I have adopted it
+as my go-to method:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     inline bool aabb::hit(const ray& r, double tmin, double tmax) const {
@@ -607,8 +607,8 @@ it as my go-to method:
 We now need to add a function to compute the bounding boxes of all the hittables. Then we will make
 a hierarchy of boxes over all the primitives, and the individual primitives--like spheres--will live
 at the leaves. That function returns a bool because not all primitives have bounding boxes (_e.g._,
-infinite planes). In addition, objects move so it takes `time1` and `time2` for the interval of the
-frame, and the bounding box will bound the object moving through that interval.
+infinite planes). In addition, moving objects will have a bounding box that encloses the object for
+the entire time interval [`time1`,`time2`].
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class hittable {
@@ -2114,7 +2114,7 @@ We get:
 </div>
 
 <div class='together'>
-This is very noisy because the light is small, but we have a problem: some of the walls are facing
+This is very noisy because the light is small. But we have a problem: some of the walls are facing
 the wrong way. We haven't specified that a diffuse material should behave differently on different
 faces of the object, but what if the Cornell box had a different pattern on the inside and outside
 walls? The rectangle objects are described such that their front faces are always in the

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -93,7 +93,7 @@ The answer of $\pi$ found will vary from computer to computer based on the initi
 On my computer, this gives me the answer `Estimate of Pi = 3.0880000000`
 
 <div class='together'>
-If we change the program to run forever, and just print out a running estimate:
+If we change the program to run forever and just print out a running estimate:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #include "rtweekend.h"
@@ -194,7 +194,7 @@ One Dimensional MC Integration
 
 Integration is all about computing areas and volumes, so we could have framed
 chapter [A Simple Monte Carlo Program] in an integral form if we wanted to make it maximally
-confusing, but sometimes integration is the most natural and clean way to formulate things.
+confusing. But sometimes integration is the most natural and clean way to formulate things.
 Rendering is often such a problem. Let’s look at a classic integral:
 
 $$ I = \int_{0}^{2} x^2 dx $$
@@ -234,12 +234,12 @@ This suggests a MC approach:
     [Listing [integ-xsq-1]: <kbd>[integrate_x_sq.cc]</kbd> Integrating $x^2$]
 </div>
 
-This, as expected, produces approximately the exact answer we get with algebra, $I = 8/3$, but we
-could also do it for functions that we can’t analytically integrate like $\log(\sin(x))$. In
-graphics, we often have functions we can evaluate but can’t write down explicitly, or functions we
-can only probabilistically evaluate. That is in fact what the ray tracing `ray_color()` function of
-the last two books is -- we don’t know what color is seen in every direction, but we can
-statistically estimate it in any given dimension.
+This, as expected, produces approximately the exact answer we get with algebra, $I = 8/3$. We could
+also do it for functions that we can’t analytically integrate like $\log(\sin(x))$. In graphics, we
+often have functions we can evaluate but can’t write down explicitly, or functions we can only
+probabilistically evaluate. That is in fact what the ray tracing `ray_color()` function of the last
+two books is -- we don’t know what color is seen in every direction, but we can statistically
+estimate it in any given dimension.
 
 One problem with the random program we wrote in the first two books is that small light sources
 create too much noise. This is because our uniform sampling doesn’t sample these light sources often
@@ -361,9 +361,9 @@ That means $f$ just undoes whatever $P$ does. So,
 </div>
 
 <div class='together'>
-The -1 means “inverse function”. Ugly notation, but standard. For our purposes, this means that if
-we have PDF $p()$ and cumulative distribution function $P()$, then if we use this "inverse function"
-with a random number, we’ll get what we want:
+The -1 means “inverse function”. Ugly notation, but standard. For our purposes, if we have PDF $p()$
+and cumulative distribution function $P()$, we can use this "inverse function" with a random number
+to get what we want:
 
   $$ e = P^{-1} (\text{random_double}()) $$
 </div>
@@ -577,7 +577,7 @@ code above produces that. Next, we are ready to apply that in ray tracing!
 The key point here is that all the integrals and probability and all that are over the unit sphere.
 The area on the unit sphere is how you measure the directions. Call it direction, solid angle, or
 area -- it’s all the same thing. Solid angle is the term usually used. If you are comfortable with
-that, great! If not, do what I do, and imagine the area on the unit sphere that a set of directions
+that, great! If not, do what I do and imagine the area on the unit sphere that a set of directions
 goes through. The solid angle $\omega$ and the projected area $A$ on the unit sphere are the same
 thing.
 
@@ -603,7 +603,7 @@ Probability of light being absorbed: $1-A$
 
 Here $A$ stands for _albedo_ (latin for _whiteness_). Albedo is a precise technical term in some
 disciplines, but in all cases it is used to define some form of _fractional reflectance_. This
-_fractional reflectance_ (or albedo) will vary with color, and (as we implemented for our glass in
+_fractional reflectance_ (or albedo) will vary with color and (as we implemented for our glass in
 book one) can vary with incident direction.
 
 In most physically based renderers, we would use a set of wavelengths for the light color rather
@@ -622,9 +622,9 @@ The color of a surface in terms of these quantities is:
   $$ Color = \int A \cdot s(direction) \cdot \text{color}(direction) $$
 </div>
 
-Note that $A$ and $s()$ may depend on the view direction, and may depend on the scattering position
-(position on a surface or position within a volume). Therefore, the output color may also vary with
-view direction or scattering position.
+Note that $A$ and $s()$ may depend on the view direction and the scattering position (position on a
+surface or position within a volume). Therefore, the output color may also vary with view direction
+or scattering position.
 
 <div class='together'>
 If we apply the MC basic formula we get the following statistical estimate:
@@ -667,7 +667,7 @@ The numerator and denominator cancel out, and we get:
   $$ Color = A \cdot color(direction) $$
 
 This is exactly what we had in our original `ray_color()` function! However, we need to generalize
-now so we can send extra rays in important directions, such as toward the lights.
+so we can send extra rays in important directions, such as toward the lights.
 
 The treatment above is slightly non-standard because I want the same math to work for surfaces and
 volumes. To do otherwise will make some ugly code.
@@ -702,7 +702,7 @@ would be:
   $$ p(direction) = \frac{1}{2}\cdotp Light(direction) + \frac{1}{2}\cdot pSurface(direction) $$
 </div>
 
-As long as the weights are positive, and add up to one, any such mixture of PDFs is a PDF. Remember,
+As long as the weights are positive and add up to one, any such mixture of PDFs is a PDF. Remember,
 we can use any PDF: _all PDF eventually converge to the correct answer_. So, the game is to figure
 out how to make the PDF larger where the product $s(direction) \cdot color(direction)$ is large. For
 diffuse surfaces, this is mainly a matter of guessing where $color(direction)$ is high.
@@ -711,8 +711,9 @@ For a mirror, $s()$ is huge only near one direction, so it matters a lot more. M
 fact make mirrors a special case, and just make the $s/p$ implicit -- our code currently does that.
 
 <div class='together'>
-Let’s do simple refactoring, and temporarily remove all materials that aren’t Lambertian. We can use
-our Cornell Box scene again, and let’s generate the camera in the function that generates the model:
+Let’s do a simple refactoring and temporarily remove all materials that aren’t Lambertian. We can
+use our Cornell Box scene again, and let’s generate the camera in the function that generates the
+model:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     hittable_list cornell_box(camera& cam, double aspect) {
@@ -770,7 +771,7 @@ Reducing that noise is our goal. We’ll do that by constructing a PDF that send
 light.
 </div>
 
-First, let’s instrument the code so that it explicitly samples some PDF, and then normalizes for
+First, let’s instrument the code so that it explicitly samples some PDF and then normalizes for
 that. Remember MC basics: $\int f(x) \approx f(r)/p(r)$. For the Lambertian material, let’s sample
 like we do now: $p(direction) = \cos(\theta) / \pi$.
 
@@ -914,14 +915,14 @@ Let’s build some infrastructure to address this.
 Generating Random Directions
 ====================================================================================================
 
-In this and the next two chapters let’s harden our understanding and tools, and figure out which
+In this and the next two chapters, let’s harden our understanding and tools and figure out which
 Cornell Box is right. Let’s first figure out how to generate random directions, but to simplify
 things let’s assume the z-axis is the surface normal and $\theta$ is the angle from the normal.
 We’ll get them oriented to the surface normal vector in the next chapter. We will only deal with
-distributions that are rotationally symmetric about $z$. So $p(direction) = f(\theta)$. If you
-have had advanced calculus, you may recall that on the sphere in spherical coordinates
-$dA = \sin(\theta) \cdot d\theta \cdot d\phi$. If you haven’t, you’ll have to take my word for the
-next step, but you’ll get it when you take advanced calc.
+distributions that are rotationally symmetric about $z$. So $p(direction) = f(\theta)$. If you have
+had advanced calculus, you may recall that on the sphere in spherical coordinates $dA = \sin(\theta)
+\cdot d\theta \cdot d\phi$. If you haven’t, you’ll have to take my word for the next step, but
+you’ll get it when you take advanced calc.
 
 <div class='together'>
 Given a directional PDF, $p(direction) = f(\theta)$ on the sphere, the 1D PDFs on $\theta$ and
@@ -1261,7 +1262,7 @@ Which produces:
   </div>
 
 Is that right? We still don’t know for sure. Tracking down bugs is hard in the absence of reliable
-reference solutions. Let’s table that for now, and move on to get rid of some of that noise.
+reference solutions. Let’s table that for now and get rid of some of that noise.
 </div>
 
 
@@ -1385,7 +1386,7 @@ down. We can do that by letting the emitted member function of hittable take ext
 </div>
 
 <div class='together'>
-We also need to flip the light so its normals point in the -y direction, and we get:
+We also need to flip the light so its normals point in the -y direction. This gives us:
 
   <div class="render">
 
@@ -1805,12 +1806,12 @@ rays; that’s a personal design preference.
 
 There are some other issues with the code.
 
-The PDF construction is hard coded in the `ray_color()` function, and we should clean that up.
-Probably we should pass something into color about the lights. Unlike BVH construction, we should be
-careful about memory leaks as there are an unbounded number of samples.
+The PDF construction is hard coded in the `ray_color()` function. We should clean that up, probably
+by passing something into color about the lights. Unlike BVH construction, we should be careful
+about memory leaks as there are an unbounded number of samples.
 
 The specular rays (glass and metal) are no longer supported. The math would work out if we just made
-their scattering function a delta function, but that would be floating point disaster. We could
+their scattering function a delta function. But that would be floating point disaster. We could
 either separate out specular reflections, or have surface roughness never be zero and have
 almost-mirrors that look perfectly smooth but don’t generate NaNs. I don’t have an opinion on which
 way to do it (I have tried both and they both have their advantages), but we have smooth metal and
@@ -1818,8 +1819,8 @@ glass code anyway, so I add perfect specular surfaces that do not do explicit f(
 
 We also lack a real background function infrastructure in case we want to add an environment map or
 more interesting functional background. Some environment maps are HDR (the R/G/B components are
-floats rather than 0–255 bytes usually interpreted as 0-1). Our output has been HDR all along, and
-we’ve just been truncating it.
+floats rather than 0–255 bytes usually interpreted as 0-1). Our output has been HDR all along; we’ve
+just been truncating it.
 
 Finally, our renderer is RGB and a more physically based one -- like an automobile manufacturer
 might use -- would probably need to use spectral colors and maybe even polarization. For a movie

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -622,7 +622,7 @@ The color of a surface in terms of these quantities is:
   $$ Color = \int A \cdot s(direction) \cdot \text{color}(direction) $$
 </div>
 
-Note that $A$ and $s()$ may depend on the view direction and the scattering position (position on a
+Note that $A$ and $s()$ may depend on the view direction or the scattering position (position on a
 surface or position within a volume). Therefore, the output color may also vary with view direction
 or scattering position.
 

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -18,7 +18,7 @@ Overview
 
 In _Ray Tracing in One Weekend_ and _Ray Tracing: the Next Week_, you built a “real” ray tracer.
 
-In this volume, I assume you will be pursuing a career related to ray tracing and we will dive into
+In this volume, I assume you will be pursuing a career related to ray tracing, and we will dive into
 the math of creating a very serious ray tracer. When you are done you should be ready to start
 messing with the many serious commercial ray tracers underlying the movie and product design
 industries. There are many many things I do not cover in this short volume; I dive into only one of
@@ -93,7 +93,7 @@ The answer of $\pi$ found will vary from computer to computer based on the initi
 On my computer, this gives me the answer `Estimate of Pi = 3.0880000000`
 
 <div class='together'>
-If we change the program to run forever and just print out a running estimate:
+If we change the program to run forever, and just print out a running estimate:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #include "rtweekend.h"
@@ -184,7 +184,7 @@ Interestingly, the stratified method is not only better, it converges with a bet
 Unfortunately, this advantage decreases with the dimension of the problem (so for example, with the
 3D sphere volume version the gap would be less). This is called the *Curse of Dimensionality*. We
 are going to be very high dimensional (each reflection adds two dimensions), so I won't stratify in
-this book. But if you are ever doing single-reflection or shadowing or some strictly 2D problem, you
+this book, but if you are ever doing single-reflection or shadowing or some strictly 2D problem, you
 definitely want to stratify.
 
 
@@ -194,7 +194,7 @@ One Dimensional MC Integration
 
 Integration is all about computing areas and volumes, so we could have framed
 chapter [A Simple Monte Carlo Program] in an integral form if we wanted to make it maximally
-confusing. But sometimes integration is the most natural and clean way to formulate things.
+confusing, but sometimes integration is the most natural and clean way to formulate things.
 Rendering is often such a problem. Let’s look at a classic integral:
 
 $$ I = \int_{0}^{2} x^2 dx $$
@@ -234,7 +234,7 @@ This suggests a MC approach:
     [Listing [integ-xsq-1]: <kbd>[integrate_x_sq.cc]</kbd> Integrating $x^2$]
 </div>
 
-This, as expected, produces approximately the exact answer we get with algebra, $I = 8/3$. But we
+This, as expected, produces approximately the exact answer we get with algebra, $I = 8/3$, but we
 could also do it for functions that we can’t analytically integrate like $\log(\sin(x))$. In
 graphics, we often have functions we can evaluate but can’t write down explicitly, or functions we
 can only probabilistically evaluate. That is in fact what the ray tracing `ray_color()` function of
@@ -281,7 +281,7 @@ A _probability density function_, henceforth _PDF_, is that fractional histogram
 
 Let’s make a _PDF_ and use it a bit to understand it more. Suppose I want a random number $r$
 between 0 and 2 whose probability is proportional to itself: $r$. We would expect the PDF $p(r)$ to
-look something like the figure below. But how high should it be?
+look something like the figure below, but how high should it be?
 
   ![Figure [linear-pdf]: A linear PDF](../images/fig.linear-pdf.jpg)
 
@@ -295,8 +295,8 @@ convention, and we should pick something that is convenient. Just as with histog
 
 <div class='together'>
 where $C$ is a scaling constant. We may as well make $C = 1$ for cleanliness, and that is exactly
-what is done in probability. And we know the probability $r$ has the value 1 somewhere, so for
-this case
+what is done in probability. We also know the probability $r$ has the value 1 somewhere, so for this
+case
 
   $$ \text{area}(p(r), 0, 2) = 1 $$
 </div>
@@ -361,9 +361,9 @@ That means $f$ just undoes whatever $P$ does. So,
 </div>
 
 <div class='together'>
-The -1 means “inverse function”. Ugly notation, but standard. For our purposes what this means is,
-if we have PDF $p()$ and cumulative distribution function $P()$, then if we use this "inverse
-function" with a random number we’ll get what we want:
+The -1 means “inverse function”. Ugly notation, but standard. For our purposes, this means that if
+we have PDF $p()$ and cumulative distribution function $P()$, then if we use this "inverse function"
+with a random number, we’ll get what we want:
 
   $$ e = P^{-1} (\text{random_double}()) $$
 </div>
@@ -426,7 +426,7 @@ sampling_.
 
 <div class='together'>
 If we take that same code with uniform samples so the PDF = $1/2$ over the range [0,2] we can use
-the machinery to get `x = random_double(0,2)` and the code is:
+the machinery to get `x = random_double(0,2)`, and the code is:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
     inline double pdf(double x) {
@@ -520,7 +520,7 @@ Suppose we have this integral over all directions:
   $$ \int cos^2(\theta) $$
 
 <div class='together'>
-By MC integration, we should just be able to sample $\cos^2(\theta) / p(\text{direction})$. But what
+By MC integration, we should just be able to sample $\cos^2(\theta) / p(\text{direction})$, but what
 is direction in that context? We could make it based on polar coordinates, so $p$ would be in terms
 of $(\theta, \phi)$. However you do it, remember that a PDF has to integrate to 1 and represent the
 relative probability of that direction being sampled. We have a method from the last books to take
@@ -547,8 +547,8 @@ uniform random samples in or on a unit sphere:
 
 <div class='together'>
 Now what is the PDF of these uniform points? As a density on the unit sphere, it is $1/\text{area}$
-of the sphere or $1/(4\pi)$. If the integrand is $\cos^2(\theta)$ and $\theta$ is the angle with the
-z axis:
+of the sphere or $1/(4\pi)$. If the integrand is $\cos^2(\theta)$, and $\theta$ is the angle with
+the z axis:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     inline double pdf(const vec3& p) {
@@ -577,7 +577,7 @@ code above produces that. Next, we are ready to apply that in ray tracing!
 The key point here is that all the integrals and probability and all that are over the unit sphere.
 The area on the unit sphere is how you measure the directions. Call it direction, solid angle, or
 area -- it’s all the same thing. Solid angle is the term usually used. If you are comfortable with
-that, great! If not, do what I do and imagine the area on the unit sphere that a set of directions
+that, great! If not, do what I do, and imagine the area on the unit sphere that a set of directions
 goes through. The solid angle $\omega$ and the projected area $A$ on the unit sphere are the same
 thing.
 
@@ -603,7 +603,7 @@ Probability of light being absorbed: $1-A$
 
 Here $A$ stands for _albedo_ (latin for _whiteness_). Albedo is a precise technical term in some
 disciplines, but in all cases it is used to define some form of _fractional reflectance_. This
-_fractional reflectance_ (or albedo) will vary with color and (as we implemented for our glass in
+_fractional reflectance_ (or albedo) will vary with color, and (as we implemented for our glass in
 book one) can vary with incident direction.
 
 In most physically based renderers, we would use a set of wavelengths for the light color rather
@@ -622,7 +622,7 @@ The color of a surface in terms of these quantities is:
   $$ Color = \int A \cdot s(direction) \cdot \text{color}(direction) $$
 </div>
 
-Note that $A$ and $s()$ may depend on the view direction and may depend on the scattering position
+Note that $A$ and $s()$ may depend on the view direction, and may depend on the scattering position
 (position on a surface or position within a volume). Therefore, the output color may also vary with
 view direction or scattering position.
 
@@ -662,12 +662,12 @@ If we sample using a PDF that equals the scattering PDF:
 
   $$ p(direction) = s(direction) = \frac{\cos(\theta)}{\pi} $$
 
-The numerator and denominator cancel out and we get:
+The numerator and denominator cancel out, and we get:
 
   $$ Color = A \cdot color(direction) $$
 
-This is exactly what we had in our original `ray_color()` function! But we need to generalize now so
-we can send extra rays in important directions such as toward the lights.
+This is exactly what we had in our original `ray_color()` function! However, we need to generalize
+now so we can send extra rays in important directions, such as toward the lights.
 
 The treatment above is slightly non-standard because I want the same math to work for surfaces and
 volumes. To do otherwise will make some ugly code.
@@ -702,16 +702,16 @@ would be:
   $$ p(direction) = \frac{1}{2}\cdotp Light(direction) + \frac{1}{2}\cdot pSurface(direction) $$
 </div>
 
-As long as the weights are positive and add up to one, any such mixture of PDFs is a PDF. Remember,
+As long as the weights are positive, and add up to one, any such mixture of PDFs is a PDF. Remember,
 we can use any PDF: _all PDF eventually converge to the correct answer_. So, the game is to figure
 out how to make the PDF larger where the product $s(direction) \cdot color(direction)$ is large. For
 diffuse surfaces, this is mainly a matter of guessing where $color(direction)$ is high.
 
 For a mirror, $s()$ is huge only near one direction, so it matters a lot more. Most renderers in
-fact make mirrors a special case and just make the $s/p$ implicit -- our code currently does that.
+fact make mirrors a special case, and just make the $s/p$ implicit -- our code currently does that.
 
 <div class='together'>
-Let’s do simple refactoring and temporarily remove all materials that aren’t Lambertian. We can use
+Let’s do simple refactoring, and temporarily remove all materials that aren’t Lambertian. We can use
 our Cornell Box scene again, and let’s generate the camera in the function that generates the model:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -770,7 +770,7 @@ Reducing that noise is our goal. We’ll do that by constructing a PDF that send
 light.
 </div>
 
-First, let’s instrument the code so that it explicitly samples some PDF and then normalizes for
+First, let’s instrument the code so that it explicitly samples some PDF, and then normalizes for
 that. Remember MC basics: $\int f(x) \approx f(r)/p(r)$. For the Lambertian material, let’s sample
 like we do now: $p(direction) = \cos(\theta) / \pi$.
 
@@ -904,8 +904,8 @@ And again I _should_ get the same picture except with different variance, but I 
 
 It’s pretty close to our old picture, but there are differences that are not noise. The front of the
 tall box is much more uniform in color. So I have the most difficult kind of bug to find in a Monte
-Carlo program -- a bug that produces a reasonable looking image. And I don’t know if the bug is the
-first version of the program or the second, or even in both!
+Carlo program -- a bug that produces a reasonable looking image. I also don’t know if the bug is the
+first version of the program, or the second, or both!
 
 Let’s build some infrastructure to address this.
 
@@ -914,7 +914,7 @@ Let’s build some infrastructure to address this.
 Generating Random Directions
 ====================================================================================================
 
-In this and the next two chapters let’s harden our understanding and tools and figure out which
+In this and the next two chapters let’s harden our understanding and tools, and figure out which
 Cornell Box is right. Let’s first figure out how to generate random directions, but to simplify
 things let’s assume the z-axis is the surface normal and $\theta$ is the angle from the normal.
 We’ll get them oriented to the surface normal vector in the next chapter. We will only deal with
@@ -961,7 +961,7 @@ Solving for $\cos(\theta)$ gives:
 
   $$ \cos(\theta) = 1 - 2 r_2 $$
 
-We don’t solve for theta because we probably only need to know $\cos(\theta)$ anyway and don’t want
+We don’t solve for theta because we probably only need to know $\cos(\theta)$ anyway, and don’t want
 needless $\arccos()$ calls running around.
 </div>
 
@@ -1015,7 +1015,7 @@ On the plot.ly website you can rotate that around and see that it appears unifor
 
 <div class='together'>
 Now let’s derive uniform on the hemisphere. The density being uniform on the hemisphere means
-$p(direction) = \frac{1}{2\pi}$ and just changing the constant in the theta equations yields:
+$p(direction) = \frac{1}{2\pi}$. Just changing the constant in the theta equations yields:
 
   $$ \cos(\theta) = 1 - r_2 $$
 </div>
@@ -1147,7 +1147,7 @@ If you take an intro graphics course, there will be a lot of time spent on coord
 4×4 coordinate transformation matrices. Pay attention, it’s important stuff in graphics! But we
 won’t need it. What we need to is generate random directions with a set distribution relative to
 $\vec{\mathbf{n}}$. We don’t need an origin because a direction is relative to no specified origin.
-We do need two cotangent vectors that are mutually perpendicular to $\vec{\mathbf{n}}$ and to each
+We do need two cotangent vectors that are mutually perpendicular to $\vec{\mathbf{n}}$, and to each
 other.
 
 <div class='together'>
@@ -1180,15 +1180,15 @@ axis.
 </div>
 
 <div class='together'>
-Once we have an ONB of $\vec{\mathbf{s}}$, $\vec{\mathbf{t}}$, and $\vec{\mathbf{n}}$ and we have a
-$random(x,y,z)$ relative to the Z-axis we can get the vector relative to $\vec{n}$ as:
+Once we have an ONB of $\vec{\mathbf{s}}$, $\vec{\mathbf{t}}$, and $\vec{\mathbf{n}}$, and we have a
+$random(x,y,z)$ relative to the Z-axis, we can get the vector relative to $\vec{n}$ as:
 
   $$ \text{Random vector} = x \vec{\mathbf{s}} + y \vec{\mathbf{t}} + z \vec{\mathbf{n}} $$
 </div>
 
 <div class='together'>
 You may notice we used similar math to get rays from a camera. That could be viewed as a change to
-the camera’s natural coordinate system. Should we make a class for ONBs or are utility functions
+the camera’s natural coordinate system. Should we make a class for ONBs, or are utility functions
 enough? I’m not sure, but let’s make a class because it won't really be more complicated than
 utility functions:
 
@@ -1261,7 +1261,7 @@ Which produces:
   </div>
 
 Is that right? We still don’t know for sure. Tracking down bugs is hard in the absence of reliable
-reference solutions. Let’s table that for now and move on to get rid of some of that noise.
+reference solutions. Let’s table that for now, and move on to get rid of some of that noise.
 </div>
 
 
@@ -1278,8 +1278,8 @@ It’s really easy to pick a random direction toward the light; just pick a rand
 and send a ray in that direction. We also need to know the PDF, $p(direction)$. What is that?
 
 For a light of area $A$, if we sample uniformly on that light, the PDF on the surface of the light
-is $\frac{1}{A}$. But what is it on the area of the unit sphere that defines directions?
-Fortunately, there is a simple correspondence, as outlined in the diagram:
+is $\frac{1}{A}$. What is it on the area of the unit sphere that defines directions? Fortunately,
+there is a simple correspondence, as outlined in the diagram:
 
   ![Figure [light-pdf]: Projection of light shape onto PDF](../images/fig.light-pdf.jpg)
 
@@ -1385,7 +1385,7 @@ down. We can do that by letting the emitted member function of hittable take ext
 </div>
 
 <div class='together'>
-We also need to flip the light so its normals point in the -y direction and we get:
+We also need to flip the light so its normals point in the -y direction, and we get:
 
   <div class="render">
 
@@ -1786,7 +1786,7 @@ And plugging it into `ray_color()`:
 
 We’ve basically gotten this same picture (with different levels of noise) with several different
 sampling patterns. It looks like the original picture was slightly wrong! Note by “wrong” here I
-mean not a correct Lambertian picture. But Lambertian is just an ideal approximation to matte, so
+mean not a correct Lambertian picture. Yet Lambertian is just an ideal approximation to matte, so
 our original picture was some other accidental approximation to matte. I don’t think the new one is
 any better, but we can at least compare it more easily with other Lambertian renderers.
 
@@ -1796,30 +1796,29 @@ Some Architectural Decisions
 ====================================================================================================
 
 I won't write any code in this chapter. We’re at a crossroads where I need to make some
-architectural decisions. The mixture-density approach is to not have traditional shadow rays and is
+architectural decisions. The mixture-density approach is to not have traditional shadow rays, and is
 something I personally like, because in addition to lights you can sample windows or bright cracks
 under doors or whatever else you think might be bright. But most programs branch, and send one or
-more terminal rays to lights explicitly and one according to the reflective distribution of the
+more terminal rays to lights explicitly, and one according to the reflective distribution of the
 surface. This could be a time you want faster convergence on more restricted scenes and add shadow
 rays; that’s a personal design preference.
 
 There are some other issues with the code.
 
-The PDF construction is hard coded in the `ray_color()` function and we should clean that up.
+The PDF construction is hard coded in the `ray_color()` function, and we should clean that up.
 Probably we should pass something into color about the lights. Unlike BVH construction, we should be
 careful about memory leaks as there are an unbounded number of samples.
 
 The specular rays (glass and metal) are no longer supported. The math would work out if we just made
-their scattering function a delta function. But that would be floating point disaster. We could
+their scattering function a delta function, but that would be floating point disaster. We could
 either separate out specular reflections, or have surface roughness never be zero and have
 almost-mirrors that look perfectly smooth but don’t generate NaNs. I don’t have an opinion on which
-way to do it -- I have tried both and they both have their advantages -- but we have smooth metal
-and glass code anyway, so I add perfect specular surfaces that do not do explicit f()/p()
-calculations.
+way to do it (I have tried both and they both have their advantages), but we have smooth metal and
+glass code anyway, so I add perfect specular surfaces that do not do explicit f()/p() calculations.
 
 We also lack a real background function infrastructure in case we want to add an environment map or
 more interesting functional background. Some environment maps are HDR (the R/G/B components are
-floats rather than 0–255 bytes usually interpreted as 0-1). Our output has been HDR all along and
+floats rather than 0–255 bytes usually interpreted as 0-1). Our output has been HDR all along, and
 we’ve just been truncating it.
 
 Finally, our renderer is RGB and a more physically based one -- like an automobile manufacturer
@@ -1971,7 +1970,7 @@ And `ray_color()` changes are small:
 
 <div class='together'>
 We have not yet dealt with specular surfaces, nor instances that mess with the surface normal, and
-we have added a memory leak by calling `new` in Lambertian material. But this design is clean
+we have added a memory leak by calling `new` in Lambertian material. However, this design is clean
 overall, and those are all fixable. For now, I will just fix `specular`. Metal is easy to fix.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2371,11 +2370,12 @@ organizing a physically based renderer’s sampling approach. Now you can explor
 potential paths.
 
 If you want to explore Monte Carlo methods, look into bidirectional and path spaced approaches such
-as Metropolis. Your probability space won't be over solid angle but will instead be over path space,
-where a path is a multidimensional point in a high-dimensional space. Don’t let that scare you -- if
-you can describe an object with an array of numbers, mathematicians call it a point in the space of
-all possible arrays of such points. That’s not just for show. Once you get a clean abstraction like
-that, your code can get clean too. Clean abstractions are what programming is all about!
+as Metropolis. Your probability space won't be over solid angle, but will instead be over path
+space, where a path is a multidimensional point in a high-dimensional space. Don’t let that scare
+you -- if you can describe an object with an array of numbers, mathematicians call it a point in the
+space of all possible arrays of such points. That’s not just for show. Once you get a clean
+abstraction like that, your code can get clean too. Clean abstractions are what programming is all
+about!
 
 If you want to do movie renderers, look at the papers out of studios and Solid Angle. They are
 surprisingly open about their craft.
@@ -2387,7 +2387,7 @@ If you want to do hard-core physically based renderers, convert your renderer fr
 I am a big fan of each ray having a random wavelength and almost all the RGBs in your program
 turning into floats. It sounds inefficient, but it isn’t!
 
-Regardless of what direction you take, add a glossy BRDF model. There are many to choose from and
+Regardless of what direction you take, add a glossy BRDF model. There are many to choose from, and
 each has its advantages.
 
 Have fun!


### PR DESCRIPTION
Generally adding commas before many conjunctions, rewording some
sentences that begin with a conjunction. I did not apply these changes
uniformly, particlularly where they would have messed with the tone of
the original text.