### PR TITLE
Rtweekend include missing from listing 29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Change Log -- Ray Tracing in One Weekend
 
 ### _In One Weekend_
   - Fix: replace old anti-alias result image with before-and-after image (#679)
+  - Fix: Listing 29: Added missing `rtweekend.h` include (#691)
 
 
 ----------------------------------------------------------------------------------------------------

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -1422,6 +1422,8 @@ code to make it all happen:
     #ifndef PERLIN_H
     #define PERLIN_H
 
+    #include "rtweekend.h"
+
     class perlin {
         public:
             perlin() {


### PR DESCRIPTION
Fix listing 29 missing rtweekend include.
It's need for `random_double()`, `point3`, etc.

Resolves #691