### PR TITLE
acks: link to GitHub user pages where known

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -4,8 +4,8 @@
 
 
                                    **Ray Tracing in One Weekend**
-                                           Peter Shirley
-                          edited by Steve Hollasch and Trevor David Black
+                                         [Peter Shirley][]
+                      edited by [Steve Hollasch][] and [Trevor David Black][]
                                                 <br>
                                      Version 3.1.2, 2020-06-03
                                                 <br>
@@ -2987,6 +2987,12 @@ Have fun, and please send me your cool images!
 
 
                                (insert acknowledgments.md.html here)
+
+
+
+[Peter Shirley]:      https://github.com/petershirley
+[Steve Hollasch]:     https://github.com/hollasch
+[Trevor David Black]: https://github.com/trevordblack
 
 
 

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -4,8 +4,8 @@
 
 
                                    **Ray Tracing: The Next Week**
-                                           Peter Shirley
-                          edited by Steve Hollasch and Trevor David Black
+                                         [Peter Shirley][]
+                      edited by [Steve Hollasch][] and [Trevor David Black][]
                                                 <br>
                                      Version 3.1.2, 2020-06-03
                                                 <br>
@@ -2864,8 +2864,10 @@ images to me at ptrshrl@gmail.com.
 
 
 
-[Markdeep]:  https://casual-effects/markdeep/
-[stb_image]: https://github.com/nothings/stb
+[stb_image]:          https://github.com/nothings/stb
+[Peter Shirley]:      https://github.com/petershirley
+[Steve Hollasch]:     https://github.com/hollasch
+[Trevor David Black]: https://github.com/trevordblack
 
 
 

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -4,8 +4,8 @@
 
 
                                **Ray Tracing: The Rest of Your Life**
-                                           Peter Shirley
-                          edited by Steve Hollasch and Trevor David Black
+                                         [Peter Shirley][]
+                      edited by [Steve Hollasch][] and [Trevor David Black][]
                                                 <br>
                                      Version 3.1.2, 2020-06-03
                                                 <br>
@@ -2444,12 +2444,18 @@ each has its advantages.
 
 Have fun!
 
-Peter Shirley<br>
+[Peter Shirley][]<br>
 Salt Lake City, March, 2016
 
 
 
                                (insert acknowledgments.md.html here)
+
+
+
+[Peter Shirley]:      https://github.com/petershirley
+[Steve Hollasch]:     https://github.com/hollasch
+[Trevor David Black]: https://github.com/trevordblack
 
 
 

--- a/books/acknowledgments.md.html
+++ b/books/acknowledgments.md.html
@@ -12,52 +12,53 @@ Acknowledgments
 
 <div class="credit-list"> **Web Release**
 
-  - Berna Kabadayı
-  - Lorenzo Mancini
-  - Lori Whippler Hollasch
-  - Ronald Wotzlaw
+  - [Berna Kabadayı](https://github.com/bernakabadayi)
+  - [Lorenzo Mancini](https://github.com/lmancini)
+  - [Lori Whippler Hollasch](https://github.com/lorihollasch)
+  - [Ronald Wotzlaw](https://github.com/ronaldfw)
 </div>
 
 <div class="credit-list"> **Corrections and Improvements**
 
-  - Aaryaman Vasishta
+  - [Aaryaman Vasishta](https://github.com/jammm)
   - Andrew Kensler
   - Apoorva Joshi
-  - Aras Pranckevičius
+  - [Aras Pranckevičius](https://github.com/aras-p)
   - Becker
   - Ben Kerl
   - Benjamin Summerton
   - Bennett Hardwick
   - Dan Drummond
-  - David Chambers
+  - [David Chambers](https://github.com/dafhi)
   - David Hart
-  - Eric Haines
+  - [Eric Haines](https://github.com/erich666)
   - Fabio Sancinetti
   - Filipe Scur
   - Frank He
-  - Gerrit Wessendorf
+  - [Gerrit Wessendorf](https://github.com/celeph)
   - Grue Debry
   - Ingo Wald
   - Jason Stone
   - Jean Buckley
   - Joey Cho
-  - Kaan Eraslan
-  - Lorenzo Mancini
-  - Manas Kale
+  - [Kaan Eraslan](https://github.com/D-K-E)
+  - [Lorenzo Mancini](https://github.com/lmancini)
+  - [Manas Kale](https://github.com/manas96)
   - Marcus Ottosson
+  - [Mark Craig](https://github.com/mrmcsoftware)
   - Matthew Heimlich
   - Nakata Daisuke
   - Paul Melis
   - Phil Cristensen
-  - Ronald Wotzlaw
-  - Shaun P. Lee
+  - [Ronald Wotzlaw](https://github.com/ronaldfw)
+  - [Shaun P. Lee](https://github.com/shaunplee)
   - Tatsuya Ogawa
   - Thiago Ize
   - Vahan Sosoyan
-  - ZeHao Chen
+  - [ZeHao Chen](https://github.com/oxine)
 </div>
 
-<div class="credit-list"> **Tools**
+<div class="credit-list"> **Special Thanks**
 
   <div class="indented">
   Thanks to the team at [Limnu](https://limnu.com/) for help on the figures.
@@ -65,6 +66,9 @@ Acknowledgments
   These books are entirely written in Morgan McGuire's fantastic and free
   [Markdeep](https://casual-effects.com/markdeep/) library. To see what this looks like, view the
   page source from your browser.
+
+  Thanks to [Helen Hu](https://github.com/hhu) for graciously donating her
+  https://github.com/RayTracing/ GitHub organization to this project.
 
   </div>
 </div>


### PR DESCRIPTION
(Direct into master)

This change updates our acknowledgments, linking contributor real names to their corresponding public GitHub user pages where known.

In addition, I realized that we never added public thanks to Helen Hu for donating the RayTracing GitHub organization, so added that.