### PR TITLE
Fix typo in 'Ray Tracing in One Weekend'

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ If you have a change you'd like to contribute,
 [please see our contribution guidelines][CONTRIBUTING].
 
 
+GitHub Discusions
+------------------
+GitHub just released GitHub Discussions — a new feature to host conversations in a project without
+requiring everything to be an issue. This is likely a much better way to post questions, ask for
+advice, or just generally talk about the project. Is it useful? Don't know, but [let's give it a
+shot!](https://github.com/RayTracing/raytracing.github.io/discussions/).
+
+
 Directory Structure
 -------------------
 The organization of this repository is meant to be simple and self-evident at a glance:

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1141,7 +1141,7 @@ the `std::vector` member variable `objects`.
 `std::vector` is included with the `<vector>` header.
 
 Finally, the `using` statements in listing [hittable-list-initial] tell the compiler that we'll be
-getting `shared_ptr` and `make_shared` from the `std` library, so we don't need to prefex these with
+getting `shared_ptr` and `make_shared` from the `std` library, so we don't need to prefix these with
 `std::` every time we reference them.
 
 


### PR DESCRIPTION
`RayTracingInOneWeekend.html` Line 1144: "so we don't need to **prefex** these with..." should be "so we don't need to prefix these with..."