### PR TITLE
733: `bvh_node` breaking with negative-radius spheres

### DIFF
--- a/src/TheNextWeek/moving_sphere.h
+++ b/src/TheNextWeek/moving_sphere.h
@@ -45,12 +45,13 @@ point3 moving_sphere::center(double time) const{
 
 
 bool moving_sphere::bounding_box(double t0, double t1, aabb& output_box) const {
+    const double r = std::abs(radius);
     aabb box0(
-        center(t0) - vec3(radius, radius, radius),
-        center(t0) + vec3(radius, radius, radius));
+        center(t0) - vec3(r, r, r),
+        center(t0) + vec3(r, r, r));
     aabb box1(
-        center(t1) - vec3(radius, radius, radius),
-        center(t1) + vec3(radius, radius, radius));
+        center(t1) - vec3(r, r, r),
+        center(t1) + vec3(r, r, r));
     output_box = surrounding_box(box0, box1);
     return true;
 }

--- a/src/TheNextWeek/sphere.h
+++ b/src/TheNextWeek/sphere.h
@@ -35,9 +35,10 @@ class sphere : public hittable  {
 
 
 bool sphere::bounding_box(double t0, double t1, aabb& output_box) const {
+    const double r = std::abs(radius);
     output_box = aabb(
-        center - vec3(radius, radius, radius),
-        center + vec3(radius, radius, radius));
+        center - vec3(r, r, r),
+        center + vec3(r, r, r));
     return true;
 }
 

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -57,9 +57,10 @@ vec3 sphere::random(const point3& o) const {
 
 
 bool sphere::bounding_box(double t0, double t1, aabb& output_box) const {
+    const double r = std::abs(radius);
     output_box = aabb(
-        center - vec3(radius, radius, radius),
-        center + vec3(radius, radius, radius));
+        center - vec3(r, r, r),
+        center + vec3(r, r, r));
     return true;
 }
 


### PR DESCRIPTION
Fix is to make sure that the AABB's is always a positive real number it
should never be negative.

Closes #733