### PR TITLE
aabb ctor treats 2 params as extrema in any order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Change Log -- Ray Tracing in One Weekend
   - Change: Class public/private access labels get two-space indents (#782)
   - Change: `interval::clamp()` replaces standalone `clamp` utility function
   - New: `rtw_image` class for easier image data loading, searches more locations (#807)
+  - Change: `aabb` class constructor treats two params as extreme points in any orientation (#733)
 
 ### In One Weekend
   - Added: More commentary about the choice between `double` and `float` (#752)

--- a/src/common/aabb.h
+++ b/src/common/aabb.h
@@ -17,7 +17,12 @@
 class aabb {
   public:
     aabb() {}
-    aabb(const point3& a, const point3& b) { minimum = a; maximum = b; }
+    aabb(const point3& a, const point3& b) {
+        // Treat the two points a and b as extrema for the bounding box, so we don't require a
+        // particular minimum/maximum coordinate order.
+        minimum = point3(fmin(a[0],b[0]), fmin(a[1],b[1]), fmin(a[2],b[2]));
+        maximum = point3(fmax(a[0],b[0]), fmax(a[1],b[1]), fmax(a[2],b[2]));
+    }
 
     point3 min() const {return minimum; }
     point3 max() const {return maximum; }


### PR DESCRIPTION
The original constructor expected that the first parameter was the
minimum point, and the second was the maximum. The new constructor now
selects the minimums of all coordinates in the two parameters, and the
maximums of all the coordinates. In this way, the two parameters are
just two extreme points of the bounds, so is significantly more robust.

This change was done because the original code had bugs when handling
spheres of negative radius (used to model glass spheres with voids).

Resolves #733