### PR TITLE
Fix: Book2: Listing 33, 39, perlin.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Change Log -- Ray Tracing in One Weekend
   - Fix: Listing 29: Added missing `rtweekend.h` include (#691)
   - Fix: undefined `vup` variable in camera definition (#686)
   - Fix: Listing 51: Add missing `hittable.h`, `rtweekend.h` includes (#693)
+  - Fix: Listings 33, 39: Add  consistent function signature for `trilinear_interp` (#722)
 
 ### _The Next Week_
   - Delete: remove unused u,v,w variables in initial `perlin::noise()` function (#684)

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -1568,21 +1568,6 @@ To make it smooth, we can linearly interpolate:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-    inline double trilinear_interp(double c[2][2][2], double u, double v, double w) {
-        auto accum = 0.0;
-        for (int i=0; i < 2; i++)
-            for (int j=0; j < 2; j++)
-                for (int k=0; k < 2; k++)
-                    accum += (i*u + (1-i)*(1-u))*
-                             (j*v + (1-j)*(1-v))*
-                             (k*w + (1-k)*(1-w))*c[i][j][k];
-
-        return accum;
-    }
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-
     class perlin {
         public:
             ...
@@ -1610,6 +1595,21 @@ To make it smooth, we can linearly interpolate:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             }
             ...
+        private:
+            ...
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+            static double trilinear_interp(double c[2][2][2], double u, double v, double w) {
+                auto accum = 0.0;
+                for (int i=0; i < 2; i++)
+                    for (int j=0; j < 2; j++)
+                        for (int k=0; k < 2; k++)
+                            accum += (i*u + (1-i)*(1-u))*
+                                    (j*v + (1-j)*(1-v))*
+                                    (k*w + (1-k)*(1-w))*c[i][j][k];
+
+                return accum;
+            }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [perlin-trilinear]: <kbd>[perlin.h]</kbd> Perlin with trilienear interpolation]
@@ -1818,25 +1818,27 @@ And the interpolation becomes a bit more complicated:
         ...
         private:
             ...
-            inline double perlin_interp(vec3 c[2][2][2], double u, double v, double w) const {
+            static double perlin_interp(vec3 c[2][2][2], double u, double v, double w) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 auto uu = u*u*(3-2*u);
                 auto vv = v*v*(3-2*v);
                 auto ww = w*w*(3-2*w);
                 auto accum = 0.0;
-
+                
                 for (int i=0; i < 2; i++)
-                    for (int j=0; j < 2; j++)
-                        for (int k=0; k < 2; k++) {
-                            vec3 weight_v(u-i, v-j, w-k);
-                            accum += (i*uu + (1-i)*(1-uu))
-                                   * (j*vv + (1-j)*(1-vv))
-                                   * (k*ww + (1-k)*(1-ww))
-                                   * dot(c[i][j][k], weight_v);
-                        }
-
+                for (int j=0; j < 2; j++)
+                for (int k=0; k < 2; k++) {
+                    vec3 weight_v(u-i, v-j, w-k);
+                    accum += (i*uu + (1-i)*(1-uu))
+                    * (j*vv + (1-j)*(1-vv))
+                    * (k*ww + (1-k)*(1-ww))
+                    * dot(c[i][j][k], weight_v);
+                }
+                
                 return accum;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             }
-        ...
+            ...
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [perlin-interp]: <kbd>[perlin.h]</kbd> Perlin interpolation function so far]

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -1826,14 +1826,14 @@ And the interpolation becomes a bit more complicated:
                 auto accum = 0.0;
                 
                 for (int i=0; i < 2; i++)
-                for (int j=0; j < 2; j++)
-                for (int k=0; k < 2; k++) {
-                    vec3 weight_v(u-i, v-j, w-k);
-                    accum += (i*uu + (1-i)*(1-uu))
-                    * (j*vv + (1-j)*(1-vv))
-                    * (k*ww + (1-k)*(1-ww))
-                    * dot(c[i][j][k], weight_v);
-                }
+                    for (int j=0; j < 2; j++)
+                        for (int k=0; k < 2; k++) {
+                            vec3 weight_v(u-i, v-j, w-k);
+                            accum += (i*uu + (1-i)*(1-uu))
+                                   * (j*vv + (1-j)*(1-vv))
+                                   * (k*ww + (1-k)*(1-ww))
+                                   * dot(c[i][j][k], weight_v);
+                        }
                 
                 return accum;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++

--- a/src/common/perlin.h
+++ b/src/common/perlin.h
@@ -97,7 +97,7 @@ class perlin {
             }
         }
 
-        inline static double perlin_interp(vec3 c[2][2][2], double u, double v, double w) {
+        static double perlin_interp(vec3 c[2][2][2], double u, double v, double w) {
             auto uu = u*u*(3-2*u);
             auto vv = v*v*(3-2*v);
             auto ww = w*w*(3-2*w);


### PR DESCRIPTION
Add consistent function signature for `perlin_interp`.
Also adds highlighting to changes between listing 33 and 39

Resolves #722