### PR TITLE
Fix bug in `rotate_y` class

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -2889,7 +2889,7 @@ For a y-rotation class we have:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class rotate_y : public hittable {
       public:
-        rotate_y(shared_ptr<hittable> p, double angle) {
+        rotate_y(shared_ptr<hittable> p, double angle) : ptr(p) {
             auto radians = degrees_to_radians(angle);
             sin_theta = sin(radians);
             cos_theta = cos(radians);

--- a/src/TheNextWeek/hittable.h
+++ b/src/TheNextWeek/hittable.h
@@ -77,7 +77,7 @@ class translate : public hittable {
 
 class rotate_y : public hittable {
   public:
-    rotate_y(shared_ptr<hittable> p, double angle) {
+    rotate_y(shared_ptr<hittable> p, double angle) : ptr(p) {
         auto radians = degrees_to_radians(angle);
         sin_theta = sin(radians);
         cos_theta = cos(radians);

--- a/src/TheRestOfYourLife/hittable.h
+++ b/src/TheRestOfYourLife/hittable.h
@@ -106,7 +106,7 @@ class translate : public hittable {
 
 class rotate_y : public hittable {
   public:
-    rotate_y(shared_ptr<hittable> p, double angle) {
+    rotate_y(shared_ptr<hittable> p, double angle) : ptr(p) {
         auto radians = degrees_to_radians(angle);
         sin_theta = sin(radians);
         cos_theta = cos(radians);


### PR DESCRIPTION
When moving method definitions into all classes, I dropped a member
initialization for the `rotate_y` constructor.