### PR TITLE
fix typo at bvh_node

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -973,7 +973,7 @@ This yields:
     ...
 
     bvh_node::bvh_node(
-        std::vector<shared_ptr<hittable>>& objects,
+        std::vector<shared_ptr<hittable>>& src_objects,
         size_t start, size_t end, double time0, double time1
     ) {
         auto objects = src_objects; // Create a modifiable array of the source scene objects


### PR DESCRIPTION
class 'bvh_node' constructor parameter name error.