### PR TITLE
Rendered images use Markdeep class=pixel

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -137,11 +137,7 @@ This is how things would look on Windows. On Mac or Linux, it would look like th
 Opening the output file (in `ToyViewer` on my Mac, but try it in your favorite viewer and Google
 “ppm viewer” if your viewer doesn’t support it) shows this result:
 
-  <div class="render">
-
-  ![First PPM image](../images/img.first-ppm-image.png)
-
-  </div>
+  ![First PPM image](../images/img.first-ppm-image.png class=pixel)
 
 </div>
 
@@ -516,11 +512,8 @@ interpolation”, or “lerp” for short, between two things. A lerp is always 
 
 with $t$ going from zero to one. In our case this produces:
 
-  <div class="render">
-
-  ![A blue-to-white gradient depending on ray Y coordinate](../images/img.blue-to-white.png)
-
-  </div>
+  ![A blue-to-white gradient depending on ray Y coordinate
+  ](../images/img.blue-to-white.png class=pixel)
 
 </div>
 
@@ -634,11 +627,7 @@ that hits a small sphere we place at -1 on the z-axis:
 <div class='together'>
 What we get is this:
 
-  <div class="render">
-
-  ![A simple red sphere](../images/img.red-sphere.png)
-
-  </div>
+  ![A simple red sphere](../images/img.red-sphere.png class=pixel)
 
 </div>
 
@@ -714,11 +703,7 @@ $\mathbf{n}$:
 <div class='together'>
 And that yields this picture:
 
-  <div class="render">
-
-  ![A sphere colored according to its normal vectors](../images/img.normals-sphere.png)
-
-  </div>
+  ![A sphere colored according to its normal vectors](../images/img.normals-sphere.png class=pixel)
 
 </div>
 
@@ -877,7 +862,8 @@ the ray. Alternatively, we can have the normal always point against the ray. If 
 the sphere, the normal will point outward, but if the ray is inside the sphere, the normal will
 point inward.
 
-  ![Figure [normal-directions]: Possible directions for sphere surface-normal geometry](../images/fig.normal-possibilities.jpg)
+  ![Figure [normal-directions]: Possible directions for sphere surface-normal geometry
+  ](../images/fig.normal-possibilities.jpg)
 
 </div>
 
@@ -1231,11 +1217,8 @@ And the new main:
 This yields a picture that is really just a visualization of where the spheres are along with their
 surface normal. This is often a great way to look at your model for flaws and characteristics.
 
-  <div class="render">
-
-  ![Resulting render of normals-colored sphere with ground](../images/img.normals-sphere-ground.png)
-
-  </div>
+  ![Resulting render of normals-colored sphere with ground
+  ](../images/img.normals-sphere-ground.png class=pixel)
 
 </div>
 
@@ -1422,11 +1405,7 @@ Main is also changed:
 Zooming into the image that is produced, the big change is in edge pixels that are part background
 and part foreground:
 
-  <div class="render">
-
-  ![Close-up of antialiased pixels](../images/img.antialias.png)
-
-  </div>
+  ![Close-up of antialiased pixels](../images/img.antialias.png class=pixel)
 
 </div>
 
@@ -1601,11 +1580,7 @@ depth, returning no light contribution at the maximum depth:
 <div class='together'>
 This gives us:
 
-  <div class="render">
-
-  ![First render of a diffuse sphere](../images/img.first-diffuse.jpg)
-
-  </div>
+  ![First render of a diffuse sphere](../images/img.first-diffuse.jpg class=pixel)
 
 </div>
 
@@ -1646,11 +1621,7 @@ square-root:
 <div class='together'>
 That yields light grey, as we desire:
 
-  <div class="render">
-
-  ![Diffuse sphere, with gamma correction](../images/img.gamma-correct.jpg)
-
-  </div>
+  ![Diffuse sphere, with gamma correction](../images/img.gamma-correct.jpg class=pixel)
 
 </div>
 
@@ -1730,11 +1701,7 @@ function.
 <div class='together'>
 After rendering we get a similar image:
 
-  <div class="render">
-
-  ![Correct rendering of Lambertian spheres](../images/img.correct-lambertian.png)
-
-  </div>
+  ![Correct rendering of Lambertian spheres](../images/img.correct-lambertian.png class=pixel)
 
 It's hard to tell the difference between these two diffuse methods, given that our scene of two
 spheres is so simple, but you should be able to notice two important visual differences:
@@ -1813,11 +1780,8 @@ Plugging the new formula into the `ray_color()` function:
 
 Gives us the following image:
 
-  <div class="render">
-
-  ![Rendering of diffuse spheres with hemispherical scattering](../images/img.rand-hemispherical.png)
-
-  </div>
+  ![Rendering of diffuse spheres with hemispherical scattering
+  ](../images/img.rand-hemispherical.png class=pixel)
 
 </div>
 
@@ -2140,11 +2104,7 @@ Now let’s add some metal spheres to our scene:
 <div class='together'>
 Which gives:
 
-  <div class="render">
-
-  ![Shiny metal](../images/img.metal-shiny.png)
-
-  </div>
+  ![Shiny metal](../images/img.metal-shiny.png class=pixel)
 
 </div>
 
@@ -2197,11 +2157,7 @@ absorb those.
 <div class='together'>
 We can try that out by adding fuzziness 0.3 and 1.0 to the metals:
 
-  <div class="render">
-
-  ![Fuzzed metal](../images/img.metal-fuzz.png)
-
-  </div>
+  ![Fuzzed metal](../images/img.metal-fuzz.png class=pixel)
 
 </div>
 
@@ -2222,11 +2178,7 @@ The hardest part to debug is the refracted ray. I usually first just have all th
 there is a refraction ray at all. For this project, I tried to put two glass balls in our scene, and
 I got this (I have not told you how to do this right or wrong yet, but soon!):
 
-  <div class="render">
-
-  ![Glass first](../images/img.glass-first.png)
-
-  </div>
+  ![Glass first](../images/img.glass-first.png class=pixel)
 
 </div>
 
@@ -2330,11 +2282,7 @@ And the dielectric material that always refracts is:
 
 This gives us the following result:
 
-<div class="render">
-
-  ![Glass sphere that always refracts](../images/img.glass-always-refract.png)
-
-</div>
+  ![Glass sphere that always refracts](../images/img.glass-always-refract.png class=pixel)
 
 
 Total Internal Reflection
@@ -2455,11 +2403,7 @@ parameters:
 
 We get:
 
-  <div class="render">
-
-  ![Glass sphere that sometimes refracts](../images/img.glass-sometimes-refract.png)
-
-  </div>
+  ![Glass sphere that sometimes refracts](../images/img.glass-sometimes-refract.png class=pixel)
 
 </div>
 
@@ -2544,11 +2488,7 @@ make a hollow glass sphere:
 <div class='together'>
 This gives:
 
-  <div class="render">
-
-  ![A hollow glass sphere](../images/img.glass-hollow.png)
-
-  </div>
+  ![A hollow glass sphere](../images/img.glass-hollow.png class=pixel)
 
 </div>
 
@@ -2625,11 +2565,7 @@ When calling it with camera `cam(90, double(image_width)/image_height)` and thes
 
 gives:
 
-  <div class="render">
-
-  ![A wide-angle view](../images/img.wide-view.png)
-
-  </div>
+  ![A wide-angle view](../images/img.wide-view.png class=pixel)
 
 </div>
 
@@ -2713,11 +2649,7 @@ This allows us to change the viewpoint:
 
 to get:
 
-  <div class="render">
-
-  ![A distant view](../images/img.view-distant.png)
-
-  </div>
+  ![A distant view](../images/img.view-distant.png class=pixel)
 
 And we can change field of view:
 
@@ -2728,11 +2660,7 @@ And we can change field of view:
 
 to get:
 
-  <div class="render">
-
-  ![Zooming in](../images/img.view-zoom.png)
-
-  </div>
+  ![Zooming in](../images/img.view-zoom.png class=pixel)
 
 </div>
 
@@ -2874,11 +2802,7 @@ Using a big aperture:
 
 We get:
 
-  <div class="render">
-
-  ![Spheres with depth-of-field](../images/img.depth-of-field.png)
-
-  </div>
+  ![Spheres with depth-of-field](../images/img.depth-of-field.png class=pixel)
 
 </div>
 
@@ -2955,11 +2879,8 @@ First let’s make the image on the cover of this book -- lots of random spheres
 <div class='together'>
 This gives:
 
-  <div class="render">
-
   ![Final scene](../images/img.book1-final.jpg)
 
-  </div>
 </div>
 
 An interesting thing you might note is the glass balls don’t really have shadows which makes them

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -352,11 +352,7 @@ And with these viewing parameters:
 
 gives the following result:
 
-  <div class="render">
-
-  ![Bouncing spheres](../images/img.bouncing-spheres.jpg)
-
-  </div>
+  ![Bouncing spheres](../images/img.bouncing-spheres.jpg class=pixel)
 
 </div>
 
@@ -1058,11 +1054,7 @@ If we add this to our `random_scene()` function’s base sphere:
 
 We get:
 
-  <div class="render">
-
-  ![Spheres on checkered ground](../images/img.checker-ground.jpg)
-
-  </div>
+  ![Spheres on checkered ground](../images/img.checker-ground.jpg class=pixel)
 
 </div>
 
@@ -1105,11 +1097,7 @@ With camera:
 
 We get:
 
-  <div class="render">
-
-  ![Checkered spheres](../images/img.checker-spheres.jpg)
-
-  </div>
+  ![Checkered spheres](../images/img.checker-spheres.jpg class=pixel)
 
 </div>
 
@@ -1122,19 +1110,11 @@ Perlin Noise
 To get cool looking solid textures most people use some form of Perlin noise. These are named after
 their inventor Ken Perlin. Perlin texture doesn’t return white noise like this:
 
-  <div class="render">
-
-  ![White noise](../images/img.white-noise.jpg)
-
-  </div>
+  ![White noise](../images/img.white-noise.jpg class=pixel)
 
 Instead it returns something similar to blurred white noise:
 
-  <div class="render">
-
-  ![White noise, blurred](../images/img.white-noise-blur.jpg)
-
-  </div>
+  ![White noise, blurred](../images/img.white-noise-blur.jpg class=pixel)
 
 </div>
 
@@ -1150,11 +1130,7 @@ Using Blocks of Random Numbers
 We could just tile all of space with a 3D array of random numbers and use them in blocks. You get
 something blocky where the repeating is clear:
 
-  <div class="render">
-
-  ![Tiled random patterns](../images/img.tile-random.jpg)
-
-  </div>
+  ![Tiled random patterns](../images/img.tile-random.jpg class=pixel)
 
 </div>
 
@@ -1284,11 +1260,7 @@ With the same camera as before:
 <div class='together'>
 Add the hashing does scramble as hoped:
 
-  <div class="render">
-
-  ![Hashed random texture](../images/img.hash-random.jpg)
-
-  </div>
+  ![Hashed random texture](../images/img.hash-random.jpg class=pixel)
 
 </div>
 
@@ -1343,11 +1315,7 @@ To make it smooth, we can linearly interpolate:
 <div class='together'>
 And we get:
 
-  <div class="render">
-
-  ![Perlin texture with trilinear interpolation](../images/img.perlin-trilerp.jpg)
-
-  </div>
+  ![Perlin texture with trilinear interpolation](../images/img.perlin-trilerp.jpg class=pixel)
 
 </div>
 
@@ -1385,11 +1353,8 @@ a Hermite cubic to round off the interpolation:
 <div class='together'>
 This gives a smoother looking image:
 
-  <div class="render">
-
-  ![Perlin texture, trilinearly interpolated, smoothed](../images/img.perlin-tlerp-smooth.jpg)
-
-  </div>
+  ![Perlin texture, trilinearly interpolated, smoothed
+  ](../images/img.perlin-tlerp-smooth.jpg class=pixel)
 
 </div>
 
@@ -1420,11 +1385,7 @@ It is also a bit low frequency. We can scale the input point to make it vary mor
 
 which gives:
 
-  <div class="render">
-
-  ![Perlin texture, higher frequency](../images/img.perlin-hifreq.jpg)
-
-  </div>
+  ![Perlin texture, higher frequency](../images/img.perlin-hifreq.jpg class=pixel)
 
 </div>
 
@@ -1564,11 +1525,7 @@ perlin output back to between 0 and 1.
 <div class='together'>
 This finally gives something more reasonable looking:
 
-  <div class="render">
-
-  ![Perlin texture, shifted off integer values](../images/img.perlin-shift.jpg)
-
-  </div>
+  ![Perlin texture, shifted off integer values](../images/img.perlin-shift.jpg class=pixel)
 
 </div>
 
@@ -1607,11 +1564,7 @@ Here `fabs()` is the absolute value function defined in `<cmath>`.
 <div class='together'>
 Used directly, turbulence gives a sort of camouflage netting appearance:
 
-  <div class="render">
-
-  ![Perlin texture with turbulence](../images/img.perlin-turb.jpg)
-
-  </div>
+  ![Perlin texture with turbulence](../images/img.perlin-turb.jpg class=pixel)
 
 </div>
 
@@ -1646,11 +1599,7 @@ effect is:
 
 Which yields:
 
-  <div class="render">
-
-  ![Perlin noise, marbled texture](../images/img.perlin-marble.jpg)
-
-  </div>
+  ![Perlin noise, marbled texture](../images/img.perlin-marble.jpg class=pixel)
 
 </div>
 
@@ -1827,11 +1776,7 @@ Using an Image Texture
 <div class='together'>
 I just grabbed a random earth map from the web -- any standard projection will do for our purposes.
 
-  <div class="render">
-
-  ![earthmap.jpg](../images/earthmap.jpg)
-
-  </div>
+  ![earthmap.jpg](../images/earthmap.jpg class=pixel)
 
 </div>
 
@@ -1857,11 +1802,7 @@ to the lambertian material, and lambertian doesn’t need to be aware of it.
 To test this, assign it to a sphere, and then temporarily cripple the `ray_color()` function in main
 to just return attenuation. You should get something like:
 
-  <div class="render">
-
-  ![Earth-mapped sphere](../images/img.earth-sphere.jpg)
-
-  </div>
+  ![Earth-mapped sphere](../images/img.earth-sphere.jpg class=pixel)
 
 </div>
 
@@ -2077,11 +2018,7 @@ If we set up a rectangle as a light:
 <div class='together'>
 We get:
 
-  <div class="render">
-
-  ![Scene with rectangle light source](../images/img.rect-light.jpg)
-
-  </div>
+  ![Scene with rectangle light source](../images/img.rect-light.jpg class=pixel)
 
 </div>
 
@@ -2090,11 +2027,7 @@ Note that the light is brighter than $(1,1,1)$. This allows it to be bright enou
 <div class='together'>
 Fool around with making some spheres lights too.
 
-  <div class="render">
-
-  ![Scene with rectangle and sphere light sources](../images/img.rect-sph-light.jpg)
-
-  </div>
+  ![Scene with rectangle and sphere light sources](../images/img.rect-sph-light.jpg class=pixel)
 
 </div>
 
@@ -2241,11 +2174,7 @@ And the view info:
 <div class='together'>
 We get:
 
-  <div class="render">
-
-  ![Empty Cornell box](../images/img.cornell-first.jpg)
-
-  </div>
+  ![Empty Cornell box](../images/img.cornell-first.jpg class=pixel)
 
 </div>
 
@@ -2319,11 +2248,7 @@ This makes Cornell:
 <div class='together'>
 And voila:
 
-  <div class="render">
-
-  ![Empty Cornell box with fixed walls](../images/img.cornell-empty.jpg)
-
-  </div>
+  ![Empty Cornell box with fixed walls](../images/img.cornell-empty.jpg class=pixel)
 
 </div>
 
@@ -2391,11 +2316,7 @@ Now we can add two blocks (but not rotated)
 <div class='together'>
 This gives:
 
-  <div class="render">
-
-  ![Cornell box with two blocks](../images/img.cornell-blocks.jpg)
-
-  </div>
+  ![Cornell box with two blocks](../images/img.cornell-blocks.jpg class=pixel)
 
 </div>
 
@@ -2623,11 +2544,7 @@ And the changes to Cornell are:
 <div class='together'>
 Which yields:
 
-  <div class="render">
-
-  ![Standard Cornell box scene](../images/img.cornell-box.jpg)
-
-  </div>
+  ![Standard Cornell box scene](../images/img.cornell-box.jpg class=pixel)
 
 </div>
 
@@ -2821,11 +2738,7 @@ bigger (and dimmer so it doesn’t blow out the scene) for faster convergence:
 <div class='together'>
 We get:
 
-  <div class="render">
-
-  ![Cornell box with blocks of smoke](../images/img.cornell-smoke.jpg)
-
-  </div>
+  ![Cornell box with blocks of smoke](../images/img.cornell-smoke.jpg class=pixel)
 
 </div>
 
@@ -2913,11 +2826,7 @@ why we get caustics and subsurface for free. It’s a double-edged design decisi
 <div class='together'>
 Running it with 10,000 rays per pixel yields:
 
-  <div class="render">
-
   ![Final scene](../images/img.book2-final.jpg)
-
-  </div>
 
 </div>
 

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -798,11 +798,7 @@ model:
 <div class='together'>
 At 500×500 my code produces this image in 10min on 1 core of my Macbook:
 
-  <div class="render">
-
-  ![Cornell box, refactored](../images/img.cornell-refactor1.jpg)
-
-  </div>
+  ![Cornell box, refactored](../images/img.cornell-refactor1.jpg class=pixel)
 
 Reducing that noise is our goal. We’ll do that by constructing a PDF that sends more rays to the
 light.
@@ -945,11 +941,7 @@ randomly from the hemisphere above the surface. This would be $p(direction) = \f
 <div class='together'>
 And again I _should_ get the same picture except with different variance, but I don’t!
 
-  <div class="render">
-
-  ![Cornell box, with different sampling strategy](../images/img.cornell-refactor2.jpg)
-
-  </div>
+  ![Cornell box, with different sampling strategy](../images/img.cornell-refactor2.jpg class=pixel)
 
 </div>
 
@@ -1317,11 +1309,8 @@ We can rewrite our Lambertian material using this to get:
 <div class='together'>
 Which produces:
 
-  <div class="render">
-
-  ![Cornell box, with orthonormal basis scatter function](../images/img.cornell-ortho.jpg)
-
-  </div>
+  ![Cornell box, with orthonormal basis scatter function
+  ](../images/img.cornell-ortho.jpg class=pixel)
 
 Is that right? We still don’t know for sure. Tracking down bugs is hard in the absence of reliable
 reference solutions. Let’s table that for now and get rid of some of that noise.
@@ -1426,11 +1415,8 @@ that math and get the concept, we can add it (see the highlighted region):
 <div class='together'>
 With 10 samples per pixel this yields:
 
-  <div class="render">
-
-  ![Cornell box, sampling only the light, 10 samples per pixel](../images/img.cornell-samplight.jpg)
-
-  </div>
+  ![Cornell box, sampling only the light, 10 samples per pixel
+  ](../images/img.cornell-samplight.jpg class=pixel)
 
 </div>
 
@@ -1461,11 +1447,8 @@ down. We can do that by letting the emitted member function of hittable take ext
 <div class='together'>
 We also need to flip the light so its normals point in the -y direction. This gives us:
 
-  <div class="render">
-
-  ![Cornell box, light emitted only in the downward direction](../images/img.cornell-lightdown.jpg)
-
-  </div>
+  ![Cornell box, light emitted only in the downward direction
+  ](../images/img.cornell-lightdown.jpg class=pixel)
 
 </div>
 
@@ -1614,11 +1597,7 @@ change variable `pdf` to some other variable name to avoid a name conflict with 
 This yields an apparently matching result so all we’ve done so far is refactor where `pdf` is
 computed:
 
-  <div class="render">
-
-  ![Cornell box with a cosine density _pdf_](../images/img.cornell-cospdf.jpg)
-
-  </div>
+  ![Cornell box with a cosine density _pdf_](../images/img.cornell-cospdf.jpg class=pixel)
 
 </div>
 
@@ -1764,11 +1743,8 @@ And then change `ray_color()`:
 <div class='together'>
 At 10 samples per pixel we get:
 
-  <div class="render">
-
-  ![Cornell box, sampling a hittable light, 10 samples per pixel](../images/img.cornell-samphit.jpg)
-
-  </div>
+  ![Cornell box, sampling a hittable light, 10 samples per pixel
+  ](../images/img.cornell-samphit.jpg class=pixel)
 
 </div>
 
@@ -1859,11 +1835,8 @@ And plugging it into `ray_color()`:
 <div class='together'>
 1000 samples per pixel yields:
 
-  <div class="render">
-
-  ![Cornell box, mixture density of cosine and light sampling](../images/img.cornell-coslight.jpg)
-
-  </div>
+  ![Cornell box, mixture density of cosine and light sampling
+  ](../images/img.cornell-coslight.jpg class=pixel)
 
 </div>
 
@@ -2194,11 +2167,7 @@ We also need to change the block to metal.
 The resulting image has a noisy reflection on the ceiling because the directions toward the box are
 not sampled with more density.
 
-  <div class="render">
-
-  ![Cornell box with arbitrary PDF functions](../images/img.cornell-flexpdf.jpg)
-
-  </div>
+  ![Cornell box with arbitrary PDF functions](../images/img.cornell-flexpdf.jpg class=pixel)
 
 </div>
 
@@ -2343,11 +2312,8 @@ This yields a noisy box, but the caustic under the sphere is good. It took five 
 sampling the light did for my code. This is probably because those rays that hit the glass are
 expensive!
 
-  <div class="render">
-
-  ![Cornell box with glass sphere, using new PDF functions](../images/img.cornell-glass.jpg)
-
-  </div>
+  ![Cornell box with glass sphere, using new PDF functions
+  ](../images/img.cornell-glass.jpg class=pixel)
 
 </div>
 
@@ -2393,11 +2359,8 @@ We assemble a list to pass to `ray_color()` `from main()`:
 <div class='together'>
 And we get a decent image with 1000 samples as before:
 
-  <div class="render">
-
-  ![Cornell box, using a mixture of glass & light PDFs](../images/img.cornell-glasslight.jpg)
-
-  </div>
+  ![Cornell box, using a mixture of glass & light PDFs
+  ](../images/img.cornell-glasslight.jpg class=pixel)
 
 </div>
 
@@ -2453,11 +2416,7 @@ for `NaN`s is that a `NaN` does not equal itself. Using this trick, we update th
 <div class='together'>
 Happily, the black specks are gone:
 
-  <div class="render">
-
-  ![Cornell box with anti-acne color function](../images/img.book3-final.jpg)
-
-  </div>
+  ![Cornell box with anti-acne color function](../images/img.book3-final.jpg class=pixel)
 
 </div>
 

--- a/style/book.css
+++ b/style/book.css
@@ -152,10 +152,6 @@ div.indented {
     width: 72ex;
 }
 
-.md div.render img {
-    image-rendering: pixelated;
-}
-
 .md div.image {
     margin-bottom: 1em;
 }


### PR DESCRIPTION
Markdeep provides a `class=pixel` attribute for included images in order
to render with a point-sampled result. I didn't realize this when I
originally created CSS styling and an enclosing `div` element to do this
before. Switching the prior styling to now use Markdeep's feature.

Resolves #498