### PR TITLE
Remove virtual keyword for override methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Change Log -- Ray Tracing in One Weekend
   - Change: Class public/private access labels get two-space indents (#782)
   - Change: `interval::clamp()` replaces standalone `clamp` utility function
   - New: `rtw_image` class for easier image data loading, searches more locations (#807)
+  - Fix: Remove redundant `virtual` keyword for methods with `override` (#805)
 
 ### In One Weekend
   - Added: More commentary about the choice between `double` and `float` (#752)

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -892,8 +892,7 @@ And here’s the sphere:
         sphere() {}
         sphere(point3 ctr, double r) : center(ctr), radius(r) {};
 
-        virtual bool hit(const ray& r, double ray_tmin, double ray_tmax, hit_record& rec)
-            const override;
+        bool hit(const ray& r, double ray_tmin, double ray_tmax, hit_record& rec) const override;
 
       public:
         point3 center;
@@ -1067,8 +1066,7 @@ that stores a list of `hittable`s:
         void clear() { objects.clear(); }
         void add(shared_ptr<hittable> object) { objects.push_back(object); }
 
-        virtual bool hit(const ray& r, double ray_tmin, double ray_tmax, hit_record& rec)
-            const override;
+        bool hit(const ray& r, double ray_tmin, double ray_tmax, hit_record& rec) const override;
 
       public:
         std::vector<shared_ptr<hittable>> objects;
@@ -1326,7 +1324,7 @@ and a maximum. We'll end up using this class quite often as we proceed.
     class hittable_list : public hittable {
         ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         ...
     };
@@ -1362,7 +1360,7 @@ and a maximum. We'll end up using this class quite often as we proceed.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class sphere : public hittable {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         ...
     };
@@ -2106,7 +2104,7 @@ within `hit_record`. See the highlighted lines below:
           : center(ctr), radius(r), mat_ptr(m) {};
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
       public:
         point3 center;
@@ -2146,9 +2144,8 @@ it could be a mixture of those strategies. For Lambertian materials we get this 
       public:
         lambertian(const color& a) : albedo(a) {}
 
-        virtual bool scatter(
-            const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-        ) const override {
+        bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+        const override {
             auto scatter_direction = rec.normal + random_unit_vector();
             scattered = ray(rec.p, scatter_direction);
             attenuation = albedo;
@@ -2192,9 +2189,8 @@ the vector is very close to zero in all dimensions.
       public:
         lambertian(const color& a) : albedo(a) {}
 
-        virtual bool scatter(
-            const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-        ) const override {
+        bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+        const override {
             auto scatter_direction = rec.normal + random_unit_vector();
 
 
@@ -2248,9 +2244,8 @@ The metal material just reflects rays using that formula:
       public:
         metal(const color& a) : albedo(a) {}
 
-        virtual bool scatter(
-            const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-        ) const override {
+        bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+        const override {
             vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
             scattered = ray(rec.p, reflected);
             attenuation = albedo;
@@ -2395,9 +2390,8 @@ absorb those.
         metal(const color& a, double f) : albedo(a), fuzz(f < 1 ? f : 1) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-        virtual bool scatter(
-            const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-        ) const override {
+        bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+        const override {
             vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             scattered = ray(rec.p, reflected + fuzz*random_in_unit_sphere());
@@ -2533,9 +2527,8 @@ And the dielectric material that always refracts is:
       public:
         dielectric(double index_of_refraction) : ir(index_of_refraction) {}
 
-        virtual bool scatter(
-            const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-        ) const override {
+        bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+        const override {
             attenuation = color(1.0, 1.0, 1.0);
             double refraction_ratio = rec.front_face ? (1.0/ir) : ir;
 
@@ -2645,9 +2638,8 @@ And the dielectric material that always refracts (when possible) is:
       public:
         dielectric(double index_of_refraction) : ir(index_of_refraction) {}
 
-        virtual bool scatter(
-            const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-        ) const override {
+        bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+        const override {
             attenuation = color(1.0, 1.0, 1.0);
             double refraction_ratio = rec.front_face ? (1.0/ir) : ir;
 
@@ -2709,9 +2701,8 @@ material:
       public:
         dielectric(double index_of_refraction) : ir(index_of_refraction) {}
 
-        virtual bool scatter(
-            const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-        ) const override {
+        bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+        const override {
             attenuation = color(1.0, 1.0, 1.0);
             double refraction_ratio = rec.front_face ? (1.0/ir) : ir;
 

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -304,7 +304,8 @@ for the time of intersection:
 
     class dielectric : public material {
         ...
-        virtual bool scatter(
+        bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+        const override {
             ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             scattered = ray(rec.p, direction, r_in.time());

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -197,7 +197,7 @@ those times need not match up with the camera aperture open and close.
             time0(time_start), time1(time_end)
         {};
 
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
         point3 center(double time) const;
 
@@ -270,9 +270,8 @@ for the time of intersection:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class lambertian : public material {
         ...
-        virtual bool scatter(
-            const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-        ) const override {
+        bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+        const override {
             auto scatter_direction = rec.normal + random_unit_vector();
 
             // Catch degenerate scatter direction
@@ -291,9 +290,8 @@ for the time of intersection:
 
     class metal : public material {
         ...
-        virtual bool scatter(
-            const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-        ) const override {
+        bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+        const override {
             vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             scattered = ray(rec.p, reflected + fuzz*random_in_unit_sphere(), r_in.time());
@@ -749,12 +747,11 @@ For a sphere, that `bounding_box` function is easy:
     class sphere : public hittable {
       public:
         ...
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
-            const override;
+        bool bounding_box(double time_start, double time_end, aabb& output_box) const override;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         ...
     };
@@ -785,12 +782,11 @@ and compute the box of those two boxes:
     class moving_sphere : public hittable {
       public:
         ...
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
-            const override;
+        bool bounding_box(double time_start, double time_end, aabb& output_box) const override;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         ...
     };
@@ -829,12 +825,11 @@ the fly because it is only usually called at BVH construction.
     class hittable_list : public hittable {
       public:
         ...
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
-            const override;
+        bool bounding_box(double time_start, double time_end, aabb& output_box) const override;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         ...
     };
@@ -912,10 +907,9 @@ a class:
             const std::vector<shared_ptr<hittable>>& src_objects,
             size_t start, size_t end, double time_start, double time_end);
 
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-        virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
-            const override;
+        bool bounding_box(double time_start, double time_end, aabb& output_box) const override;
 
       public:
         shared_ptr<hittable> left;
@@ -1110,7 +1104,7 @@ The First Texture Class: Constant Texture
 
         solid_color(double red, double green, double blue) : solid_color(color(red,green,blue)) {}
 
-        virtual color value(double u, double v, const vec3& p) const override {
+        color value(double u, double v, const vec3& p) const override {
             return color_value;
         }
 
@@ -1265,9 +1259,8 @@ Now we can make textured materials by replacing the `const color& a` with a text
         lambertian(shared_ptr<texture> a) : albedo(a) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-        virtual bool scatter(
-            const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-        ) const override {
+        bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+        const override {
             auto scatter_direction = rec.normal + random_unit_vector();
 
             // Catch degenerate scatter direction
@@ -1309,7 +1302,7 @@ forms a 3D checker pattern.
         checker_texture(color c1, color c2)
           : even(make_shared<solid_color>(c1)) , odd(make_shared<solid_color>(c2)) {}
 
-        virtual color value(double u, double v, const point3& p) const override {
+        color value(double u, double v, const point3& p) const override {
             auto sines = sin(10*p.x())*sin(10*p.y())*sin(10*p.z());
             if (sines < 0)
                 return odd->value(u, v, p);
@@ -1552,7 +1545,7 @@ Now if we create an actual texture that takes these floats between 0 and 1 and c
       public:
         noise_texture() {}
 
-        virtual color value(double u, double v, const point3& p) const override {
+        color value(double u, double v, const point3& p) const override {
             return color(1,1,1) * noise.noise(p);
         }
 
@@ -1734,7 +1727,7 @@ It is also a bit low frequency. We can scale the input point to make it vary mor
         noise_texture(double sc) : scale(sc) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-        virtual color value(double u, double v, const point3& p) const override {
+        color value(double u, double v, const point3& p) const override {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             return color(1,1,1) * noise.noise(scale * p);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1914,7 +1907,7 @@ perlin output back to between 0 and 1.
         noise_texture() {}
         noise_texture(double sc) : scale(sc) {}
 
-        virtual color value(double u, double v, const point3& p) const override {
+        color value(double u, double v, const point3& p) const override {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             return color(1,1,1) * 0.5 * (1.0 + noise.noise(scale * p));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1975,7 +1968,7 @@ Here `fabs()` is the absolute value function defined in `<cmath>`.
         noise_texture() {}
         noise_texture(double sc) : scale(sc) {}
 
-        virtual color value(double u, double v, const point3& p) const override {
+        color value(double u, double v, const point3& p) const override {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             return color(1,1,1) * noise.turb(scale * p);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2012,7 +2005,7 @@ effect is:
         noise_texture() {}
         noise_texture(double sc) : scale(sc) {}
 
-        virtual color value(double u, double v, const point3& p) const override {
+        color value(double u, double v, const point3& p) const override {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             return color(1,1,1) * 0.5 * (1 + sin(scale*p.z() + 10*noise.turb(p)));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2178,7 +2171,7 @@ The `image_texture` class uses the `rtw_image` class:
         image_texture() {}
         image_texture(const char* filename) : image(filename) {}
 
-        virtual color value(double u, double v, const vec3& p) const override {
+        color value(double u, double v, const vec3& p) const override {
             // If we have no texture data, then return solid cyan as a debugging aid.
             if (image.height() <= 0) return color(0,1,1);
 
@@ -2290,13 +2283,12 @@ the ray what color it is and performs no reflection. It’s very simple:
         diffuse_light(shared_ptr<texture> a) : emit(a) {}
         diffuse_light(color c) : emit(make_shared<solid_color>(c)) {}
 
-        virtual bool scatter(
-            const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-        ) const override {
+        bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+        const override {
             return false;
         }
 
-        virtual color emitted(double u, double v, const point3& p) const override {
+        color emitted(double u, double v, const point3& p) const override {
             return emit->value(u, v, p);
         }
 
@@ -2506,10 +2498,9 @@ The actual `xy_rect` class is thus:
             shared_ptr<material> mat)
             : x0(_x0), x1(_x1), y0(_y0), y1(_y1), k(_k), mp(mat) {};
 
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-        virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
-        const override {
+        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
             // The bounding box must have non-zero width in each dimension, so pad the Z
             // dimension a small amount.
             output_box = aabb(point3(x0, y0, k-0.0001), point3(x1, y1, k+0.0001));
@@ -2647,11 +2638,9 @@ This is xz and yz:
         xz_rect(double _x0, double _x1, double _z0, double _z1, double _k, shared_ptr<material> mat)
           : x0(_x0), x1(_x1), z0(_z0), z1(_z1), k(_k), mp(mat) {};
 
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-        virtual bool bounding_box(
-            double time_start, double time_end, aabb& output_box
-        ) const override {
+        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
             // The bounding box must have non-zero width in each dimension, so pad the Y
             // dimension a small amount.
             output_box = aabb(point3(x0, k-0.0001, z0), point3(x1, k+0.0001, z1));
@@ -2670,11 +2659,9 @@ This is xz and yz:
         yz_rect(double _y0, double _y1, double _z0, double _z1, double _k, shared_ptr<material> mat)
           : y0(_y0), y1(_y1), z0(_z0), z1(_z1), k(_k), mp(mat) {};
 
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-        virtual bool bounding_box(
-            double time_start, double time_end, aabb& output_box
-        ) const override {
+        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
             // The bounding box must have non-zero width in each dimension, so pad the X
             // dimension a small amount.
             output_box = aabb(point3(k-0.0001, y0, z0), point3(k+0.0001, y1, z1));
@@ -2829,11 +2816,9 @@ make an axis-aligned block primitive that holds 6 rectangles:
         box() {}
         box(const point3& p0, const point3& p1, shared_ptr<material> ptr);
 
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-        virtual bool bounding_box(
-            double time_start, double time_end, aabb& output_box
-        ) const override {
+        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
             output_box = aabb(box_min, box_max);
             return true;
         }
@@ -2912,10 +2897,9 @@ move any underlying hittable is a _translate_ instance.
         translate(shared_ptr<hittable> p, const vec3& displacement)
           : ptr(p), offset(displacement) {}
 
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-        virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
-            const override;
+        bool bounding_box(double time_start, double time_end, aabb& output_box) const override;
 
       public:
         shared_ptr<hittable> ptr;
@@ -2999,11 +2983,9 @@ For a y-rotation class we have:
       public:
         rotate_y(shared_ptr<hittable> p, double angle);
 
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-        virtual bool bounding_box(
-            double time_start, double time_end, aabb& output_box
-        ) const override {
+        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
             output_box = bbox;
             return hasbox;
         }
@@ -3175,11 +3157,9 @@ density $C$ and the boundary. I’ll use another hittable for the boundary. The 
           : boundary(b), neg_inv_density(-1/d), phase_function(make_shared<isotropic>(c))
         {}
 
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-        virtual bool bounding_box(
-            double time_start, double time_end, aabb& output_box
-        ) const override {
+        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
             return boundary->bounding_box(time_start, time_end, output_box);
         }
 
@@ -3203,9 +3183,8 @@ The scattering function of isotropic picks a uniform random direction:
         isotropic(color c) : albedo(make_shared<solid_color>(c)) {}
         isotropic(shared_ptr<texture> a) : albedo(a) {}
 
-        virtual bool scatter(
-            const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-        ) const override {
+        bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+        const override {
             scattered = ray(rec.p, random_in_unit_sphere(), r_in.time());
             attenuation = albedo->value(rec.u, rec.v, rec.p);
             return true;

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -948,9 +948,8 @@ We modify the base-class `material` to enable this importance sampling:
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        virtual double scattering_pdf(
-            const ray& r_in, const hit_record& rec, const ray& scattered
-        ) const {
+        virtual double scattering_pdf(const ray& r_in, const hit_record& rec, const ray& scattered)
+        const {
             return 0;
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -995,9 +994,7 @@ And _Lambertian_ material becomes:
         }
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        double scattering_pdf(
-            const ray& r_in, const hit_record& rec, const ray& scattered
-        ) const {
+        double scattering_pdf(const ray& r_in, const hit_record& rec, const ray& scattered) const {
             auto cosine = dot(rec.normal, unit_vector(scattered.direction()));
             return cosine < 0 ? 0 : cosine/pi;
         }
@@ -2132,9 +2129,8 @@ We can redesign `material` and stuff all the new arguments into a class like we 
             return false;
         }
 
-        virtual double scattering_pdf(
-            const ray& r_in, const hit_record& rec, const ray& scattered
-        ) const {
+        virtual double scattering_pdf(const ray& r_in, const hit_record& rec, const ray& scattered)
+        const {
             return 0;
         }
     };
@@ -2160,9 +2156,7 @@ The Lambertian material becomes simpler:
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-        double scattering_pdf(
-            const ray& r_in, const hit_record& rec, const ray& scattered
-        ) const {
+        double scattering_pdf(const ray& r_in, const hit_record& rec, const ray& scattered) const {
             auto cosine = dot(rec.normal, unit_vector(scattered.direction()));
             return cosine < 0 ? 0 : cosine/pi;
         }

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -975,8 +975,8 @@ And _Lambertian_ material becomes:
         lambertian(shared_ptr<texture> a) : albedo(a) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-        virtual bool scatter(
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+        bool scatter(
             const ray& r_in, const hit_record& rec, color& alb, ray& scattered, double& pdf
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         ) const override {
@@ -1057,19 +1057,22 @@ Now, just for the experience, try a different sampling strategy. As in the first
 randomly from the hemisphere above the surface. This would be $p(direction) = \frac{1}{2\pi}$.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    virtual bool scatter(
-        const ray& r_in, const hit_record& rec, color& alb, ray& scattered, double& pdf
-    ) const override {
+    class lambertian : public material {
+      public:
+        ...
+        bool scatter(
+            const ray& r_in, const hit_record& rec, color& alb, ray& scattered, double& pdf
+        ) const override {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        auto direction = random_in_hemisphere(rec.normal);
+            auto direction = random_in_hemisphere(rec.normal);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-        scattered = ray(rec.p, unit_vector(direction), r_in.time());
-        alb = albedo->value(rec.u, rec.v, rec.p);
+            scattered = ray(rec.p, unit_vector(direction), r_in.time());
+            alb = albedo->value(rec.u, rec.v, rec.p);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        pdf = 0.5 / pi;
+            pdf = 0.5 / pi;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-        return true;
-    }
+            return true;
+        }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scatter-mod]: <kbd>[material.h]</kbd> Modified scatter function]
 </div>
@@ -1430,21 +1433,24 @@ class because it won't really be more complicated than utility functions:
 We can rewrite our Lambertian material using this to get:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    virtual bool scatter(
-        const ray& r_in, const hit_record& rec, color& alb, ray& scattered, double& pdf
-    ) const override {
+    class lambertian : public material {
+      public:
+        ...
+        bool scatter(
+            const ray& r_in, const hit_record& rec, color& alb, ray& scattered, double& pdf
+        ) const override {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        onb uvw;
-        uvw.build_from_w(rec.normal);
-        auto direction = uvw.local(random_cosine_direction());
+            onb uvw;
+            uvw.build_from_w(rec.normal);
+            auto direction = uvw.local(random_cosine_direction());
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-        scattered = ray(rec.p, unit_vector(direction), r_in.time());
-        alb = albedo->value(rec.u, rec.v, rec.p);
+            scattered = ray(rec.p, unit_vector(direction), r_in.time());
+            alb = albedo->value(rec.u, rec.v, rec.p);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        pdf = dot(uvw.w(), scattered.direction()) / pi;
+            pdf = dot(uvw.w(), scattered.direction()) / pi;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-        return true;
-    }
+            return true;
+        }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scatter-onb]: <kbd>[material.h]</kbd> Scatter function, with orthonormal basis]
 </div>
@@ -1576,9 +1582,8 @@ and there is a small space between light and ceiling. We probably want to have t
 down. We can do that by letting the emitted member function of hittable take extra information:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    virtual color emitted(const ray& r_in, const hit_record& rec, double u, double v,
-        const point3& p) const override {
-
+    color emitted(const ray& r_in, const hit_record& rec, double u, double v, const point3& p)
+    const override {
         if (rec.front_face)
             return emit->value(u, v, p);
         else
@@ -1596,7 +1601,7 @@ We also need to flip the light so its normals point in the $-y$ direction:
       public:
         flip_face(shared_ptr<hittable> p) : ptr(p) {}
 
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
             if (!ptr->hit(r, ray_t, rec))
                 return false;
 
@@ -1607,9 +1612,7 @@ We also need to flip the light so its normals point in the $-y$ direction:
             return true;
         }
 
-        virtual bool bounding_box(
-            double time_start, double time_end, aabb& output_box
-        ) const override {
+        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
             return ptr->bounding_box(time_start, time_end, output_box);
         }
 
@@ -1741,12 +1744,12 @@ First, let’s try a cosine density:
       public:
         cosine_pdf(const vec3& w) { uvw.build_from_w(w); }
 
-        virtual double value(const vec3& direction) const override {
+        double value(const vec3& direction) const override {
             auto cosine = dot(unit_vector(direction), uvw.w());
             return (cosine <= 0) ? 0 : cosine/pi;
         }
 
-        virtual vec3 generate() const override {
+        vec3 generate() const override {
             return uvw.local(random_cosine_direction());
         }
 
@@ -1815,11 +1818,11 @@ Now we can try sampling directions toward a `hittable`, like the light.
       public:
         hittable_pdf(shared_ptr<hittable> p, const point3& origin) : ptr(p), o(origin) {}
 
-        virtual double value(const vec3& direction) const override {
+        double value(const vec3& direction) const override {
             return ptr->pdf_value(o, direction);
         }
 
-        virtual vec3 generate() const override {
+        vec3 generate() const override {
             return ptr->random(o);
         }
 
@@ -1866,7 +1869,7 @@ And we change `xz_rect` to implement those functions:
         ...
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        virtual double pdf_value(const point3& origin, const vec3& v) const override {
+        double pdf_value(const point3& origin, const vec3& v) const override {
             hit_record rec;
             if (!this->hit(ray(origin, v), interval(0.001, infinity), rec))
                 return 0;
@@ -1878,7 +1881,7 @@ And we change `xz_rect` to implement those functions:
             return distance_squared / (cosine * area);
         }
 
-        virtual vec3 random(const point3& origin) const override {
+        vec3 random(const point3& origin) const override {
             auto random_point = point3(random_double(x0,x1), k, random_double(z0,z1));
             return random_point - origin;
         }
@@ -1967,11 +1970,11 @@ class is straightforward:
             p[1] = p1;
         }
 
-        virtual double value(const vec3& direction) const override {
+        double value(const vec3& direction) const override {
             return 0.5 * p[0]->value(direction) + 0.5 *p[1]->value(direction);
         }
 
-        virtual vec3 generate() const override {
+        vec3 generate() const override {
             if (random_double() < 0.5)
                 return p[0]->generate();
             else
@@ -2149,9 +2152,7 @@ The Lambertian material becomes simpler:
         lambertian(shared_ptr<texture> a) : albedo(a) {}
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        virtual bool scatter(
-            const ray& r_in, const hit_record& rec, scatter_record& srec
-        ) const override {
+        bool scatter(const ray& r_in, const hit_record& rec, scatter_record& srec) const override {
             srec.is_specular = false;
             srec.attenuation = albedo->value(rec.u, rec.v, rec.p);
             srec.pdf_ptr = new cosine_pdf(rec.normal);
@@ -2244,9 +2245,7 @@ and dielectric materials are easy to fix.
       public:
         metal(const color& a, double f) : albedo(a), fuzz(f < 1 ? f : 1) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        virtual bool scatter(
-            const ray& r_in, const hit_record& rec, scatter_record& srec
-        ) const override {
+        bool scatter(const ray& r_in, const hit_record& rec, scatter_record& srec) const override {
             vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
             srec.specular_ray = ray(rec.p, reflected+fuzz*random_in_unit_sphere());
             srec.attenuation = albedo;
@@ -2266,9 +2265,7 @@ and dielectric materials are easy to fix.
     class dielectric : public material {
       public:
         ...
-        virtual bool scatter(
-            const ray& r_in, const hit_record& rec, scatter_record& srec
-        ) const override {
+        bool scatter(const ray& r_in, const hit_record& rec, scatter_record& srec) const override {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             srec.is_specular = true;
             srec.pdf_ptr = nullptr;

--- a/src/InOneWeekend/hittable_list.h
+++ b/src/InOneWeekend/hittable_list.h
@@ -27,7 +27,7 @@ class hittable_list : public hittable {
     void clear() { objects.clear(); }
     void add(shared_ptr<hittable> object) { objects.push_back(object); }
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
   public:
     std::vector<shared_ptr<hittable>> objects;

--- a/src/InOneWeekend/material.h
+++ b/src/InOneWeekend/material.h
@@ -29,9 +29,8 @@ class lambertian : public material {
   public:
     lambertian(const color& a) : albedo(a) {}
 
-    virtual bool scatter(
-        const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-    ) const override {
+    bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+    const override {
         auto scatter_direction = rec.normal + random_unit_vector();
 
         // Catch degenerate scatter direction
@@ -52,9 +51,8 @@ class metal : public material {
   public:
     metal(const color& a, double f) : albedo(a), fuzz(f < 1 ? f : 1) {}
 
-    virtual bool scatter(
-        const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-    ) const override {
+    bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+    const override {
         vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
         scattered = ray(rec.p, reflected + fuzz*random_in_unit_sphere());
         attenuation = albedo;
@@ -71,9 +69,8 @@ class dielectric : public material {
   public:
     dielectric(double index_of_refraction) : ir(index_of_refraction) {}
 
-    virtual bool scatter(
-        const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-    ) const override {
+    bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+    const override {
         attenuation = color(1.0, 1.0, 1.0);
         double refraction_ratio = rec.front_face ? (1.0/ir) : ir;
 

--- a/src/InOneWeekend/sphere.h
+++ b/src/InOneWeekend/sphere.h
@@ -22,7 +22,7 @@ class sphere : public hittable {
     sphere(point3 ctr, double r, shared_ptr<material> m)
       : center(ctr), radius(r), mat_ptr(m) {};
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
   public:
     point3 center;

--- a/src/TheNextWeek/aarect.h
+++ b/src/TheNextWeek/aarect.h
@@ -23,11 +23,9 @@ class xy_rect : public hittable {
     xy_rect(double _x0, double _x1, double _y0, double _y1, double _k, shared_ptr<material> mat)
       : x0(_x0), x1(_x1), y0(_y0), y1(_y1), k(_k), mp(mat) {};
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(
-        double time_start, double time_end, aabb& output_box
-    ) const override {
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
         // The bounding box must have non-zero width in each dimension, so pad the Z
         // dimension a small amount.
         output_box = aabb(point3(x0, y0, k-0.0001), point3(x1, y1, k+0.0001));
@@ -47,11 +45,9 @@ class xz_rect : public hittable {
     xz_rect(double _x0, double _x1, double _z0, double _z1, double _k, shared_ptr<material> mat)
       : x0(_x0), x1(_x1), z0(_z0), z1(_z1), k(_k), mp(mat) {};
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(
-        double time_start, double time_end, aabb& output_box
-    ) const override {
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
         // The bounding box must have non-zero width in each dimension, so pad the Y
         // dimension a small amount.
         output_box = aabb(point3(x0, k-0.0001, z0), point3(x1, k+0.0001, z1));
@@ -71,11 +67,9 @@ class yz_rect : public hittable {
     yz_rect(double _y0, double _y1, double _z0, double _z1, double _k, shared_ptr<material> mat)
       : y0(_y0), y1(_y1), z0(_z0), z1(_z1), k(_k), mp(mat) {};
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(
-        double time_start, double time_end, aabb& output_box
-    ) const override {
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
         // The bounding box must have non-zero width in each dimension, so pad the X
         // dimension a small amount.
         output_box = aabb(point3(k-0.0001, y0, z0), point3(k+0.0001, y1, z1));

--- a/src/TheNextWeek/box.h
+++ b/src/TheNextWeek/box.h
@@ -22,11 +22,9 @@ class box : public hittable {
     box() {}
     box(const point3& p0, const point3& p1, shared_ptr<material> ptr);
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(
-        double time_start, double time_end, aabb& output_box
-    ) const override {
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
         output_box = aabb(box_min, box_max);
         return true;
     }

--- a/src/TheNextWeek/bvh.h
+++ b/src/TheNextWeek/bvh.h
@@ -31,9 +31,9 @@ class bvh_node : public hittable {
         const std::vector<shared_ptr<hittable>>& src_objects,
         size_t start, size_t end, double time0, double time1);
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(double time0, double time1, aabb& output_box) const override;
+    bool bounding_box(double time0, double time1, aabb& output_box) const override;
 
   public:
     shared_ptr<hittable> left;

--- a/src/TheNextWeek/constant_medium.h
+++ b/src/TheNextWeek/constant_medium.h
@@ -28,11 +28,9 @@ class constant_medium : public hittable {
       : boundary(b), neg_inv_density(-1/d), phase_function(make_shared<isotropic>(c))
     {}
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(
-        double time_start, double time_end, aabb& output_box
-    ) const override {
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
         return boundary->bounding_box(time_start, time_end, output_box);
     }
 

--- a/src/TheNextWeek/hittable.h
+++ b/src/TheNextWeek/hittable.h
@@ -48,10 +48,9 @@ class translate : public hittable {
     translate(shared_ptr<hittable> p, const vec3& displacement)
       : ptr(p), offset(displacement) {}
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
-        const override;
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override;
 
   public:
     shared_ptr<hittable> ptr;
@@ -87,11 +86,9 @@ class rotate_y : public hittable {
   public:
     rotate_y(shared_ptr<hittable> p, double angle);
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(
-        double time_start, double time_end, aabb& output_box
-    ) const override {
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
         output_box = bbox;
         return hasbox;
     }

--- a/src/TheNextWeek/hittable_list.h
+++ b/src/TheNextWeek/hittable_list.h
@@ -27,10 +27,9 @@ class hittable_list : public hittable {
     void clear() { objects.clear(); }
     void add(shared_ptr<hittable> object) { objects.push_back(object); }
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
-        const override;
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override;
 
   public:
     std::vector<shared_ptr<hittable>> objects;

--- a/src/TheNextWeek/material.h
+++ b/src/TheNextWeek/material.h
@@ -34,9 +34,8 @@ class lambertian : public material {
     lambertian(const color& a) : albedo(make_shared<solid_color>(a)) {}
     lambertian(shared_ptr<texture> a) : albedo(a) {}
 
-    virtual bool scatter(
-        const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-    ) const override {
+    bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+    const override {
         auto scatter_direction = rec.normal + random_unit_vector();
 
         // Catch degenerate scatter direction
@@ -57,9 +56,8 @@ class metal : public material {
   public:
     metal(const color& a, double f) : albedo(a), fuzz(f < 1 ? f : 1) {}
 
-    virtual bool scatter(
-        const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-    ) const override {
+    bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+    const override {
         vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
         scattered = ray(rec.p, reflected + fuzz*random_in_unit_sphere(), r_in.time());
         attenuation = albedo;
@@ -76,9 +74,8 @@ class dielectric : public material {
   public:
     dielectric(double index_of_refraction) : ir(index_of_refraction) {}
 
-    virtual bool scatter(
-        const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-    ) const override {
+    bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+    const override {
         attenuation = color(1.0, 1.0, 1.0);
         double refraction_ratio = rec.front_face ? (1.0/ir) : ir;
 
@@ -116,13 +113,12 @@ class diffuse_light : public material {
     diffuse_light(shared_ptr<texture> a) : emit(a) {}
     diffuse_light(color c) : emit(make_shared<solid_color>(c)) {}
 
-    virtual bool scatter(
-        const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-    ) const override {
+    bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+    const override {
         return false;
     }
 
-    virtual color emitted(double u, double v, const point3& p) const override {
+    color emitted(double u, double v, const point3& p) const override {
         return emit->value(u, v, p);
     }
 
@@ -136,9 +132,8 @@ class isotropic : public material {
     isotropic(color c) : albedo(make_shared<solid_color>(c)) {}
     isotropic(shared_ptr<texture> a) : albedo(a) {}
 
-    virtual bool scatter(
-        const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-    ) const override {
+    bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+    const override {
         scattered = ray(rec.p, random_in_unit_sphere(), r_in.time());
         attenuation = albedo->value(rec.u, rec.v, rec.p);
         return true;

--- a/src/TheNextWeek/moving_sphere.h
+++ b/src/TheNextWeek/moving_sphere.h
@@ -25,10 +25,9 @@ class moving_sphere : public hittable {
       : center0(ctr0), center1(ctr1), radius(r), mat_ptr(m), time0(time_start), time1(time_end)
     {};
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
-        const override;
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override;
 
     point3 center(double time) const;
 

--- a/src/TheNextWeek/sphere.h
+++ b/src/TheNextWeek/sphere.h
@@ -22,10 +22,9 @@ class sphere : public hittable {
     sphere(point3 ctr, double r, shared_ptr<material> m)
       : center(ctr), radius(r), mat_ptr(m) {};
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
-        const override;
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override;
 
   public:
     point3 center;

--- a/src/TheRestOfYourLife/aarect.h
+++ b/src/TheRestOfYourLife/aarect.h
@@ -23,11 +23,9 @@ class xy_rect : public hittable {
     xy_rect(double _x0, double _x1, double _y0, double _y1, double _k, shared_ptr<material> mat)
       : x0(_x0), x1(_x1), y0(_y0), y1(_y1), k(_k), mp(mat) {};
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
-        const override
-    {
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
         // The bounding box must have non-zero width in each dimension, so pad the Z
         // dimension a small amount.
         output_box = aabb(point3(x0, y0, k-0.0001), point3(x1, y1, k+0.0001));
@@ -47,18 +45,16 @@ class xz_rect : public hittable {
     xz_rect(double _x0, double _x1, double _z0, double _z1, double _k, shared_ptr<material> mat)
       : x0(_x0), x1(_x1), z0(_z0), z1(_z1), k(_k), mp(mat) {};
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(
-        double time_start, double time_end, aabb& output_box
-    ) const override {
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
         // The bounding box must have non-zero width in each dimension, so pad the Y
         // dimension a small amount.
         output_box = aabb(point3(x0, k-0.0001, z0), point3(x1, k+0.0001, z1));
         return true;
     }
 
-    virtual double pdf_value(const point3& origin, const vec3& v) const override {
+    double pdf_value(const point3& origin, const vec3& v) const override {
         hit_record rec;
         if (!this->hit(ray(origin, v), interval(0.001, infinity), rec))
             return 0;
@@ -70,7 +66,7 @@ class xz_rect : public hittable {
         return distance_squared / (cosine * area);
     }
 
-    virtual vec3 random(const point3& origin) const override {
+    vec3 random(const point3& origin) const override {
         auto random_point = point3(random_double(x0,x1), k, random_double(z0,z1));
         return random_point - origin;
     }
@@ -88,11 +84,9 @@ class yz_rect : public hittable {
     yz_rect(double _y0, double _y1, double _z0, double _z1, double _k, shared_ptr<material> mat)
       : y0(_y0), y1(_y1), z0(_z0), z1(_z1), k(_k), mp(mat) {};
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(
-        double time_start, double time_end, aabb& output_box
-    ) const override {
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
         // The bounding box must have non-zero width in each dimension, so pad the X
         // dimension a small amount.
         output_box = aabb(point3(k-0.0001, y0, z0), point3(k+0.0001, y1, z1));

--- a/src/TheRestOfYourLife/box.h
+++ b/src/TheRestOfYourLife/box.h
@@ -22,11 +22,9 @@ class box : public hittable {
     box() {}
     box(const point3& p0, const point3& p1, shared_ptr<material> ptr);
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(
-        double time_start, double time_end, aabb& output_box
-    ) const override {
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
         output_box = aabb(box_min, box_max);
         return true;
     }

--- a/src/TheRestOfYourLife/bvh.h
+++ b/src/TheRestOfYourLife/bvh.h
@@ -31,9 +31,9 @@ class bvh_node : public hittable {
         const std::vector<shared_ptr<hittable>>& src_objects,
         size_t start, size_t end, double time0, double time1);
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(double time0, double time1, aabb& output_box) const override;
+    bool bounding_box(double time0, double time1, aabb& output_box) const override;
 
   public:
     shared_ptr<hittable> left;

--- a/src/TheRestOfYourLife/hittable.h
+++ b/src/TheRestOfYourLife/hittable.h
@@ -56,7 +56,7 @@ class flip_face : public hittable {
   public:
     flip_face(shared_ptr<hittable> p) : ptr(p) {}
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
         if (!ptr->hit(r, ray_t, rec))
             return false;
 
@@ -64,9 +64,7 @@ class flip_face : public hittable {
         return true;
     }
 
-    virtual bool bounding_box(
-        double time_start, double time_end, aabb& output_box
-    ) const override {
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
         return ptr->bounding_box(time_start, time_end, output_box);
     }
 
@@ -80,10 +78,9 @@ class translate : public hittable {
     translate(shared_ptr<hittable> p, const vec3& displacement)
         : ptr(p), offset(displacement) {}
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
-        const override;
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override;
 
   public:
     shared_ptr<hittable> ptr;
@@ -119,11 +116,9 @@ class rotate_y : public hittable {
   public:
     rotate_y(shared_ptr<hittable> p, double angle);
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(
-        double time_start, double time_end, aabb& output_box
-    ) const override {
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
         output_box = bbox;
         return hasbox;
     }

--- a/src/TheRestOfYourLife/hittable_list.h
+++ b/src/TheRestOfYourLife/hittable_list.h
@@ -27,13 +27,12 @@ class hittable_list : public hittable {
     void clear() { objects.clear(); }
     void add(shared_ptr<hittable> object) { objects.push_back(object); }
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
-        const override;
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override;
 
-    virtual double pdf_value(const vec3 &o, const vec3 &v) const override;
-    virtual vec3 random(const vec3 &o) const override;
+    double pdf_value(const vec3 &o, const vec3 &v) const override;
+    vec3 random(const vec3 &o) const override;
 
   public:
     std::vector<shared_ptr<hittable>> objects;

--- a/src/TheRestOfYourLife/material.h
+++ b/src/TheRestOfYourLife/material.h
@@ -53,18 +53,15 @@ class lambertian : public material {
     lambertian(const color& a) : albedo(make_shared<solid_color>(a)) {}
     lambertian(shared_ptr<texture> a) : albedo(a) {}
 
-    virtual bool scatter(
-        const ray& r_in, const hit_record& rec, scatter_record& srec
-    ) const override {
+    bool scatter(const ray& r_in, const hit_record& rec, scatter_record& srec) const override {
         srec.is_specular = false;
         srec.attenuation = albedo->value(rec.u, rec.v, rec.p);
         srec.pdf_ptr = make_shared<cosine_pdf>(rec.normal);
         return true;
     }
 
-    double scattering_pdf(
-        const ray& r_in, const hit_record& rec, const ray& scattered
-    ) const override {
+    double scattering_pdf(const ray& r_in, const hit_record& rec, const ray& scattered)
+    const override {
         auto cosine = dot(rec.normal, unit_vector(scattered.direction()));
         return cosine < 0 ? 0 : cosine/pi;
     }
@@ -78,9 +75,7 @@ class metal : public material {
   public:
     metal(const color& a, double f) : albedo(a), fuzz(f < 1 ? f : 1) {}
 
-    virtual bool scatter(
-        const ray& r_in, const hit_record& rec, scatter_record& srec
-    ) const override {
+    bool scatter(const ray& r_in, const hit_record& rec, scatter_record& srec) const override {
         vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
         srec.specular_ray =
             ray(rec.p, reflected + fuzz*random_in_unit_sphere(), r_in.time());
@@ -100,9 +95,7 @@ class dielectric : public material {
   public:
     dielectric(double index_of_refraction) : ir(index_of_refraction) {}
 
-    virtual bool scatter(
-        const ray& r_in, const hit_record& rec, scatter_record& srec
-    ) const override {
+    bool scatter(const ray& r_in, const hit_record& rec, scatter_record& srec) const override {
         srec.is_specular = true;
         srec.pdf_ptr = nullptr;
         srec.attenuation = color(1.0, 1.0, 1.0);
@@ -142,9 +135,8 @@ class diffuse_light : public material {
     diffuse_light(shared_ptr<texture> a) : emit(a) {}
     diffuse_light(color c) : emit(make_shared<solid_color>(c)) {}
 
-    virtual color emitted(
-        const ray& r_in, const hit_record& rec, double u, double v, const point3& p
-    ) const override {
+    color emitted(const ray& r_in, const hit_record& rec, double u, double v, const point3& p)
+    const override {
         if (!rec.front_face)
             return color(0,0,0);
         return emit->value(u, v, p);
@@ -165,9 +157,8 @@ class isotropic : public material {
     // This method doesn't match the signature in the base `material` class, so this one's
     // never actually called. Disabling this definition until we sort this out.
 
-    virtual bool scatter(
-        const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-    ) const override {
+    bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
+    const override {
         scattered = ray(rec.p, random_in_unit_sphere(), r_in.time());
         attenuation = albedo->value(rec.u, rec.v, rec.p);
         return true;

--- a/src/TheRestOfYourLife/material.h
+++ b/src/TheRestOfYourLife/material.h
@@ -34,15 +34,12 @@ class material {
         return color(0,0,0);
     }
 
-    virtual bool scatter(
-        const ray& r_in, const hit_record& rec, scatter_record& srec
-    ) const {
+    virtual bool scatter(const ray& r_in, const hit_record& rec, scatter_record& srec) const {
         return false;
     }
 
-    virtual double scattering_pdf(
-        const ray& r_in, const hit_record& rec, const ray& scattered
-    ) const {
+    virtual double scattering_pdf(const ray& r_in, const hit_record& rec, const ray& scattered)
+    const {
         return 0;
     }
 };

--- a/src/TheRestOfYourLife/pdf.h
+++ b/src/TheRestOfYourLife/pdf.h
@@ -55,12 +55,12 @@ class cosine_pdf : public pdf {
   public:
     cosine_pdf(const vec3& w) { uvw.build_from_w(w); }
 
-    virtual double value(const vec3& direction) const override {
+    double value(const vec3& direction) const override {
         auto cosine = dot(unit_vector(direction), uvw.w());
         return (cosine <= 0) ? 0 : cosine/pi;
     }
 
-    virtual vec3 generate() const override {
+    vec3 generate() const override {
         return uvw.local(random_cosine_direction());
     }
 
@@ -73,11 +73,11 @@ class hittable_pdf : public pdf {
   public:
     hittable_pdf(shared_ptr<hittable> p, const point3& origin) : ptr(p), o(origin) {}
 
-    virtual double value(const vec3& direction) const override {
+    double value(const vec3& direction) const override {
         return ptr->pdf_value(o, direction);
     }
 
-    virtual vec3 generate() const override {
+    vec3 generate() const override {
         return ptr->random(o);
     }
 
@@ -94,11 +94,11 @@ class mixture_pdf : public pdf {
         p[1] = p1;
     }
 
-    virtual double value(const vec3& direction) const override {
+    double value(const vec3& direction) const override {
         return 0.5 * p[0]->value(direction) + 0.5 *p[1]->value(direction);
     }
 
-    virtual vec3 generate() const override {
+    vec3 generate() const override {
         if (random_double() < 0.5)
             return p[0]->generate();
         else

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -23,13 +23,12 @@ class sphere : public hittable {
     sphere(point3 ctr, double r, shared_ptr<material> m)
       : center(ctr), radius(r), mat_ptr(m) {};
 
-    virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
 
-    virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
-        const override;
+    bool bounding_box(double time_start, double time_end, aabb& output_box) const override;
 
-    virtual double pdf_value(const point3& o, const vec3& v) const override;
-    virtual vec3 random(const point3& o) const override;
+    double pdf_value(const point3& o, const vec3& v) const override;
+    vec3 random(const point3& o) const override;
 
   public:
     point3 center;

--- a/src/common/texture.h
+++ b/src/common/texture.h
@@ -31,7 +31,7 @@ class solid_color : public texture {
     solid_color(double red, double green, double blue)
       : solid_color(color(red,green,blue)) {}
 
-    virtual color value(double u, double v, const vec3& p) const override {
+    color value(double u, double v, const vec3& p) const override {
         return color_value;
     }
 
@@ -50,7 +50,7 @@ class checker_texture : public texture {
     checker_texture(color c1, color c2)
       : even(make_shared<solid_color>(c1)) , odd(make_shared<solid_color>(c2)) {}
 
-    virtual color value(double u, double v, const vec3& p) const override {
+    color value(double u, double v, const vec3& p) const override {
         auto sines = sin(10*p.x())*sin(10*p.y())*sin(10*p.z());
         if (sines < 0)
             return odd->value(u, v, p);
@@ -69,7 +69,7 @@ class noise_texture : public texture {
     noise_texture() {}
     noise_texture(double sc) : scale(sc) {}
 
-    virtual color value(double u, double v, const vec3& p) const override {
+    color value(double u, double v, const vec3& p) const override {
         // return color(1,1,1)*0.5*(1 + noise.turb(scale * p));
         // return color(1,1,1)*noise.turb(scale * p);
         return color(1,1,1)*0.5*(1 + sin(scale*p.z() + 10*noise.turb(p)));
@@ -86,7 +86,7 @@ class image_texture : public texture {
     image_texture() {}
     image_texture(const char* filename) : image(filename) {}
 
-    virtual color value(double u, double v, const vec3& p) const override {
+    color value(double u, double v, const vec3& p) const override {
         // If we have no texture data, then return solid cyan as a debugging aid.
         if (image.height() <= 0) return color(0,1,1);
 


### PR DESCRIPTION
If a method is declared with the `override` keyword, then it is
implicitly virtual, so the `virtual` keyword is redundant and can be
removed.

Resolves #805