### PR TITLE
Remove unnecesary include of cstdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Change Log -- Ray Tracing in One Weekend
 
 ### _In One Weekend_
   - Fix: replace old anti-alias result image with before-and-after image (#679)
+  - Delete: remove unnecessary `cstdlib` include, as it's not needed until we use `rand()` (#687)
 
 
 ----------------------------------------------------------------------------------------------------

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1183,7 +1183,6 @@ file.
     #define RTWEEKEND_H
 
     #include <cmath>
-    #include <cstdlib>
     #include <limits>
     #include <memory>
 


### PR DESCRIPTION
It's not needed until we use the std `rand()` function.

Resolves #687