### PR TITLE
Managing scene parameters, approach C

### DIFF
--- a/src/TheNextWeek/main.cc
+++ b/src/TheNextWeek/main.cc
@@ -24,30 +24,29 @@
 
 #include <iostream>
 
+static struct {
+    int           image_width;
+    int           sample_count;
+    color         background;
+    camera        cam;
+    hittable_list world;
 
-color ray_color(const ray& r, const color& background, const hittable& world, int depth) {
-    hit_record rec;
-
-    // If we've exceeded the ray bounce limit, no more light is gathered.
-    if (depth <= 0)
-        return color(0,0,0);
-
-    // If the ray hits nothing, return the background color.
-    if (!world.hit(r, 0.001, infinity, rec))
-        return background;
-
-    ray scattered;
-    color attenuation;
-    color emitted = rec.mat_ptr->emitted(rec.u, rec.v, rec.p);
-
-    if (!rec.mat_ptr->scatter(r, rec, attenuation, scattered))
-        return emitted;
-
-    return emitted + attenuation * ray_color(scattered, background, world, depth-1);
-}
+    int get_image_height() {
+        return static_cast<int>(image_width / cam.aspect_ratio);
+    }
+} scene;
 
 
-hittable_list random_scene() {
+void bouncing_spheres() {
+    scene.image_width      = 400;
+    scene.sample_count     = 100;
+    scene.background       = color(0.70, 0.80, 1.00);
+    scene.cam.aspect_ratio = 16.0 / 9.0;
+    scene.cam.aperture     = 0.1;
+    scene.cam.vfov         = 20.0;
+    scene.cam.lookfrom     = point3(13,2,3);
+    scene.cam.lookat       = point3(0,0,0);
+
     hittable_list world;
 
     auto checker = make_shared<checker_texture>(color(0.2, 0.3, 0.1), color(0.9, 0.9, 0.9));
@@ -93,100 +92,146 @@ hittable_list random_scene() {
     auto material3 = make_shared<metal>(color(0.7, 0.6, 0.5), 0.0);
     world.add(make_shared<sphere>(point3(4, 1, 0), 1.0, material3));
 
-    return hittable_list(make_shared<bvh_node>(world, 0.0, 1.0));
+    scene.world = hittable_list(make_shared<bvh_node>(world, 0.0, 1.0));
 }
 
 
-hittable_list two_spheres() {
-    hittable_list objects;
+void two_spheres() {
+    scene.image_width      = 400;
+    scene.sample_count     = 100;
+    scene.background       = color(0.70, 0.80, 1.00);
+    scene.cam.aspect_ratio = 16.0 / 9.0;
+    scene.cam.aperture     = 0.0;
+    scene.cam.vfov         = 20.0;
+    scene.cam.lookfrom     = point3(13,2,3);
+    scene.cam.lookat       = point3(0,0,0);
+
+    hittable_list& world = scene.world;
 
     auto checker = make_shared<checker_texture>(color(0.2, 0.3, 0.1), color(0.9, 0.9, 0.9));
 
-    objects.add(make_shared<sphere>(point3(0,-10, 0), 10, make_shared<lambertian>(checker)));
-    objects.add(make_shared<sphere>(point3(0, 10, 0), 10, make_shared<lambertian>(checker)));
-
-    return objects;
+    world.add(make_shared<sphere>(point3(0,-10, 0), 10, make_shared<lambertian>(checker)));
+    world.add(make_shared<sphere>(point3(0, 10, 0), 10, make_shared<lambertian>(checker)));
 }
 
 
-hittable_list two_perlin_spheres() {
-    hittable_list objects;
+void two_perlin_spheres() {
+    scene.image_width      = 400;
+    scene.sample_count     = 100;
+    scene.background       = color(0.70, 0.80, 1.00);
+    scene.cam.aspect_ratio = 16.0 / 9.0;
+    scene.cam.aperture     = 0.0;
+    scene.cam.vfov         = 20.0;
+    scene.cam.lookfrom     = point3(13,2,3);
+    scene.cam.lookat       = point3(0,0,0);
+
+    hittable_list& world = scene.world;
 
     auto pertext = make_shared<noise_texture>(4);
-    objects.add(make_shared<sphere>(point3(0,-1000,0), 1000, make_shared<lambertian>(pertext)));
-    objects.add(make_shared<sphere>(point3(0,2,0), 2, make_shared<lambertian>(pertext)));
-
-    return objects;
+    world.add(make_shared<sphere>(point3(0,-1000,0), 1000, make_shared<lambertian>(pertext)));
+    world.add(make_shared<sphere>(point3(0,2,0), 2, make_shared<lambertian>(pertext)));
 }
 
 
-hittable_list earth() {
+void earth() {
+    scene.image_width      = 400;
+    scene.sample_count     = 100;
+    scene.background       = color(0.70, 0.80, 1.00);
+    scene.cam.aspect_ratio = 16.0 / 9.0;
+    scene.cam.aperture     = 0.0;
+    scene.cam.vfov         = 20.0;
+    scene.cam.lookfrom     = point3(0,0,12);
+    scene.cam.lookat       = point3(0,0,0);
+
     auto earth_texture = make_shared<image_texture>("earthmap.jpg");
     auto earth_surface = make_shared<lambertian>(earth_texture);
     auto globe = make_shared<sphere>(point3(0,0,0), 2, earth_surface);
 
-    return hittable_list(globe);
+    scene.world = hittable_list(globe);
 }
 
 
-hittable_list simple_light() {
-    hittable_list objects;
+void simple_light() {
+    scene.image_width      = 400;
+    scene.sample_count     = 100;
+    scene.background       = color(0,0,0);
+    scene.cam.aspect_ratio = 16.0 / 9.0;
+    scene.cam.aperture     = 0.0;
+    scene.cam.vfov         = 20.0;
+    scene.cam.lookfrom     = point3(26,3,6);
+    scene.cam.lookat       = point3(0,2,0);
+
+    hittable_list& world = scene.world;
 
     auto pertext = make_shared<noise_texture>(4);
-    objects.add(make_shared<sphere>(point3(0,-1000,0), 1000, make_shared<lambertian>(pertext)));
-    objects.add(make_shared<sphere>(point3(0,2,0), 2, make_shared<lambertian>(pertext)));
+    world.add(make_shared<sphere>(point3(0,-1000,0), 1000, make_shared<lambertian>(pertext)));
+    world.add(make_shared<sphere>(point3(0,2,0), 2, make_shared<lambertian>(pertext)));
 
     auto difflight = make_shared<diffuse_light>(color(4,4,4));
-    objects.add(make_shared<sphere>(point3(0,7,0), 2, difflight));
-    objects.add(make_shared<xy_rect>(3, 5, 1, 3, -2, difflight));
-
-    return objects;
+    world.add(make_shared<sphere>(point3(0,7,0), 2, difflight));
+    world.add(make_shared<xy_rect>(3, 5, 1, 3, -2, difflight));
 }
 
 
-hittable_list cornell_box() {
-    hittable_list objects;
+void cornell_box() {
+    scene.image_width      = 600;
+    scene.sample_count     = 200;
+    scene.background       = color(0,0,0);
+    scene.cam.aspect_ratio = 1.0;
+    scene.cam.aperture     = 0.0;
+    scene.cam.vfov         = 40.0;
+    scene.cam.lookfrom     = point3(278, 278, -800);
+    scene.cam.lookat       = point3(278, 278, 0);
+
+    hittable_list& world = scene.world;
 
     auto red   = make_shared<lambertian>(color(.65, .05, .05));
     auto white = make_shared<lambertian>(color(.73, .73, .73));
     auto green = make_shared<lambertian>(color(.12, .45, .15));
     auto light = make_shared<diffuse_light>(color(15,15,15));
 
-    objects.add(make_shared<yz_rect>(0, 555, 0, 555, 555, green));
-    objects.add(make_shared<yz_rect>(0, 555, 0, 555, 0, red));
-    objects.add(make_shared<xz_rect>(213, 343, 227, 332, 554, light));
-    objects.add(make_shared<xz_rect>(0, 555, 0, 555, 555, white));
-    objects.add(make_shared<xz_rect>(0, 555, 0, 555, 0, white));
-    objects.add(make_shared<xy_rect>(0, 555, 0, 555, 555, white));
+    world.add(make_shared<yz_rect>(0, 555, 0, 555, 555, green));
+    world.add(make_shared<yz_rect>(0, 555, 0, 555, 0, red));
+    world.add(make_shared<xz_rect>(213, 343, 227, 332, 554, light));
+    world.add(make_shared<xz_rect>(0, 555, 0, 555, 555, white));
+    world.add(make_shared<xz_rect>(0, 555, 0, 555, 0, white));
+    world.add(make_shared<xy_rect>(0, 555, 0, 555, 555, white));
 
     shared_ptr<hittable> box1 = make_shared<box>(point3(0,0,0), point3(165,330,165), white);
     box1 = make_shared<rotate_y>(box1, 15);
     box1 = make_shared<translate>(box1, vec3(265,0,295));
-    objects.add(box1);
+    world.add(box1);
 
     shared_ptr<hittable> box2 = make_shared<box>(point3(0,0,0), point3(165,165,165), white);
     box2 = make_shared<rotate_y>(box2, -18);
     box2 = make_shared<translate>(box2, vec3(130,0,65));
-    objects.add(box2);
-
-    return objects;
+    world.add(box2);
 }
 
 
-hittable_list cornell_smoke() {
-    hittable_list objects;
+void cornell_smoke() {
+    scene.image_width      = 600;
+    scene.sample_count     = 200;
+    scene.background       = color(0,0,0);
+    scene.cam.aspect_ratio = 1.0;
+    scene.cam.aperture     = 0.0;
+    scene.cam.vfov         = 40.0;
+    scene.cam.lookfrom     = point3(278, 278, -800);
+    scene.cam.lookat       = point3(278, 278, 0);
+
+    hittable_list& world = scene.world;
 
     auto red   = make_shared<lambertian>(color(.65, .05, .05));
     auto white = make_shared<lambertian>(color(.73, .73, .73));
     auto green = make_shared<lambertian>(color(.12, .45, .15));
     auto light = make_shared<diffuse_light>(color(7, 7, 7));
 
-    objects.add(make_shared<yz_rect>(0, 555, 0, 555, 555, green));
-    objects.add(make_shared<yz_rect>(0, 555, 0, 555, 0, red));
-    objects.add(make_shared<xz_rect>(113, 443, 127, 432, 554, light));
-    objects.add(make_shared<xz_rect>(0, 555, 0, 555, 555, white));
-    objects.add(make_shared<xz_rect>(0, 555, 0, 555, 0, white));
-    objects.add(make_shared<xy_rect>(0, 555, 0, 555, 555, white));
+    world.add(make_shared<yz_rect>(0, 555, 0, 555, 555, green));
+    world.add(make_shared<yz_rect>(0, 555, 0, 555, 0, red));
+    world.add(make_shared<xz_rect>(113, 443, 127, 432, 554, light));
+    world.add(make_shared<xz_rect>(0, 555, 0, 555, 555, white));
+    world.add(make_shared<xz_rect>(0, 555, 0, 555, 0, white));
+    world.add(make_shared<xy_rect>(0, 555, 0, 555, 555, white));
 
     shared_ptr<hittable> box1 = make_shared<box>(point3(0,0,0), point3(165,330,165), white);
     box1 = make_shared<rotate_y>(box1, 15);
@@ -196,14 +241,21 @@ hittable_list cornell_smoke() {
     box2 = make_shared<rotate_y>(box2, -18);
     box2 = make_shared<translate>(box2, vec3(130,0,65));
 
-    objects.add(make_shared<constant_medium>(box1, 0.01, color(0,0,0)));
-    objects.add(make_shared<constant_medium>(box2, 0.01, color(1,1,1)));
-
-    return objects;
+    world.add(make_shared<constant_medium>(box1, 0.01, color(0,0,0)));
+    world.add(make_shared<constant_medium>(box2, 0.01, color(1,1,1)));
 }
 
 
-hittable_list final_scene() {
+void final_scene() {
+    scene.image_width      = 800;
+    scene.sample_count     = 10000;
+    scene.background       = color(0,0,0);
+    scene.cam.aspect_ratio = 1.0;
+    scene.cam.aperture     = 0.0;
+    scene.cam.vfov         = 40.0;
+    scene.cam.lookfrom     = point3(478, 278, -600);
+    scene.cam.lookat       = point3(278, 278, 0);
+
     hittable_list boxes1;
     auto ground = make_shared<lambertian>(color(0.48, 0.83, 0.53));
 
@@ -222,33 +274,33 @@ hittable_list final_scene() {
         }
     }
 
-    hittable_list objects;
+    hittable_list& world = scene.world;
 
-    objects.add(make_shared<bvh_node>(boxes1, 0, 1));
+    world.add(make_shared<bvh_node>(boxes1, 0, 1));
 
     auto light = make_shared<diffuse_light>(color(7, 7, 7));
-    objects.add(make_shared<xz_rect>(123, 423, 147, 412, 554, light));
+    world.add(make_shared<xz_rect>(123, 423, 147, 412, 554, light));
 
     auto center1 = point3(400, 400, 200);
     auto center2 = center1 + vec3(30,0,0);
     auto moving_sphere_material = make_shared<lambertian>(color(0.7, 0.3, 0.1));
-    objects.add(make_shared<moving_sphere>(center1, center2, 0, 1, 50, moving_sphere_material));
+    world.add(make_shared<moving_sphere>(center1, center2, 0, 1, 50, moving_sphere_material));
 
-    objects.add(make_shared<sphere>(point3(260, 150, 45), 50, make_shared<dielectric>(1.5)));
-    objects.add(make_shared<sphere>(
+    world.add(make_shared<sphere>(point3(260, 150, 45), 50, make_shared<dielectric>(1.5)));
+    world.add(make_shared<sphere>(
         point3(0, 150, 145), 50, make_shared<metal>(color(0.8, 0.8, 0.9), 1.0)
     ));
 
     auto boundary = make_shared<sphere>(point3(360,150,145), 70, make_shared<dielectric>(1.5));
-    objects.add(boundary);
-    objects.add(make_shared<constant_medium>(boundary, 0.2, color(0.2, 0.4, 0.9)));
+    world.add(boundary);
+    world.add(make_shared<constant_medium>(boundary, 0.2, color(0.2, 0.4, 0.9)));
     boundary = make_shared<sphere>(point3(0,0,0), 5000, make_shared<dielectric>(1.5));
-    objects.add(make_shared<constant_medium>(boundary, .0001, color(1,1,1)));
+    world.add(make_shared<constant_medium>(boundary, .0001, color(1,1,1)));
 
     auto emat = make_shared<lambertian>(make_shared<image_texture>("earthmap.jpg"));
-    objects.add(make_shared<sphere>(point3(400,200,400), 100, emat));
+    world.add(make_shared<sphere>(point3(400,200,400), 100, emat));
     auto pertext = make_shared<noise_texture>(0.1);
-    objects.add(make_shared<sphere>(point3(220,280,300), 80, make_shared<lambertian>(pertext)));
+    world.add(make_shared<sphere>(point3(220,280,300), 80, make_shared<lambertian>(pertext)));
 
     hittable_list boxes2;
     auto white = make_shared<lambertian>(color(.73, .73, .73));
@@ -257,135 +309,91 @@ hittable_list final_scene() {
         boxes2.add(make_shared<sphere>(point3::random(0,165), 10, white));
     }
 
-    objects.add(make_shared<translate>(
+    world.add(make_shared<translate>(
         make_shared<rotate_y>(
             make_shared<bvh_node>(boxes2, 0.0, 1.0), 15),
             vec3(-100,270,395)
         )
     );
-
-    return objects;
 }
 
 
-int main() {
+void default_scene() {
+    final_scene();
+    scene.image_width  = 400;
+    scene.sample_count = 100;
+}
 
-    // Image
 
-    auto aspect_ratio = 16.0 / 9.0;
-    int image_width = 400;
-    int samples_per_pixel = 100;
-    int max_depth = 50;
+static color ray_color(const ray& r, int depth) {
+    hit_record rec;
 
-    // World
+    // If we've exceeded the ray bounce limit, no more light is gathered.
+    if (depth <= 0)
+        return color(0,0,0);
 
-    hittable_list world;
+    // If the ray hits nothing, return the background color.
+    if (!scene.world.hit(r, 0.001, infinity, rec))
+        return scene.background;
 
-    point3 lookfrom;
-    point3 lookat;
-    auto vfov = 40.0;
-    auto aperture = 0.0;
-    color background(0,0,0);
+    ray scattered;
+    color attenuation;
+    color emitted = rec.mat_ptr->emitted(rec.u, rec.v, rec.p);
 
-    switch (0) {
-        case 1:
-            world = random_scene();
-            background = color(0.70, 0.80, 1.00);
-            lookfrom = point3(13,2,3);
-            lookat = point3(0,0,0);
-            vfov = 20.0;
-            aperture = 0.1;
-            break;
+    if (!rec.mat_ptr->scatter(r, rec, attenuation, scattered))
+        return emitted;
 
-        case 2:
-            world = two_spheres();
-            background = color(0.70, 0.80, 1.00);
-            lookfrom = point3(13,2,3);
-            lookat = point3(0,0,0);
-            vfov = 20.0;
-            break;
+    return emitted + attenuation * ray_color(scattered, depth-1);
+}
 
-        case 3:
-            world = two_perlin_spheres();
-            background = color(0.70, 0.80, 1.00);
-            lookfrom = point3(13,2,3);
-            lookat = point3(0,0,0);
-            vfov = 20.0;
-            break;
 
-        case 4:
-            world = earth();
-            background = color(0.70, 0.80, 1.00);
-            lookfrom = point3(0,0,12);
-            lookat = point3(0,0,0);
-            vfov = 20.0;
-            break;
-
-        case 5:
-            world = simple_light();
-            samples_per_pixel = 400;
-            lookfrom = point3(26,3,6);
-            lookat = point3(0,2,0);
-            vfov = 20.0;
-            break;
-
-        default:
-        case 6:
-            world = cornell_box();
-            aspect_ratio = 1.0;
-            image_width = 600;
-            samples_per_pixel = 200;
-            lookfrom = point3(278, 278, -800);
-            lookat = point3(278, 278, 0);
-            vfov = 40.0;
-            break;
-
-        case 7:
-            world = cornell_smoke();
-            aspect_ratio = 1.0;
-            image_width = 600;
-            samples_per_pixel = 200;
-            lookfrom = point3(278, 278, -800);
-            lookat = point3(278, 278, 0);
-            vfov = 40.0;
-            break;
-
-        case 8:
-            world = final_scene();
-            aspect_ratio = 1.0;
-            image_width = 800;
-            samples_per_pixel = 10000;
-            lookfrom = point3(478, 278, -600);
-            lookat = point3(278, 278, 0);
-            vfov = 40.0;
-            break;
-    }
-
-    // Camera
-
-    const vec3 vup(0,1,0);
-    const auto dist_to_focus = 10.0;
-    const int image_height = static_cast<int>(image_width / aspect_ratio);
-
-    camera cam(lookfrom, lookat, vup, vfov, aspect_ratio, aperture, dist_to_focus, 0.0, 1.0);
-
-    // Render
+void render() {
+    const int image_width  = scene.image_width;
+    const int image_height = scene.get_image_height();
+    scene.cam.initialize();
 
     std::cout << "P3\n" << image_width << ' ' << image_height << "\n255\n";
+
+    const int max_depth = 50;
 
     for (int j = image_height-1; j >= 0; --j) {
         std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;
         for (int i = 0; i < image_width; ++i) {
             color pixel_color(0,0,0);
-            for (int s = 0; s < samples_per_pixel; ++s) {
+            for (int s = 0; s < scene.sample_count; ++s) {
                 auto u = (i + random_double()) / (image_width-1);
                 auto v = (j + random_double()) / (image_height-1);
-                ray r = cam.get_ray(u, v);
-                pixel_color += ray_color(r, background, world, max_depth);
+                ray r = scene.cam.get_ray(u, v);
+                pixel_color += ray_color(r, max_depth);
             }
-            write_color(std::cout, pixel_color, samples_per_pixel);
+            write_color(std::cout, pixel_color, scene.sample_count);
         }
     }
 
     std::cerr << "\nDone.\n";
+}
+
+
+int main() {
+    scene.image_width    = 1000;
+    scene.sample_count   = 100;
+    scene.background     = color(0,0,0);
+    scene.cam.vup        = vec3(0,1,0);
+    scene.cam.focus_dist = 10.0;
+    scene.cam.time0      = 0;
+    scene.cam.time1      = 1;
+
+    switch (0) {
+        case 1:  bouncing_spheres();   break;
+        case 2:  two_spheres();        break;
+        case 3:  two_perlin_spheres(); break;
+        case 4:  earth();              break;
+        case 5:  simple_light();       break;
+        case 6:  cornell_box();        break;
+        case 7:  cornell_smoke();      break;
+        case 8:  final_scene();        break;
+        default: default_scene();      break;
+    }
+
+    render();
 }

--- a/src/common/camera.h
+++ b/src/common/camera.h
@@ -16,19 +16,35 @@
 
 class camera {
     public:
-        camera() : camera(point3(0,0,-1), point3(0,0,0), vec3(0,1,0), 40, 1, 0, 10) {}
+        camera() : camera(point3(0,0,-1), point3(0,0,0), vec3(0,1,0), 40, 1, 0, 10) {
+            initialize();
+        }
 
         camera(
-            point3 lookfrom,
-            point3 lookat,
-            vec3   vup,
-            double vfov, // vertical field-of-view in degrees
-            double aspect_ratio,
-            double aperture,
-            double focus_dist,
-            double t0 = 0,
-            double t1 = 0
-        ) {
+            point3 _lookfrom,
+            point3 _lookat,
+            vec3   _vup,
+            double _vfov, // vertical field-of-view in degrees
+            double _aspect_ratio,
+            double _aperture,
+            double _focus_dist,
+            double _time0 = 0,
+            double _time1 = 0
+        )
+          : lookfrom(_lookfrom),
+            lookat(_lookat),
+            vup(_vup),
+            vfov(_vfov),
+            aspect_ratio(_aspect_ratio),
+            aperture(_aperture),
+            focus_dist(_focus_dist),
+            time0(_time0),
+            time1(_time1)
+        {
+            initialize();
+        }
+
+        void initialize() {
             auto theta = degrees_to_radians(vfov);
             auto h = tan(theta/2);
             auto viewport_height = 2.0 * h;
@@ -44,8 +60,6 @@ class camera {
             lower_left_corner = origin - horizontal/2 - vertical/2 - focus_dist*w;
 
             lens_radius = aperture / 2;
-            time0 = t0;
-            time1 = t1;
         }
 
         ray get_ray(double s, double t) const {
@@ -58,6 +72,16 @@ class camera {
             );
         }
 
+    public:
+        point3 lookfrom;
+        point3 lookat;
+        vec3   vup;
+        double vfov;
+        double aspect_ratio;
+        double aperture;
+        double focus_dist;
+        double time0, time1;  // shutter open/close times
+
     private:
         point3 origin;
         point3 lower_left_corner;
@@ -65,7 +89,6 @@ class camera {
         vec3 vertical;
         vec3 u, v, w;
         double lens_radius;
-        double time0, time1;  // shutter open/close times
 };
 
 #endif


### PR DESCRIPTION
Had a thought while driving today about another way to accomplish the original objectives of managing scenes better.

This is not code I'd write for an actual C++ project, but avoids creating a new class and associated overhead. Basically just moves all scene parameters into a static file-level anonymous struct with one helper method, and everything in main just accesses that structure without passing it around. All scene functions still drive their own scene parameters. In addition, I really like pulling out the render function from main, as I think this would help discussion throughout the books.

Yeah, it's old-school, but it's also simple and limits changes to main.cc.