### PR TITLE
Remove premature include of cstdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Change Log -- Ray Tracing in One Weekend
 # v3.2.1 (in progress)
 
 ### _In One Weekend_
+  - Delete: remove premature `cstdlib` include; not needed until we use `rand()` (#687)
   - Fix: replace old anti-alias result image with before-and-after image (#679)
   - Fix: undefined `vup` variable in camera definition (#686)
 

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1183,7 +1183,6 @@ file.
     #define RTWEEKEND_H
 
     #include <cmath>
-    #include <cstdlib>
     #include <limits>
     #include <memory>
 


### PR DESCRIPTION
It's not needed until we use the `rand()` function.

Resolves #687