### PR TITLE
Fix usage of random generator

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1315,7 +1315,7 @@ If you want to use this, you can obtain a random number with the conditions we n
     inline double random_double() {
         static std::uniform_real_distribution<double> distribution(0.0, 1.0);
         static std::mt19937 generator;
-        return generator(distribution);
+        return distribution(generator);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [random-double-alt]: <kbd>[rtweekend.h]</kbd> random_double(), alternate implemenation]


### PR DESCRIPTION
I am reading [Ray Tracing in One Weekend](https://raytracing.github.io/books/RayTracingInOneWeekend.html) on the web,
and encountered compile error in Chapter 7:

```sh
$ g++ -O2 -c -o main.o -std=c++11 main.cpp
In file included from main.cpp:1:
./rtweekend.h:30:10: error: no matching function for call to object of type 'std::mt19937' (aka 'mersenne_twister_engine<unsigned int, 32, 624, 397, 31,
      2567483615U, 11, 4294967295U, 7, 2636928640U, 15, 4022730752U, 18, 1812433253>')
  return generator(distribution);
         ^~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/random:2129:17: note: candidate function not viable:
      requires 0 arguments, but 1 was provided
    result_type operator()();
                ^
1 error generated.
make: *** [main.o] Error 1
```

It looks there is some error in RNG usage.
Would you please take a look this PR?
Thanks!
