### PR TITLE
Fixed book 2 Chapter 8.1 typo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Change Log -- Ray Tracing in One Weekend
     that take `shared_ptr<texture>` arguments, simplifying calling code. This applies to the
     following classes: `checker_texture`, `constant_medium`, `diffuse_light`, and `lambertian`.
     (#516)
+  - Fix: "Intance" typo in Chapter 8.1 to "Instance" (#629)
 
 ### _In One Weekend_
   - Change: Updated all rendered images except for 1.13, 1.14 (#179, #547, #548, #549, #550, #551,

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -2295,7 +2295,7 @@ subtract 2 off the x-component of the ray origin.
 </div>
 
 
-Intance Translation
+Instance Translation
 --------------------
 <div class='together'>
 Whether you think of this as a move or a change of coordinates is up to you. The code for this, to


### PR DESCRIPTION
Fixes #629 .
I saw two versions in progress in the CHANGELOG.md file: v3.2.0 and v3.1.2. I've put this change under v3.2.0, let me know if it should go under v3.1.2.