### PR TITLE
Update image generation code

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -466,9 +466,9 @@ for now because we’ll add antialiasing later):
     }
 
     int main() {
-        const int image_width = 768;
-        const auto aspect_ratio = 9.0 / 16.0;
-        const int image_height = static_cast<int>(aspect_ratio * image_width);
+        const auto aspect_ratio = 16.0 / 9.0;
+        const int image_width = 384;
+        const int image_height = static_cast<int>(image_width / aspect_ratio);
 
         std::cout << "P3\n" << image_width << " " << image_height << "\n255\n";
 
@@ -1180,8 +1180,9 @@ And the new main:
     }
 
     int main() {
-        const int image_width = 200;
-        const int image_height = 100;
+        const auto aspect_ratio = 16.0 / 9.0;
+        const int image_width = 384;
+        const int image_height = static_cast<int>(image_width / aspect_ratio);
 
         std::cout << "P3\n" << image_width << ' ' << image_height << "\n255\n";
 
@@ -1373,8 +1374,9 @@ Main is also changed:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     int main() {
-        const int image_width = 200;
-        const int image_height = 100;
+        const auto aspect_ratio = 16.0 / 9.0;
+        const int image_width = 384;
+        const int image_height = static_cast<int>(image_width / aspect_ratio);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         const int samples_per_pixel = 100;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1553,8 +1555,9 @@ depth, returning no light contribution at the maximum depth:
     ...
 
     int main() {
-        const int image_width = 200;
-        const int image_height = 100;
+        const auto aspect_ratio = 16.0 / 9.0;
+        const int image_width = 384;
+        const int image_height = static_cast<int>(image_width / aspect_ratio);
         const int samples_per_pixel = 100;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         const int max_depth = 50;
@@ -2076,8 +2079,9 @@ Now let’s add some metal spheres to our scene:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     int main() {
-        const int image_width = 200;
-        const int image_height = 100;
+        const auto aspect_ratio = 16.0 / 9.0;
+        const int image_width = 384;
+        const int image_height = static_cast<int>(image_width / aspect_ratio);
         const int samples_per_pixel = 100;
         const int max_depth = 50;
 
@@ -2563,14 +2567,14 @@ This implies $h = \tan(\frac{\theta}{2})$. Our camera now becomes:
         public:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             camera(
-                double vfov, // top to bottom, in degrees
-                double aspect
+                double vfov, // vertical field-of-view in degrees
+                double aspect_ratio
             ) {
                 origin = point3(0.0, 0.0, 0.0);
 
                 auto theta = degrees_to_radians(vfov);
                 auto half_height = tan(theta/2);
-                auto half_width = aspect * half_height;
+                auto half_width = aspect_ratio * half_height;
 
                 lower_left_corner = point3(-half_width, -half_height, -1.0);
 
@@ -2646,8 +2650,8 @@ camera horizontally level until you decide to experiment with crazy camera angle
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 point3 lookfrom, point3 lookat, vec3 vup,
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-                double vfov, // top to bottom, in degrees
-                double aspect
+                double vfov, // vertical field-of-view in degrees
+                double aspect_ratio
             ) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 origin = lookfrom;
@@ -2656,7 +2660,7 @@ camera horizontally level until you decide to experiment with crazy camera angle
 
                 auto theta = degrees_to_radians(vfov);
                 auto half_height = tan(theta/2);
-                auto half_width = aspect * half_height;
+                auto half_width = aspect_ratio * half_height;
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 w = unit_vector(lookfrom - lookat);
@@ -2687,8 +2691,6 @@ camera horizontally level until you decide to experiment with crazy camera angle
 This allows us to change the viewpoint:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    const auto aspect_ratio = double(image_width) / image_height;
-    ...
     camera cam(point3(-2,2,1), point3(0,0,-1), vup, 90, aspect_ratio);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-free-view]: <kbd>[main.cc]</kbd> Scene with alternate viewpoint]
@@ -2781,9 +2783,9 @@ defocus disk of radius zero (no blur at all), so all rays originated at the disk
         public:
             camera(
                 point3 lookfrom, point3 lookat, vec3 vup,
-                double vfov, // top to bottom, in degrees
+                double vfov, // vertical field-of-view in degrees
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-                double aspect, double aperture, double focus_dist
+                double aspect_ratio, double aperture, double focus_dist
             ) {
                 origin = lookfrom;
                 lens_radius = aperture / 2;
@@ -2791,7 +2793,7 @@ defocus disk of radius zero (no blur at all), so all rays originated at the disk
 
                 auto theta = degrees_to_radians(vfov);
                 auto half_height = tan(theta/2);
-                auto half_width = aspect * half_height;
+                auto half_width = aspect_ratio * half_height;
 
                 w = unit_vector(lookfrom - lookat);
                 u = unit_vector(cross(vup, w));
@@ -2837,8 +2839,6 @@ defocus disk of radius zero (no blur at all), so all rays originated at the disk
 Using a big aperture:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    const auto aspect_ratio = double(image_width) / image_height;
-    ...
     point3 lookfrom(3,3,2);
     point3 lookat(0,0,-1);
     vec3 vup(0,1,0);

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -109,9 +109,10 @@ to camera because for now it is not allowed to move; it just sends out rays over
         public:
             camera(
                 point3 lookfrom, point3 lookat, vec3 vup,
-                double vfov, // top to bottom, in degrees
+                double vfov, // vertical field-of-view in degrees
+                double aspect_ratio, double aperture, double focus_dist,
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-                double aspect, double aperture, double focus_dist, double t0 = 0, double t1 = 0
+                double t0 = 0, double t1 = 0
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             ) {
                 origin = lookfrom;

--- a/src/InOneWeekend/main.cc
+++ b/src/InOneWeekend/main.cc
@@ -90,11 +90,11 @@ hittable_list random_scene() {
 
 
 int main() {
+    const auto aspect_ratio = 16.0 / 9.0;
     const int image_width = 1200;
-    const int image_height = 800;
+    const int image_height = static_cast<int>(image_width / aspect_ratio);
     const int samples_per_pixel = 10;
     const int max_depth = 50;
-    const auto aspect_ratio = double(image_width) / image_height;
 
     std::cout << "P3\n" << image_width << ' ' << image_height << "\n255\n";
 
@@ -113,8 +113,8 @@ int main() {
         for (int i = 0; i < image_width; ++i) {
             color pixel_color;
             for (int s = 0; s < samples_per_pixel; ++s) {
-                auto u = (i + random_double()) / image_width;
-                auto v = (j + random_double()) / image_height;
+                auto u = (i + random_double()) / (image_width-1);
+                auto v = (j + random_double()) / (image_height-1);
                 ray r = cam.get_ray(u, v);
                 pixel_color += ray_color(r, world, max_depth);
             }

--- a/src/TheNextWeek/main.cc
+++ b/src/TheNextWeek/main.cc
@@ -339,9 +339,9 @@ hittable_list final_scene() {
 
 
 int main() {
+    const auto aspect_ratio = 1.0 / 1.0;
     const int image_width = 600;
-    const int image_height = 600;
-    const auto aspect_ratio = double(image_width) / image_height;
+    const int image_height = static_cast<int>(image_width / aspect_ratio);
 
     hittable_list world;
 
@@ -442,8 +442,8 @@ int main() {
         for (int i = 0; i < image_width; ++i) {
             color pixel_color;
             for (int s = 0; s < samples_per_pixel; ++s) {
-                auto u = (i + random_double()) / image_width;
-                auto v = (j + random_double()) / image_height;
+                auto u = (i + random_double()) / (image_width-1);
+                auto v = (j + random_double()) / (image_height-1);
                 ray r = cam.get_ray(u, v);
                 pixel_color += ray_color(r, background, world, max_depth);
             }

--- a/src/TheRestOfYourLife/main.cc
+++ b/src/TheRestOfYourLife/main.cc
@@ -100,11 +100,11 @@ hittable_list cornell_box(camera& cam, double aspect) {
 
 
 int main() {
+    const auto aspect_ratio = 1.0 / 1.0;
     const int image_width = 600;
-    const int image_height = 600;
+    const int image_height = static_cast<int>(image_width / aspect_ratio);
     const int samples_per_pixel = 100;
     const int max_depth = 50;
-    const auto aspect_ratio = double(image_width) / image_height;
 
     std::cout << "P3\n" << image_width << ' ' << image_height << "\n255\n";
 
@@ -122,8 +122,8 @@ int main() {
         for (int i = 0; i < image_width; ++i) {
             color pixel_color;
             for (int s = 0; s < samples_per_pixel; ++s) {
-                auto u = (i + random_double()) / image_width;
-                auto v = (j + random_double()) / image_height;
+                auto u = (i + random_double()) / (image_width-1);
+                auto v = (j + random_double()) / (image_height-1);
                 ray r = cam.get_ray(u, v);
                 pixel_color += ray_color(r, background, world, lights, max_depth);
             }

--- a/src/common/camera.h
+++ b/src/common/camera.h
@@ -20,8 +20,9 @@ class camera {
 
         camera(
             point3 lookfrom, point3 lookat, vec3 vup,
-            double vfov, // top to bottom, in degrees
-            double aspect, double aperture, double focus_dist, double t0 = 0, double t1 = 0
+            double vfov, // vertical field-of-view in degrees
+            double aspect_ratio, double aperture, double focus_dist,
+            double t0 = 0, double t1 = 0
         ) {
             origin = lookfrom;
             lens_radius = aperture / 2;
@@ -30,7 +31,7 @@ class camera {
 
             auto theta = degrees_to_radians(vfov);
             auto half_height = tan(theta/2);
-            auto half_width = aspect * half_height;
+            auto half_width = aspect_ratio * half_height;
 
             w = unit_vector(lookfrom - lookat);
             u = unit_vector(cross(vup, w));


### PR DESCRIPTION
Generally, define aspect ratio up front, then derive image height from
that and the image width.

This change also fixes an issue where the sampling was slightly off due
to an off-by-one error when computing the image basis vectors.

Finally, some naming and commenting tweaks to `aspect_ratio` and `vfov`.