### PR TITLE
Fix `random_unit_vector()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ Change Log -- Ray Tracing in One Weekend
 # v3.2.2 (in progress)
 
 ### Common
-  - Fix: Added `fmin` to book text for `cos_theta` of `refract`
+  - Fix: Added `fmin` to book text for `cos_theta` of `refract` (#732)
   - Fix: Standardized naming for ray-t and time parameters (#746)
+  - Fix: `random_unit_vector()` was incorrect (#697)
 
 ### In One Weekend
 

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1764,16 +1764,18 @@ at shallow angles spreads over a larger area, and thus has a lower contribution 
 
 However, we are interested in a Lambertian distribution, which has a distribution of $\cos (\phi)$.
 True Lambertian has the probability higher for ray scattering close to the normal, but the
-distribution is more uniform. This is achieved by picking points on the surface of the unit sphere,
-offset along the surface normal. Picking points on the sphere can be achieved by picking points in
-the unit ball, and then normalizing those.
+distribution is more uniform. This is achieved by picking random points on the surface of the unit
+sphere, offset along the surface normal. Picking random points on the unit sphere can be achieved by
+picking random points _in_ the unit sphere, and then normalizing those.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    inline vec3 random_in_unit_sphere() {
+        ...
+    }
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
     vec3 random_unit_vector() {
-        auto a = random_double(0, 2*pi);
-        auto z = random_double(-1, 1);
-        auto r = sqrt(1 - z*z);
-        return vec3(r*cos(a), r*sin(a), z);
+        return unit_vector(random_in_unit_sphere());
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [random-unit-vector]: <kbd>[vec3.h]</kbd> The random_unit_vector() function]

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -544,33 +544,12 @@ Suppose we have this integral over all directions:
 
   $$ \int cos^2(\theta) $$
 
-<div class='together'>
 By MC integration, we should just be able to sample $\cos^2(\theta) / p(\text{direction})$, but what
-is direction in that context? We could make it based on polar coordinates, so $p$ would be in terms
-of $(\theta, \phi)$. However you do it, remember that a PDF has to integrate to 1 and represent the
-relative probability of that direction being sampled. We have a method from the last books to take
-uniform random samples in or on a unit sphere:
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    vec3 random_unit_vector() {
-        auto a = random_double(0, 2*pi);
-        auto z = random_double(-1, 1);
-        auto r = sqrt(1 - z*z);
-        return vec3(r*cos(a), r*sin(a), z);
-    }
-
-    ...
-
-    vec3 random_in_unit_sphere() {
-        while (true) {
-            auto p = vec3::random(-1,1);
-            if (p.length_squared() >= 1) continue;
-            return p;
-        }
-    }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [random-unit-vector]: <kbd>[vec3.h]</kbd> Random vector of unit length]
-</div>
+is _direction_ in that context? We could make it based on polar coordinates, so $p$ would be in
+terms of $(\theta, \phi)$. However you do it, remember that a PDF has to integrate to 1 and
+represent the relative probability of that direction being sampled. Recall that we have vec3
+functions to take uniform random samples in (`random_in_unit_sphere()`) or on
+(`random_unit_vector()`) a unit sphere.
 
 <div class='together'>
 Now what is the PDF of these uniform points? As a density on the unit sphere, it is $1/\text{area}$

--- a/src/common/vec3.h
+++ b/src/common/vec3.h
@@ -119,13 +119,6 @@ inline vec3 unit_vector(vec3 v) {
     return v / v.length();
 }
 
-inline vec3 random_unit_vector() {
-    auto a = random_double(0, 2*pi);
-    auto z = random_double(-1, 1);
-    auto r = sqrt(1 - z*z);
-    return vec3(r*cos(a), r*sin(a), z);
-}
-
 inline vec3 random_in_unit_disk() {
     while (true) {
         auto p = vec3(random_double(-1,1), random_double(-1,1), 0);
@@ -140,6 +133,10 @@ inline vec3 random_in_unit_sphere() {
         if (p.length_squared() >= 1) continue;
         return p;
     }
+}
+
+inline vec3 random_unit_vector() {
+    return unit_vector(random_in_unit_sphere());
 }
 
 inline vec3 random_in_hemisphere(const vec3& normal) {


### PR DESCRIPTION
I added an alternate formula for uniformly-distributed points on a unit
sphere for this function. It's presented in
https://mathworld.wolfram.com/SpherePointPicking.html, equations 6-8.

Unfortunately, I misinterpreted "u in [-1, 1]" to be equivalent to
`u = random_double(-1,1)`. However, you're supposed to pick u = cos(phi)
to be uniformly distributed.

I replaced this body with the original one, just generating a unit point
_in_ the unit sphere, and normalizing the result.

Resolves #697