### PR TITLE
Add new rtw_image class to manage image files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Change Log -- Ray Tracing in One Weekend
   - Change: `hittable:hit()` methods use new interval class for ray-t parameter
   - Change: Class public/private access labels get two-space indents (#782)
   - Change: `interval::clamp()` replaces standalone `clamp` utility function
+  - New: `rtw_image` class for easier image data loading, searches more locations (#807)
 
 ### In One Weekend
   - Added: More commentary about the choice between `double` and `float` (#752)

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -2084,31 +2084,27 @@ files even easier, we provide a helper class to manage all this -- `rtw_image`:
 
         rtw_image(const char* image_filename) {
             // Loads image data from the given file name. If the RTW_IMAGES environment variable is
-            // defined, looks only in that directory for the image file. If RTW_IMAGES is not
-            // defined, this constructor will search for the specified image file first from the
-            // current directory, then in the images/ subdirectory, then the _parent's_ images/
-            // subdirectory, and then _that_ parent, on so on, for six levels up. If the image was
-            // not loaded successfully, width() and height() will return 0.
+            // defined, looks only in that directory for the image file. If the image was not found,
+            // searches for the specified image file first from the current directory, then in the
+            // images/ subdirectory, then the _parent's_ images/ subdirectory, and then _that_
+            // parent, on so on, for six levels up. If the image was not loaded successfully,
+            // width() and height() will return 0.
 
+            auto filename = std::string(image_filename);
             const auto imagedir = getenv("RTW_IMAGES");
-            if (imagedir) {
-                // If RTW_IMAGES is defined, then only use that value to locate the image file.
-                if (load(std::string(imagedir) + "/" + image_filename)) return;
-            } else {
-                // Hunt for the image file in some likely locations.
-                auto filename = std::string(image_filename);
-                if (load(filename)) return;
-                if (load("images/" + filename)) return;
-                if (load("../images/" + filename)) return;
-                if (load("../../images/" + filename)) return;
-                if (load("../../../images/" + filename)) return;
-                if (load("../../../../images/" + filename)) return;
-                if (load("../../../../../images/" + filename)) return;
-                if (load("../../../../../../images/" + filename)) return;
-            }
+
+            // Hunt for the image file in some likely locations.
+            if (imagedir && load(std::string(imagedir) + "/" + image_filename)) return;
+            if (load(filename)) return;
+            if (load("images/" + filename)) return;
+            if (load("../images/" + filename)) return;
+            if (load("../../images/" + filename)) return;
+            if (load("../../../images/" + filename)) return;
+            if (load("../../../../images/" + filename)) return;
+            if (load("../../../../../images/" + filename)) return;
+            if (load("../../../../../../images/" + filename)) return;
 
             std::cerr << "ERROR: Could not load image file '" << image_filename << "'.\n";
-            std::cerr << "STBI: " << stbi_failure_reason() << '\n';
         }
 
         ~rtw_image() { STBI_FREE(data); }

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -2057,105 +2057,147 @@ This is just a fractional position.
 
 Storing Texture Image Data
 ---------------------------
-Now we also need to create a texture class that holds an image. I am going to use my favorite image
-utility [stb_image][]. It reads in an image into a big array of unsigned char. These are just packed
-RGBs with each component in the range [0,255] (black to full white). The `image_texture` class uses
-the resulting image data.
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include "rtweekend.h"
-    #include "rtw_stb_image.h"
-    #include "perlin.h"
-
-    #include <iostream>
-
-    ...
-
-    class image_texture : public texture {
-      public:
-        const static int bytes_per_pixel = 3;
-
-        image_texture() : data(nullptr), width(0), height(0), bytes_per_scanline(0) {}
-
-        image_texture(const char* filename) {
-            auto components_per_pixel = bytes_per_pixel;
-
-            data = stbi_load(
-                filename, &width, &height, &components_per_pixel, components_per_pixel);
-
-            if (!data) {
-                std::cerr << "ERROR: Could not load texture image file '" << filename << "'.\n";
-                width = height = 0;
-            }
-
-            bytes_per_scanline = bytes_per_pixel * width;
-        }
-
-        ~image_texture() {
-            delete data;
-        }
-
-        virtual color value(double u, double v, const vec3& p) const override {
-            // If we have no texture data, then return solid cyan as a debugging aid.
-            if (data == nullptr)
-                return color(0,1,1);
-
-            // Clamp input texture coordinates to [0,1] x [1,0]
-            u = interval(0,1).clamp(u);
-            v = 1.0 - interval(0,1).clamp(v);  // Flip V to image coordinates
-
-            auto i = static_cast<int>(u * width);
-            auto j = static_cast<int>(v * height);
-
-            // Clamp integer mapping, since actual coordinates should be less than 1.0
-            if (i >= width)  i = width-1;
-            if (j >= height) j = height-1;
-
-            const auto color_scale = 1.0 / 255.0;
-            auto pixel = data + j*bytes_per_scanline + i*bytes_per_pixel;
-
-            return color(color_scale*pixel[0], color_scale*pixel[1], color_scale*pixel[2]);
-        }
-
-      private:
-        unsigned char *data;
-        int width, height;
-        int bytes_per_scanline;
-    };
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [img-texture]: <kbd>[texture.h]</kbd> Image texture class]
-
-<div class='together'>
-The representation of a packed array in that order is pretty standard. Thankfully, the [stb_image][]
-package makes that super simple -- just write a header called `rtw_stb_image.h` that also deals with
-some compiler warnings:
+Now it's time to create a texture class that holds an image. I am going to use my favorite image
+utility, [stb_image][]. It reads image data into a big array of unsigned char. These are just packed
+RGBs with each component in the range [0,255] (black to full white). To help make loading our image
+files even easier, we provide a helper class to manage all this -- `rtw_image`:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #ifndef RTWEEKEND_STB_IMAGE_H
     #define RTWEEKEND_STB_IMAGE_H
 
-    // Disable pedantic warnings for this external library.
+    // Disable pedantic warnings for this header from the Microsoft Visual C++ compiler.
     #ifdef _MSC_VER
-        // Microsoft Visual C++ Compiler
         #pragma warning (push, 0)
     #endif
 
     #define STB_IMAGE_IMPLEMENTATION
+    #define STBI_FAILURE_USERMSG
     #include "external/stb_image.h"
 
-    // Restore warning levels.
+    #include <cstdlib>
+    #include <iostream>
+
+    class rtw_image {
+      public:
+        rtw_image() : data(nullptr) {}
+
+        rtw_image(const char* image_filename) {
+            // Loads image data from the given file name. If the RTW_IMAGES environment variable is
+            // defined, looks only in that directory for the image file. If RTW_IMAGES is not
+            // defined, this constructor will search for the specified image file first from the
+            // current directory, then in the images/ subdirectory, then the _parent's_ images/
+            // subdirectory, and then _that_ parent, on so on, for six levels up. If the image was
+            // not loaded successfully, width() and height() will return 0.
+
+            const auto imagedir = getenv("RTW_IMAGES");
+            if (imagedir) {
+                // If RTW_IMAGES is defined, then only use that value to locate the image file.
+                if (load(std::string(imagedir) + "/" + image_filename)) return;
+            } else {
+                // Hunt for the image file in some likely locations.
+                auto filename = std::string(image_filename);
+                if (load(filename)) return;
+                if (load("images/" + filename)) return;
+                if (load("../images/" + filename)) return;
+                if (load("../../images/" + filename)) return;
+                if (load("../../../images/" + filename)) return;
+                if (load("../../../../images/" + filename)) return;
+                if (load("../../../../../images/" + filename)) return;
+                if (load("../../../../../../images/" + filename)) return;
+            }
+
+            std::cerr << "ERROR: Could not load image file '" << image_filename << "'.\n";
+            std::cerr << "STBI: " << stbi_failure_reason() << '\n';
+        }
+
+        ~rtw_image() { STBI_FREE(data); }
+
+        bool load(const std::string filename) {
+            // Loads image data from the given file name. Returns true if the load succeeded.
+            auto components_per_pixel = bytes_per_pixel; // Components per pixel
+            data = stbi_load(filename.c_str(),
+                &image_width, &image_height, &components_per_pixel, bytes_per_pixel);
+            bytes_per_scanline = image_width * bytes_per_pixel;
+            return data != nullptr;
+        }
+
+        int width()  const { return (data == nullptr) ? 0 : image_width; }
+        int height() const { return (data == nullptr) ? 0 : image_height; }
+
+        const unsigned char* pixel_data(int x, int y) const {
+            // Return the address of the three bytes of the pixel at x,y (or magenta if no data).
+            static unsigned char magenta[] = { 255, 0, 255 };
+            if (!data) return magenta;
+
+            // Clamp pixel coordintes to [0,width-1] x [0,height-1]
+            x = (x < 0) ? 0 : (x < image_width)  ? x : (image_width  - 1);
+            y = (y < 0) ? 0 : (y < image_height) ? y : (image_height - 1);
+
+            return data + y*bytes_per_scanline + x*bytes_per_pixel;
+        }
+
+      private:
+        const int bytes_per_pixel = 3;
+        unsigned char *data;
+        int image_width, image_height;
+        int bytes_per_scanline;
+    };
+
+    // Restore MSVC compiler warnings
     #ifdef _MSC_VER
-        // Microsoft Visual C++ Compiler
         #pragma warning (pop)
     #endif
 
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [rtw-stb-image]: <kbd>[rtw_stb_image.h]</kbd> Include the stb_image package]
+    [Listing [rtw_image]: <kbd>[rtw_stb_image.h] The rtw_image helper class]
 
-The above assumes that you have copied the `stb_image.h` into a folder called `external`. Adjust
-according to your directory structure.
+The preceding listing assumes that you have copied the `stb_image.h` header into a folder called
+`external`. Adjust according to your directory structure.
+
+If you are writing your implementation in a language other than C or C++, you'll need to locate (or
+write) an image loading library that provides similar functionality.
+
+<div class='together'>
+The `image_texture` class uses the `rtw_image` class:
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    #include "rtweekend.h"
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+    #include "rtw_stb_image.h"
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    #include "perlin.h"
+
+    ...
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+    class image_texture : public texture {
+      public:
+        image_texture() {}
+        image_texture(const char* filename) : image(filename) {}
+
+        virtual color value(double u, double v, const vec3& p) const override {
+            // If we have no texture data, then return solid cyan as a debugging aid.
+            if (image.height() <= 0) return color(0,1,1);
+
+            // Clamp input texture coordinates to [0,1] x [1,0]
+            u = interval(0,1).clamp(u);
+            v = 1.0 - interval(0,1).clamp(v);  // Flip V to image coordinates
+
+            auto i = static_cast<int>(u * image.width());
+            auto j = static_cast<int>(v * image.height());
+            auto pixel = image.pixel_data(i,j);
+
+            const auto color_scale = 1.0 / 255.0;
+            return color(color_scale*pixel[0], color_scale*pixel[1], color_scale*pixel[2]);
+        }
+
+      private:
+        rtw_image image;
+    };
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    [Listing [img-texture]: <kbd>[texture.h]</kbd> Image texture class]
 </div>
 
 

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -2058,15 +2058,18 @@ This is just a fractional position.
 Storing Texture Image Data
 ---------------------------
 Now it's time to create a texture class that holds an image. I am going to use my favorite image
-utility, [stb_image][]. It reads image data into a big array of unsigned char. These are just packed
-RGBs with each component in the range [0,255] (black to full white). To help make loading our image
-files even easier, we provide a helper class to manage all this -- `rtw_image`:
+utility, [stb_image][]. It reads image data into a big array of unsigned chars. These are just
+packed RGBs with each component in the range [0,255] (black to full white). To help make loading our
+image files even easier, we provide a helper class to manage all this -- `rtw_image`. The following
+listing assumes that you have copied the `stb_image.h` header into a folder called `external`.
+Adjust according to your directory structure.
+
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #ifndef RTWEEKEND_STB_IMAGE_H
-    #define RTWEEKEND_STB_IMAGE_H
+    #ifndef RTW_STB_IMAGE_H
+    #define RTW_STB_IMAGE_H
 
-    // Disable pedantic warnings for this header from the Microsoft Visual C++ compiler.
+    // Disable strict warnings for this header from the Microsoft Visual C++ compiler.
     #ifdef _MSC_VER
         #pragma warning (push, 0)
     #endif
@@ -2083,7 +2086,7 @@ files even easier, we provide a helper class to manage all this -- `rtw_image`:
         rtw_image() : data(nullptr) {}
 
         rtw_image(const char* image_filename) {
-            // Loads image data from the given file name. If the RTW_IMAGES environment variable is
+            // Loads image data from the specified file. If the RTW_IMAGES environment variable is
             // defined, looks only in that directory for the image file. If the image was not found,
             // searches for the specified image file first from the current directory, then in the
             // images/ subdirectory, then the _parent's_ images/ subdirectory, and then _that_
@@ -2111,9 +2114,8 @@ files even easier, we provide a helper class to manage all this -- `rtw_image`:
 
         bool load(const std::string filename) {
             // Loads image data from the given file name. Returns true if the load succeeded.
-            auto components_per_pixel = bytes_per_pixel; // Components per pixel
-            data = stbi_load(filename.c_str(),
-                &image_width, &image_height, &components_per_pixel, bytes_per_pixel);
+            auto n = bytes_per_pixel; // Dummy out parameter: original components per pixel
+            data = stbi_load(filename.c_str(), &image_width, &image_height, &n, bytes_per_pixel);
             bytes_per_scanline = image_width * bytes_per_pixel;
             return data != nullptr;
         }
@@ -2124,11 +2126,10 @@ files even easier, we provide a helper class to manage all this -- `rtw_image`:
         const unsigned char* pixel_data(int x, int y) const {
             // Return the address of the three bytes of the pixel at x,y (or magenta if no data).
             static unsigned char magenta[] = { 255, 0, 255 };
-            if (!data) return magenta;
+            if (data == nullptr) return magenta;
 
-            // Clamp pixel coordintes to [0,width-1] x [0,height-1]
-            x = (x < 0) ? 0 : (x < image_width)  ? x : (image_width  - 1);
-            y = (y < 0) ? 0 : (y < image_height) ? y : (image_height - 1);
+            x = clamp(x, 0, image_width);
+            y = clamp(y, 0, image_height);
 
             return data + y*bytes_per_scanline + x*bytes_per_pixel;
         }
@@ -2138,6 +2139,13 @@ files even easier, we provide a helper class to manage all this -- `rtw_image`:
         unsigned char *data;
         int image_width, image_height;
         int bytes_per_scanline;
+
+        static int clamp(int x, int low, int high) {
+            // Return the value clamped to the range [low, high).
+            if (x < low) return low;
+            if (x < high) return x;
+            return high - 1;
+        }
     };
 
     // Restore MSVC compiler warnings
@@ -2148,9 +2156,6 @@ files even easier, we provide a helper class to manage all this -- `rtw_image`:
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [rtw_image]: <kbd>[rtw_stb_image.h] The rtw_image helper class]
-
-The preceding listing assumes that you have copied the `stb_image.h` header into a folder called
-`external`. Adjust according to your directory structure.
 
 If you are writing your implementation in a language other than C or C++, you'll need to locate (or
 write) an image loading library that provides similar functionality.

--- a/src/common/rtw_stb_image.h
+++ b/src/common/rtw_stb_image.h
@@ -8,7 +8,6 @@
 #endif
 
 #define STB_IMAGE_IMPLEMENTATION
-#define STBI_FAILURE_USERMSG
 #include "external/stb_image.h"
 
 #include <cstdlib>
@@ -21,31 +20,27 @@ class rtw_image {
 
     rtw_image(const char* image_filename) {
         // Loads image data from the given file name. If the RTW_IMAGES environment variable is
-        // defined, looks only in that directory for the image file. If RTW_IMAGES is not
-        // defined, this constructor will search for the specified image file first from the
-        // current directory, then in the images/ subdirectory, then the _parent's_ images/
-        // subdirectory, and then _that_ parent, on so on, for six levels up. If the image was
-        // not loaded successfully, width() and height() will return 0.
+        // defined, looks only in that directory for the image file. If the image was not found,
+        // searches for the specified image file first from the current directory, then in the
+        // images/ subdirectory, then the _parent's_ images/ subdirectory, and then _that_
+        // parent, on so on, for six levels up. If the image was not loaded successfully,
+        // width() and height() will return 0.
 
+        auto filename = std::string(image_filename);
         const auto imagedir = getenv("RTW_IMAGES");
-        if (imagedir) {
-            // If RTW_IMAGES is defined, then only use that value to locate the image file.
-            if (load(std::string(imagedir) + "/" + image_filename)) return;
-        } else {
-            // Hunt for the image file in some likely locations.
-            auto filename = std::string(image_filename);
-            if (load(filename)) return;
-            if (load("images/" + filename)) return;
-            if (load("../images/" + filename)) return;
-            if (load("../../images/" + filename)) return;
-            if (load("../../../images/" + filename)) return;
-            if (load("../../../../images/" + filename)) return;
-            if (load("../../../../../images/" + filename)) return;
-            if (load("../../../../../../images/" + filename)) return;
-        }
+
+        // Hunt for the image file in some likely locations.
+        if (imagedir && load(std::string(imagedir) + "/" + image_filename)) return;
+        if (load(filename)) return;
+        if (load("images/" + filename)) return;
+        if (load("../images/" + filename)) return;
+        if (load("../../images/" + filename)) return;
+        if (load("../../../images/" + filename)) return;
+        if (load("../../../../images/" + filename)) return;
+        if (load("../../../../../images/" + filename)) return;
+        if (load("../../../../../../images/" + filename)) return;
 
         std::cerr << "ERROR: Could not load image file '" << image_filename << "'.\n";
-        std::cerr << "STBI: " << stbi_failure_reason() << '\n';
     }
 
     ~rtw_image() { STBI_FREE(data); }

--- a/src/common/rtw_stb_image.h
+++ b/src/common/rtw_stb_image.h
@@ -2,22 +2,90 @@
 #define RTWEEKEND_STB_IMAGE_H
 
 
-// Disable pedantic warnings for this external library.
+// Disable pedantic warnings for this header from the Microsoft Visual C++ compiler.
 #ifdef _MSC_VER
-    // Microsoft Visual C++ Compiler
     #pragma warning (push, 0)
 #endif
 
-
-
 #define STB_IMAGE_IMPLEMENTATION
+#define STBI_FAILURE_USERMSG
 #include "external/stb_image.h"
 
+#include <cstdlib>
+#include <iostream>
 
-// Restore warning levels.
+
+class rtw_image {
+  public:
+    rtw_image() : data(nullptr) {}
+
+    rtw_image(const char* image_filename) {
+        // Loads image data from the given file name. If the RTW_IMAGES environment variable is
+        // defined, looks only in that directory for the image file. If RTW_IMAGES is not
+        // defined, this constructor will search for the specified image file first from the
+        // current directory, then in the images/ subdirectory, then the _parent's_ images/
+        // subdirectory, and then _that_ parent, on so on, for six levels up. If the image was
+        // not loaded successfully, width() and height() will return 0.
+
+        const auto imagedir = getenv("RTW_IMAGES");
+        if (imagedir) {
+            // If RTW_IMAGES is defined, then only use that value to locate the image file.
+            if (load(std::string(imagedir) + "/" + image_filename)) return;
+        } else {
+            // Hunt for the image file in some likely locations.
+            auto filename = std::string(image_filename);
+            if (load(filename)) return;
+            if (load("images/" + filename)) return;
+            if (load("../images/" + filename)) return;
+            if (load("../../images/" + filename)) return;
+            if (load("../../../images/" + filename)) return;
+            if (load("../../../../images/" + filename)) return;
+            if (load("../../../../../images/" + filename)) return;
+            if (load("../../../../../../images/" + filename)) return;
+        }
+
+        std::cerr << "ERROR: Could not load image file '" << image_filename << "'.\n";
+        std::cerr << "STBI: " << stbi_failure_reason() << '\n';
+    }
+
+    ~rtw_image() { STBI_FREE(data); }
+
+    bool load(const std::string filename) {
+        // Loads image data from the given file name. Returns true if the load succeeded.
+        auto components_per_pixel = bytes_per_pixel; // Components per pixel
+        data = stbi_load(filename.c_str(),
+            &image_width, &image_height, &components_per_pixel, bytes_per_pixel);
+        bytes_per_scanline = image_width * bytes_per_pixel;
+        return data != nullptr;
+    }
+
+    int width()  const { return (data == nullptr) ? 0 : image_width; }
+    int height() const { return (data == nullptr) ? 0 : image_height; }
+
+    const unsigned char* pixel_data(int x, int y) const {
+        // Return the address of the three bytes of the pixel at x,y (or magenta if no data).
+        static unsigned char magenta[] = { 255, 0, 255 };
+        if (!data) return magenta;
+
+        // Clamp pixel coordintes to [0,width-1] x [0,height-1]
+        x = (x < 0) ? 0 : (x < image_width)  ? x : (image_width  - 1);
+        y = (y < 0) ? 0 : (y < image_height) ? y : (image_height - 1);
+
+        return data + y*bytes_per_scanline + x*bytes_per_pixel;
+    }
+
+  private:
+    const int bytes_per_pixel = 3;
+    unsigned char *data;
+    int image_width, image_height;
+    int bytes_per_scanline;
+};
+
+
+// Restore MSVC compiler warnings
 #ifdef _MSC_VER
-    // Microsoft Visual C++ Compiler
     #pragma warning (pop)
 #endif
+
 
 #endif

--- a/src/common/texture.h
+++ b/src/common/texture.h
@@ -16,8 +16,6 @@
 #include "perlin.h"
 #include "rtw_stb_image.h"
 
-#include <iostream>
-
 
 class texture {
   public:
@@ -85,55 +83,27 @@ class noise_texture : public texture {
 
 class image_texture : public texture {
   public:
-    const static int bytes_per_pixel = 3;
-
-    image_texture()
-      : data(nullptr), width(0), height(0), bytes_per_scanline(0) {}
-
-    image_texture(const char* filename) {
-        auto components_per_pixel = bytes_per_pixel;
-
-        data = stbi_load(
-            filename, &width, &height, &components_per_pixel, components_per_pixel);
-
-        if (!data) {
-            std::cerr << "ERROR: Could not load texture image file '" << filename << "'.\n";
-            width = height = 0;
-        }
-
-        bytes_per_scanline = bytes_per_pixel * width;
-    }
-
-    ~image_texture() {
-        STBI_FREE(data);
-    }
+    image_texture() {}
+    image_texture(const char* filename) : image(filename) {}
 
     virtual color value(double u, double v, const vec3& p) const override {
         // If we have no texture data, then return solid cyan as a debugging aid.
-        if (data == nullptr)
-            return color(0,1,1);
+        if (image.height() <= 0) return color(0,1,1);
 
         // Clamp input texture coordinates to [0,1] x [1,0]
         u = interval(0,1).clamp(u);
         v = 1.0 - interval(0,1).clamp(v);  // Flip V to image coordinates
 
-        auto i = static_cast<int>(u * width);
-        auto j = static_cast<int>(v * height);
-
-        // Clamp integer mapping, since actual coordinates should be less than 1.0
-        if (i >= width)  i = width-1;
-        if (j >= height) j = height-1;
+        auto i = static_cast<int>(u * image.width());
+        auto j = static_cast<int>(v * image.height());
+        auto pixel = image.pixel_data(i,j);
 
         const auto color_scale = 1.0 / 255.0;
-        auto pixel = data + j*bytes_per_scanline + i*bytes_per_pixel;
-
         return color(color_scale*pixel[0], color_scale*pixel[1], color_scale*pixel[2]);
     }
 
   private:
-    unsigned char *data;
-    int width, height;
-    int bytes_per_scanline;
+    rtw_image image;
 };
 
 

--- a/style/book.css
+++ b/style/book.css
@@ -90,7 +90,7 @@ div.indented {
     /* All code, both in fenced blocks and inline. */
     font-family: Consolas, Menlo, monospace;
     font-size: 86%;
-    background: #e0e0dc;
+    background: #f0f0ec;
 }
 
 .md pre.listing.tilde code {


### PR DESCRIPTION
- Honors RTW_IMAGES environment variable to locate RTW image directory
- If RTW_IMAGES is unset, searches for image files in several likely
  image directory locations.
- Separates image data management from diffuse texture map class.
- Better error reporting on image load failure.
- More robust getters in the face of absent image data.

Resolves #807