### PR TITLE
Image texture dtor should call STBI_FREE(data)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Change Log -- Ray Tracing in One Weekend
   - Change: Refactored dielectric class for clarity
   - Fix: Update local Markdeep library (for offline reading) to v1.11. The prior version had
     incorrect content (#712)
+  - Fix: Image texture destructor should call `STBI_FREE` instead of delete (#734)
 
 ### _In One Weekend_
   - Delete: Remove premature `cstdlib` include; not needed until we use `rand()` (#687)

--- a/src/common/texture.h
+++ b/src/common/texture.h
@@ -105,7 +105,7 @@ class image_texture : public texture {
         }
 
         ~image_texture() {
-            delete data;
+            STBI_FREE(data);
         }
 
         virtual color value(double u, double v, const vec3& p) const override {


### PR DESCRIPTION
because the `stbi_load` function uses `STBI_MALLOC`.

Resolves #734