### PR TITLE
Fix book 3 listing 28, 30 / use default material

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Change Log -- Ray Tracing in One Weekend
   - Fix: Missing closing parenthesis in listing 10 (#603)
   - Fix: Tiny improvements to the lambertian::scatter() development (#604)
   - Fix: Correct geometry type and unit vector method in `ray_color()`, listing 20 (#606)
+  - Fix: Listing 28, 30: `light_shape` should have default material, not `0` (#607)
 
 
 ----------------------------------------------------------------------------------------------------

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -1710,7 +1710,8 @@ And then change `ray_color()`:
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        shared_ptr<hittable> light_shape = make_shared<xz_rect>(213, 343, 227, 332, 554, 0);
+        shared_ptr<hittable> light_shape =
+            make_shared<xz_rect>(213, 343, 227, 332, 554, shared_ptr<material>());
         hittable_pdf p(light_shape, rec.p);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
@@ -1797,11 +1798,10 @@ And plugging it into `ray_color()`:
         if (!rec.mat_ptr->scatter(r, rec, albedo, scattered, pdf_val))
             return emitted;
 
-
+        shared_ptr<hittable> light_shape =
+            make_shared<xz_rect>(213, 343, 227, 332, 554, make_shared<material>());
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        shared_ptr<hittable> light_ptr = make_shared<xz_rect>(213, 343, 227, 332, 554, 0);
-        hittable_pdf p0(light_ptr, rec.p);
-
+        hittable_pdf p0(light_shape, rec.p);
         cosine_pdf p1(rec.normal);
         mixture_pdf p(&p0, &p1);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++


### PR DESCRIPTION
The original listing had `0` where it should have had
`make_shared<material>()`.

Resolves #607