### PR TITLE
The C++ `<random>` version of `random_double()` no longer depends on the `<functional>` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Change Log -- Ray Tracing in One Weekend
 - Change: First image size changed to 256x256
 - Change: Default image sizes changed from 200x100 to 384x216
 - Change: Define image aspect ratio up front, then image height from that and the image width
+- Change: The C++ `<random>` version of `random_double()` no longer depends on `<functional>` header
 
 ### _The Next Week_
 - Change: Large rewrite of the `image_texture` class. Now handles image loading too. (#434)

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1290,15 +1290,12 @@ addressed this issue with the `<random>` header (if imperfectly according to som
 If you want to use this, you can obtain a random number with the conditions we need as follows:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include <functional>
     #include <random>
 
     inline double random_double() {
         static std::uniform_real_distribution<double> distribution(0.0, 1.0);
         static std::mt19937 generator;
-        static std::function<double()> rand_generator =
-            std::bind(distribution, generator);
-        return rand_generator();
+        return generator(distribution);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [random-double-alt]: <kbd>[rtweekend.h]</kbd> random_double(), alternate implemenation]


### PR DESCRIPTION
#468 also has some discussion on fixed seeding, but that is a bigger change that should probably be in a separate commit. 

As the discussion, the only way to achieve true portable random number generation is to not use what the standard library provided. We can probably put something like [Xorshift](https://en.wikipedia.org/wiki/Xorshift) in the book if we want to achieve that.