### PR TITLE
Inline clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Change Log -- Ray Tracing in One Weekend
   - Change: Class public/private access labels get two-space indents (#782)
   - Change: `interval::clamp()` replaces standalone `clamp` utility function
   - New: `rtw_image` class for easier image data loading, searches more locations (#807)
+  - Change: Cleaned up multiple cases where the `inline` keyword was unnecessary, and reorganized
+    some global utility functions as either private static, or in better locations.
 
 ### In One Weekend
   - Added: More commentary about the choice between `double` and `float` (#752)

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1670,11 +1670,11 @@ range from -1 to +1. Reject this point and try again if the point is outside the
     class vec3 {
       public:
         ...
-        inline static vec3 random() {
+        static vec3 random() {
             return vec3(random_double(), random_double(), random_double());
         }
 
-        inline static vec3 random(double min, double max) {
+        static vec3 random(double min, double max) {
             return vec3(random_double(min,max), random_double(min,max), random_double(min,max));
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1009,7 +1009,7 @@ calculation for us.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         bool front_face;
 
-        inline void set_face_normal(const ray& r, const vec3& outward_normal) {
+        void set_face_normal(const ray& r, const vec3& outward_normal) {
             front_face = dot(r.direction(), outward_normal) < 0;
             normal = front_face ? outward_normal :-outward_normal;
         }
@@ -2077,7 +2077,7 @@ that the pointer is to a class, which the “class material” in the hittable c
         double t;
         bool front_face;
 
-        inline void set_face_normal(const ray& r, const vec3& outward_normal) {
+        void set_face_normal(const ray& r, const vec3& outward_normal) {
             front_face = dot(r.direction(), outward_normal) < 0;
             normal = front_face ? outward_normal :-outward_normal;
         }

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -1264,12 +1264,7 @@ We can save a little algebra on specific cases by noting
 Let’s also start generating them as random vectors:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include "rtweekend.h"
-
-    #include <iostream>
-    #include <math.h>
-
-    vec3 random_cosine_direction() {
+    inline vec3 random_cosine_direction() {
         auto r1 = random_double();
         auto r2 = random_double();
         auto z = sqrt(1-r2);
@@ -1280,6 +1275,17 @@ Let’s also start generating them as random vectors:
 
         return vec3(x, y, z);
     }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    [Listing [random-cosine-direction]: <kbd>vec3.h</kbd> Random cosine direction utility function
+
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    #include "rtweekend.h"
+
+    #include <iostream>
+    #include <iomanip>
+    #include <math.h>
+
 
     int main() {
         int N = 1000000;
@@ -1725,18 +1731,6 @@ bounding box that works with all its subclasses.
 First, let’s try a cosine density:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    inline vec3 random_cosine_direction() {
-        auto r1 = random_double();
-        auto r2 = random_double();
-        auto z = sqrt(1-r2);
-
-        auto phi = 2*pi*r1;
-        auto x = cos(phi)*sqrt(r2);
-        auto y = sin(phi)*sqrt(r2);
-
-        return vec3(x, y, z);
-    }
-
     class cosine_pdf : public pdf {
       public:
         cosine_pdf(const vec3& w) { uvw.build_from_w(w); }

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -2447,6 +2447,23 @@ Updating the Sphere Code
 The sphere class needs the two PDF-related functions:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    class sphere : public hittable {
+        ...
+      private:
+        ...
+        static vec3 random_to_sphere(double radius, double distance_squared) {
+            auto r1 = random_double();
+            auto r2 = random_double();
+            auto z = 1 + r2*(sqrt(1-radius*radius/distance_squared) - 1);
+
+            auto phi = 2*pi*r1;
+            auto x = cos(phi)*sqrt(1-z*z);
+            auto y = sin(phi)*sqrt(1-z*z);
+
+            return vec3(x, y, z);
+        }
+    };
+
     double sphere::pdf_value(const point3& o, const vec3& v) const {
         hit_record rec;
         if (!this->hit(ray(o, v), interval(0.001, infinity), rec))
@@ -2467,25 +2484,6 @@ The sphere class needs the two PDF-related functions:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [sphere-pdf]: <kbd>[sphere.h]</kbd> Sphere with PDF]
-</div>
-
-<div class='together'>
-With the utility function:
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    inline vec3 random_to_sphere(double radius, double distance_squared) {
-        auto r1 = random_double();
-        auto r2 = random_double();
-        auto z = 1 + r2*(sqrt(1-radius*radius/distance_squared) - 1);
-
-        auto phi = 2*pi*r1;
-        auto x = cos(phi)*sqrt(1-z*z);
-        auto y = sin(phi)*sqrt(1-z*z);
-
-        return vec3(x, y, z);
-    }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [rand-to-sphere]: <kbd>[pdf.h]</kbd> The random_to_sphere utility function]
 </div>
 
 <div class='together'>

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -1394,7 +1394,7 @@ class because it won't really be more complicated than utility functions:
       public:
         onb() {}
 
-        inline vec3 operator[](int i) const { return axis[i]; }
+        vec3 operator[](int i) const { return axis[i]; }
 
         vec3 u() const { return axis[0]; }
         vec3 v() const { return axis[1]; }

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -529,7 +529,7 @@ down-weight. The PDF is a perfect measure of how much or little sampling is bein
 weighting function should be proportional to $1/pdf$. In fact it is exactly $1/pdf$:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-    inline double pdf(double x) {
+    double pdf(double x) {
         return 0.5*x;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -563,7 +563,7 @@ If we take that same code with uniform samples so the PDF = $1/2$ over the range
 the machinery to get `x = random_double(0,2)`, and the code is:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-    inline double pdf(double x) {
+    double pdf(double x) {
         return 0.5;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -606,7 +606,7 @@ integrating $p$ analytically), but it’s a good exercise to make sure our code 
 sample we get:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-    inline double pdf(double x) {
+    double pdf(double x) {
         return 3*x*x/8;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -667,7 +667,7 @@ of the sphere or $1/(4\pi)$. If the integrand is $\cos^2(\theta)$, and $\theta$ 
 the z axis:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    inline double pdf(const vec3& p) {
+    double pdf(const vec3& p) {
         return 1 / (4*pi);
     }
 
@@ -1269,7 +1269,7 @@ Let’s also start generating them as random vectors:
     #include <iostream>
     #include <math.h>
 
-    inline vec3 random_cosine_direction() {
+    vec3 random_cosine_direction() {
         auto r1 = random_double();
         auto r2 = random_double();
         auto z = sqrt(1-r2);

--- a/src/InOneWeekend/hittable.h
+++ b/src/InOneWeekend/hittable.h
@@ -24,7 +24,7 @@ class hit_record {
     double t;
     bool front_face;
 
-    inline void set_face_normal(const ray& r, const vec3& outward_normal) {
+    void set_face_normal(const ray& r, const vec3& outward_normal) {
         front_face = dot(r.direction(), outward_normal) < 0;
         normal = front_face ? outward_normal :-outward_normal;
     }

--- a/src/TheNextWeek/hittable.h
+++ b/src/TheNextWeek/hittable.h
@@ -29,7 +29,7 @@ class hit_record {
     double v;
     bool front_face;
 
-    inline void set_face_normal(const ray& r, const vec3& outward_normal) {
+    void set_face_normal(const ray& r, const vec3& outward_normal) {
         front_face = dot(r.direction(), outward_normal) < 0;
         normal = front_face ? outward_normal :-outward_normal;
     }

--- a/src/TheRestOfYourLife/cos_density.cc
+++ b/src/TheRestOfYourLife/cos_density.cc
@@ -16,18 +16,6 @@
 #include <math.h>
 
 
-vec3 random_cosine_direction() {
-    auto r1 = random_double();
-    auto r2 = random_double();
-    auto z = sqrt(1-r2);
-    auto phi = 2*pi*r1;
-    auto x = cos(phi)*sqrt(r2);
-    auto y = sin(phi)*sqrt(r2);
-
-    return vec3(x, y, z);
-}
-
-
 int main() {
     int N = 1000000;
 

--- a/src/TheRestOfYourLife/cos_density.cc
+++ b/src/TheRestOfYourLife/cos_density.cc
@@ -16,7 +16,7 @@
 #include <math.h>
 
 
-inline vec3 random_cosine_direction() {
+vec3 random_cosine_direction() {
     auto r1 = random_double();
     auto r2 = random_double();
     auto z = sqrt(1-r2);

--- a/src/TheRestOfYourLife/hittable.h
+++ b/src/TheRestOfYourLife/hittable.h
@@ -29,7 +29,7 @@ class hit_record {
     double v;
     bool front_face;
 
-    inline void set_face_normal(const ray& r, const vec3& outward_normal) {
+    void set_face_normal(const ray& r, const vec3& outward_normal) {
         front_face = dot(r.direction(), outward_normal) < 0;
         normal = front_face ? outward_normal :-outward_normal;
     }

--- a/src/TheRestOfYourLife/integrate_x_sq.cc
+++ b/src/TheRestOfYourLife/integrate_x_sq.cc
@@ -17,7 +17,7 @@
 #include <stdlib.h>
 
 
-inline double pdf(double x) {
+double pdf(double x) {
     return  3*x*x/8;
 }
 

--- a/src/TheRestOfYourLife/onb.h
+++ b/src/TheRestOfYourLife/onb.h
@@ -19,7 +19,7 @@ class onb
   public:
     onb() {}
 
-    inline vec3 operator[](int i) const { return axis[i]; }
+    vec3 operator[](int i) const { return axis[i]; }
 
     vec3 u() const { return axis[0]; }
     vec3 v() const { return axis[1]; }

--- a/src/TheRestOfYourLife/pdf.h
+++ b/src/TheRestOfYourLife/pdf.h
@@ -16,19 +16,6 @@
 #include "onb.h"
 
 
-inline vec3 random_cosine_direction() {
-    auto r1 = random_double();
-    auto r2 = random_double();
-    auto z = sqrt(1-r2);
-
-    auto phi = 2*pi*r1;
-    auto x = cos(phi)*sqrt(r2);
-    auto y = sin(phi)*sqrt(r2);
-
-    return vec3(x, y, z);
-}
-
-
 class pdf {
   public:
     virtual ~pdf() {}

--- a/src/TheRestOfYourLife/pdf.h
+++ b/src/TheRestOfYourLife/pdf.h
@@ -29,19 +29,6 @@ inline vec3 random_cosine_direction() {
 }
 
 
-inline vec3 random_to_sphere(double radius, double distance_squared) {
-    auto r1 = random_double();
-    auto r2 = random_double();
-    auto z = 1 + r2*(sqrt(1-radius*radius/distance_squared) - 1);
-
-    auto phi = 2*pi*r1;
-    auto x = cos(phi)*sqrt(1-z*z);
-    auto y = sin(phi)*sqrt(1-z*z);
-
-    return vec3(x, y, z);
-}
-
-
 class pdf {
   public:
     virtual ~pdf() {}

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -51,6 +51,18 @@ class sphere : public hittable {
         u = phi / (2*pi);
         v = theta / pi;
     }
+
+    static vec3 random_to_sphere(double radius, double distance_squared) {
+        auto r1 = random_double();
+        auto r2 = random_double();
+        auto z = 1 + r2*(sqrt(1-radius*radius/distance_squared) - 1);
+
+        auto phi = 2*pi*r1;
+        auto x = cos(phi)*sqrt(1-z*z);
+        auto y = sin(phi)*sqrt(1-z*z);
+
+        return vec3(x, y, z);
+    }
 };
 
 

--- a/src/TheRestOfYourLife/sphere_importance.cc
+++ b/src/TheRestOfYourLife/sphere_importance.cc
@@ -17,7 +17,7 @@
 #include <stdlib.h>
 
 
-inline double pdf(const vec3& p) {
+double pdf(const vec3& p) {
     return  1.0 / (4.0*pi);
 }
 

--- a/src/common/vec3.h
+++ b/src/common/vec3.h
@@ -62,11 +62,11 @@ class vec3 {
         return (fabs(e[0]) < s) && (fabs(e[1]) < s) && (fabs(e[2]) < s);
     }
 
-    inline static vec3 random() {
+    static vec3 random() {
         return vec3(random_double(), random_double(), random_double());
     }
 
-    inline static vec3 random(double min, double max) {
+    static vec3 random(double min, double max) {
         return vec3(random_double(min,max), random_double(min,max), random_double(min,max));
     }
 

--- a/src/common/vec3.h
+++ b/src/common/vec3.h
@@ -165,5 +165,17 @@ inline vec3 refract(const vec3& uv, const vec3& n, double etai_over_etat) {
     return r_out_perp + r_out_parallel;
 }
 
+inline vec3 random_cosine_direction() {
+    auto r1 = random_double();
+    auto r2 = random_double();
+    auto z = sqrt(1-r2);
+
+    auto phi = 2*pi*r1;
+    auto x = cos(phi)*sqrt(r2);
+    auto y = sin(phi)*sqrt(r2);
+
+    return vec3(x, y, z);
+}
+
 
 #endif


### PR DESCRIPTION
Despite comments in #803, we still had multiple cases where `inline` keywords were not required or where there was a better location for many of these global functions. Simple cleanup pass of different cases.