### PR TITLE
Tweak CMake settings: no version, better C++ ver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,12 @@
 
 cmake_minimum_required ( VERSION 3.1.0 )
 
-project ( RTWeekend
-  VERSION 3.0.0
-  LANGUAGES CXX
-)
+project ( RTWeekend LANGUAGES CXX )
 
-# Set to c++11
-set ( CMAKE_CXX_STANDARD 11 )
+# Set to C++11
+set ( CMAKE_CXX_STANDARD          11 )
+set ( CMAKE_CXX_STANDARD_REQUIRED ON )
+set ( CMAKE_CXX_EXTENSIONS        OFF )
 
 # Source
 set ( COMMON_ALL

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ If you have a change you'd like to contribute,
 [please see our contribution guidelines][CONTRIBUTING].
 
 
+GitHub Discusions
+------------------
+GitHub just released GitHub Discussions — a new feature to host conversations in a project without
+requiring everything to be an issue. This is likely a much better way to post questions, ask for
+advice, or just generally talk about the project. Is it useful? Don't know, but [let's give it a
+shot!](https://github.com/RayTracing/raytracing.github.io/discussions/).
+
+
 Directory Structure
 -------------------
 The organization of this repository is meant to be simple and self-evident at a glance:


### PR DESCRIPTION
- The prior CMakeLists.txt file specified a version for the project,
  which we hadn't been updating. This isn't of much use in our project,
  since users are expected to change this program all the time. Thus,
  pulling any explicit version stamping.

- When specifying the C++ version (we use C++11 currently), you should
  set all three CMake variables CMAKE_CXX_STANDARD,
  CMAKE_CXX_STANDARD_REQUIRED, and CMAKE_CXX_EXTENSIONS.