### PR TITLE
Fix a typo

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -840,7 +840,7 @@ Using these observations, we can now simplify the sphere-intersection code to th
 An Abstraction for Hittable Objects
 ------------------------------------
 Now, how about several spheres? While it is tempting to have an array of spheres, a very clean
-solution is the make an “abstract class” for anything a ray might hit, and make both a sphere and a
+solution is to make an “abstract class” for anything a ray might hit, and make both a sphere and a
 list of spheres just something you can hit. What that class should be called is something of a
 quandary -- calling it an “object” would be good if not for “object oriented” programming. “Surface”
 is often used, with the weakness being maybe we will want volumes. “hittable” emphasizes the member


### PR DESCRIPTION
Fix a typo:
* From: "a very clean solution is **the** make an “abstract class”" 
* To: "a very clean solution is **to** make an “abstract class”".