### PR TITLE
Time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Change Log -- Ray Tracing in One Weekend
   - Change: Rearranged the texture-mapping presentation. The three types (solid, spatial, image) are
     now sequenced in that order, and the checker texture presented more explicitly as an
     illustration of a spatial texture.
+  - Change: Broad rewrite of time management for moving objects, primarily `camera` and
+    `moving_sphere`, but also impacting the API for `hittable::bounding_box()` (#799)
 
 ### The Rest of Your Life
 

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -39,28 +39,27 @@ at the end of this book.
 
 Motion Blur
 ====================================================================================================
-When you decided to ray trace, you decided that visual quality was worth more than run-time. In your
-fuzzy reflection and defocus blur you needed multiple samples per pixel. Once you have taken a step
-down that road, the good news is that almost all effects can be brute-forced. Motion blur is
-certainly one of those. In a real camera, the shutter opens and stays open for a time interval, and
-the camera and objects may move during that time. Its really an average of what the camera sees over
-that interval that we want.
+When you decided to ray trace, you decided that visual quality was worth more than run-time. When
+rendering fuzzy reflection and defocus blur, we used multiple samples per pixel. Once you have taken
+a step down that road, the good news is that almost _all_ effects can be similarly brute-forced.
+Motion blur is certainly one of those.
+
+In a real camera, the shutter remains open for a short time interval, during which the camera and
+objects in the world may move. To accurately reproduce such a camera shot, we seek an average of
+all the instant images that the camera perceives while its shutter is open to the world.
 
 
 Introduction of SpaceTime Ray Tracing
 --------------------------------------
-We can get a random estimate by sending each ray at some random time when the shutter is open. As
-long as the objects are where they should be at that time, we can get the right average answer with
-a ray that is at exactly a single time. This is fundamentally why random ray tracing tends to be
-simple.
-
-The basic idea is to generate rays at random times while the shutter is open and intersect the model
-at that one time. The way it is usually done is to have the camera move and the objects move, but
-have each ray exist at exactly one time. This way the “engine” of the ray tracer can just make sure
-the objects are where they need to be for the ray, and the intersection guts don’t change much.
+We can get a random estimate of a single photon by sending a single ray at some random instant in
+time when the shutter is open. As long as the objects are where they should be at that instant, we
+can get an accurate measure of the light for that ray at that same instant. This is yet another
+example of how random (Monte Carlo) ray tracing ends up being quite simple. Brute force wins again!
 
 <div class='together'>
-For this we will first need to have a ray store the time it exists at:
+Since the “engine” of the ray tracer can just make sure the objects are where they need to be for
+each ray, the intersection guts don’t change much. To accomplish this, we need to store the exact
+time for each ray:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class ray {
@@ -82,7 +81,7 @@ For this we will first need to have a ray store the time it exists at:
             return orig + t*dir;
         }
 
-      public:
+      private:
         point3 orig;
         vec3 dir;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -94,10 +93,35 @@ For this we will first need to have a ray store the time it exists at:
 </div>
 
 
+Managing Time
+--------------
+Before continuing, let's think about time, and how we might manage it across one or more renders.
+There are two aspects of shutter timing to think about: the time from one shutter opening to the
+next shutter opening, and how long the shutter stays open for each frame. Standard movie film used
+to be shot at 24 frames per second. Modern digital films can be 30 or even 60 frames per second.
+Each frame can have its own shutter speed, which need not be -- and typically isn't -- the maximum
+duration of the entire shutter period. You could have the shutter open for 1/1000th of a second per
+frame, or 1/60th of a second. It may surprise you to learn that for most film motion pictures, the
+screen is actually dark more than it is lit up with the movie frames!
+
+If you wanted to render a sequence of images, you would need to set up the camera with the
+appropriate shutter timings: frame-to-frame period, shutter/render duration, and the total number of
+frames (or total shot time). If the camera is moving and the world is static, you're good to go.
+However, if anything in the world is moving, you would need to add a method to `hittable` to
+broadcast the current shot timing to every object in the world. This method would then provide a way
+for all animate objects to set up their motion during that frame.
+
+This is fairly straight-forward, and definitely a fun avenue for you to experiment with if you wish.
+However, for our purposes right now, we're going to proceed with a drastically simplified model. We
+will be render only a single frame, assuming a start at time = 0 and ending at time = 1. Our first
+task is to modify the camera to launch rays with random times in $[0,1]$, and our second task will
+be the creation of an animate sphere class.
+
+
 Updating the Camera to Simulate Motion Blur
 --------------------------------------------
-Now we need to modify the camera to generate rays at a random time between the start time and the
-end time. Should the camera keep track of the time interval, or should that be up to the user of
+We need to modify the camera to generate rays at a random instant between the start time and the end
+time. Should the camera keep track of the time interval, or should that be up to the user of the
 camera when a ray is created? When in doubt, I like to make constructors complicated if it makes
 calls simple, so I will make the camera keep track, but that’s a personal preference. Not many
 changes are needed to camera because for now it is not allowed to move; it just sends out rays over
@@ -130,9 +154,9 @@ a time period.
 
 Adding Moving Spheres
 ----------------------
-We also need a moving object. I’ll create a sphere class that has its center move linearly from
-`center0` at `time_start` to `center1` at `time_end`. Outside that time interval it continues on, so
-those times need not match up with the camera aperture open and close.
+Now to create a moving object. I’ll create a sphere class that has its center move linearly from
+`center0` at time 0 to `center1` at time 1. (It continues on outside that time interval, so it
+really can be sampled at any time.)
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #ifndef MOVING_SPHERE_H
@@ -147,17 +171,10 @@ those times need not match up with the camera aperture open and close.
         moving_sphere() {}
         moving_sphere(point3 c0, point3 c1, double r, shared_ptr<material> m)
           : center0(c0), center1(c1), center_vec(c1 - c0), radius(r), mat_ptr(m)
-        {
-            // To Be Implemented
-        };
+        { };
 
         bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
-            // To Be Implemented
-        }
-
-        bool bounding_box(aabb& output_box) const override {
-            output_box = bbox;
-            return true;
+            // Implementation below.
         }
 
         point3 center(double time) const {
@@ -171,7 +188,6 @@ those times need not match up with the camera aperture open and close.
         vec3 center_vec;
         double radius;
         shared_ptr<material> mat_ptr;
-        aabb bbox;
     };
 
     #endif
@@ -226,7 +242,7 @@ just needs to become a function `center(time)`:
     [Listing [moving-sphere-hit]: <kbd>[moving_sphere.h]</kbd> Moving sphere hit function]
 </div>
 
-We need to implement the `interval::contains()` method mentioned above:
+We need to implement the new `interval::contains()` method mentioned above:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class interval {
@@ -305,9 +321,8 @@ Putting Everything Together
 ----------------------------
 <div class='together'>
 The code below takes the example diffuse spheres from the scene at the end of the last book, and
-makes them move during the image render. (Think of a camera with shutter opening at time 0 and
-closing at time 1.) Each sphere moves from its center $\mathbf{C}$ at time $t=0$ to $\mathbf{C} +
-(0, r/2, 0)$ at time $t=1$, where $r$ is a random number in $[0,1)$:
+makes them move during the image render. Each sphere moves from its center $\mathbf{C}$ at time
+$t=0$ to $\mathbf{C} + (0, r/2, 0)$ at time $t=1$:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     ...
@@ -725,7 +740,8 @@ For a sphere, that `bounding_box` function is easy:
 </div>
 
 <div class='together'>
-For `moving sphere`, we can take the box of the sphere at $t_0$, and the box of the sphere at $t_1$,
+For `moving sphere`, we want the bounds of all places the moving sphere could occupy while it moves.
+To do this, we can take the box of the sphere at time = 0, and the box of the sphere at time = 1,
 and compute the box of those two boxes. We'll add a new `aabb` constructor that takes two boxes as
 input below.
 
@@ -739,6 +755,7 @@ input below.
     class moving_sphere : public hittable {
       public:
         ...
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         moving_sphere(point3 c0, point3 c1, double r, shared_ptr<material> m)
           : center0(c0), center1(c1), center_vec(c1 - c0), radius(r), mat_ptr(m)
         {
@@ -747,8 +764,10 @@ input below.
             const aabb box1(center1 - rvec, center1 + rvec);
             bbox = aabb(box0, box1);
         };
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         ...
+
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         bool bounding_box(aabb& output_box) const override {
@@ -756,7 +775,17 @@ input below.
             return true;
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
         ...
+
+      public:
+        point3 center0, center1;
+        vec3 center_vec;
+        double radius;
+        shared_ptr<material> mat_ptr;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+        aabb bbox;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [moving-sphere-bbox]: <kbd>[moving_sphere.h]</kbd> Moving sphere with bounding box]
@@ -1241,8 +1270,6 @@ Here's the scene construction function:
 
         scene_desc.cam.vup = vec3(0,1,0);
         scene_desc.cam.focus_dist = 10.0;
-        scene_desc.cam.time_start = 0;
-        scene_desc.cam.time_end = 1;
 
         switch (0) {
             case 1:  random_spheres(scene_desc); break;
@@ -2350,8 +2377,6 @@ the new `emitted` value.
 
         scene_desc.cam.vup = vec3(0,1,0);
         scene_desc.cam.focus_dist = 10.0;
-        scene_desc.cam.time_start = 0;
-        scene_desc.cam.time_end = 1;
 
         ...
     }
@@ -3275,7 +3300,7 @@ why we get caustics and subsurface for free. It’s a double-edged design decisi
         auto center1 = point3(400, 400, 200);
         auto center2 = center1 + vec3(30,0,0);
         auto moving_sphere_material = make_shared<lambertian>(color(0.7, 0.3, 0.1));
-        world.add(make_shared<moving_sphere>(center1, center2, 50, moving_sphere_material, 0, 1));
+        world.add(make_shared<moving_sphere>(center1, center2, 50, moving_sphere_material));
 
         world.add(make_shared<sphere>(point3(260, 150, 45), 50, make_shared<dielectric>(1.5)));
         world.add(make_shared<sphere>(

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -106,64 +106,22 @@ a time period.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class camera {
       public:
-        camera(
-        void initialize(double aspect_ratio = 1.0) {
-            auto theta = degrees_to_radians(vfov);
-            auto h = tan(theta/2);
-            auto viewport_height = 2.0 * h;
-            auto viewport_width = aspect_ratio * viewport_height;
-
-            w = unit_vector(lookfrom - lookat);
-            u = unit_vector(cross(vup, w));
-            v = cross(w, u);
-
-            origin = lookfrom;
-            horizontal = focus_dist * viewport_width * u;
-            vertical = focus_dist * viewport_height * v;
-            lower_left_corner = origin - horizontal/2 - vertical/2 - focus_dist*w;
-
-            lens_radius = aperture / 2;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-            time0 = time_start;
-            time1 = time_end;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-        }
-
+        ...
         ray get_ray(double s, double t) const {
             vec3 rd = lens_radius * random_in_unit_disk();
             vec3 offset = u * rd.x() + v * rd.y();
+            const auto ray_time = random_double(0.0, 1.0);
 
             return ray(
                 origin + offset,
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 lower_left_corner + s*horizontal + t*vertical - origin - offset,
-                random_double(time0, time1)
+                ray_time
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             );
         }
 
-      public:
-        double vfov       = 40;
-        double aperture   = 0;
-        double focus_dist = 10;
-
-        point3 lookfrom = point3(0,0,-1);
-        point3 lookat   = point3(0,0,0);
-        vec3   vup      = vec3(0,1,0);
-
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        double time_start = 0;
-        double time_end = 1;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-
-      private:
-        point3 origin;
-        point3 lower_left_corner;
-        vec3 horizontal;
-        vec3 vertical;
-        vec3 u, v, w;
-        double lens_radius;
+        ...
     };
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -187,27 +145,33 @@ those times need not match up with the camera aperture open and close.
     class moving_sphere : public hittable {
       public:
         moving_sphere() {}
-        moving_sphere(
-            point3 ctr0, point3 ctr1, double r, shared_ptr<material> m,
-            double time_start, double time_end)
-            :
-            center0(ctr0), center1(ctr1), radius(r), mat_ptr(m),
-            time0(time_start), time1(time_end)
-        {};
+        moving_sphere(point3 c0, point3 c1, double r, shared_ptr<material> m)
+          : center0(c0), center1(c1), center_vec(c1 - c0), radius(r), mat_ptr(m)
+        {
+            // To Be Implemented
+        };
 
         bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
             // To Be Implemented
         }
 
+        bool bounding_box(aabb& output_box) const override {
+            output_box = bbox;
+            return true;
+        }
+
         point3 center(double time) const {
-            return center0 + ((time - time0) / (time1 - time0))*(center1 - center0);
+            // Linearly interpolate from center0 to center1 according to time, where t=0 yields
+            // center0, and t=1 yields center1.
+            return center0 + time * center_vec;
         }
 
       public:
         point3 center0, center1;
-        double time0, time1;
+        vec3 center_vec;
         double radius;
         shared_ptr<material> mat_ptr;
+        aabb bbox;
     };
 
     #endif
@@ -388,7 +352,7 @@ closing at time 1.) Each sphere moves from its center $\mathbf{C}$ at time $t=0$
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                         auto center2 = center + vec3(0, random_double(0,.5), 0);
                         world.add(make_shared<moving_sphere>(
-                            center, center2, 0.2, sphere_material, 0.0, 1.0));
+                            center, center2, 0.2, sphere_material));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                     } else if (choose_mat < 0.95) {
                     ...
@@ -716,7 +680,7 @@ the entire time interval [`time0`,`time1`].
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
+        virtual bool bounding_box(aabb& output_box)
             const = 0;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         ...
@@ -732,15 +696,29 @@ For a sphere, that `bounding_box` function is easy:
     class sphere : public hittable {
       public:
         ...
+        sphere() {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
-            output_box = aabb(
-                center - vec3(radius, radius, radius),
-                center + vec3(radius, radius, radius));
+        sphere(point3 ctr, double r, shared_ptr<material> m) : center(ctr), radius(r), mat_ptr(m) {
+            const auto rvec = vec3(radius, radius, radius);
+            bbox = aabb(center - rvec, center + rvec);
+        };
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    ...
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+        bool bounding_box(aabb& output_box) const override {
+            output_box = bbox;
             return true;
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         ...
+
+      public:
+        point3 center;
+        double radius;
+        shared_ptr<material> mat_ptr;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+        aabb bbox;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [sphere-bbox]: <kbd>[sphere.h]</kbd> Sphere with bounding box]
@@ -761,18 +739,20 @@ input below.
     class moving_sphere : public hittable {
       public:
         ...
-        bool hit(const ray& r, interval ray_t, hit_record& rec) const override;
+        moving_sphere(point3 c0, point3 c1, double r, shared_ptr<material> m)
+          : center0(c0), center1(c1), center_vec(c1 - c0), radius(r), mat_ptr(m)
+        {
+            const auto rvec = vec3(radius, radius, radius);
+            const aabb box0(center0 - rvec, center0 + rvec);
+            const aabb box1(center1 - rvec, center1 + rvec);
+            bbox = aabb(box0, box1);
+        };
 
+        ...
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
-            aabb box0(
-                center(time_start) - vec3(radius, radius, radius),
-                center(time_start) + vec3(radius, radius, radius));
-            aabb box1(
-                center(time_end) - vec3(radius, radius, radius),
-                center(time_end) + vec3(radius, radius, radius));
-            output_box = aabb(box0, box1);
+        bool bounding_box(aabb& output_box) const override {
+            output_box = bbox;
             return true;
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -800,14 +780,14 @@ the fly because it is only usually called at BVH construction.
       public:
         ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+        bool bounding_box(aabb& output_box) const override {
             if (objects.empty()) return false;
 
             aabb temp_box;
             bool first_box = true;
 
             for (const auto& object : objects) {
-                if (!object->bounding_box(time_start, time_end, temp_box)) return false;
+                if (!object->bounding_box(temp_box)) return false;
                 output_box = first_box ? temp_box : aabb(output_box, temp_box);
                 first_box = false;
             }
@@ -865,14 +845,9 @@ I am a fan of the one class design when feasible. Here is such a class:
       public:
         bvh_node();
 
-        bvh_node(const hittable_list& list, double time_start, double time_end)
-          : bvh_node(list.objects, 0, list.objects.size(), time_start, time_end)
-        {}
+        bvh_node(const hittable_list& list) : bvh_node(list.objects, 0, list.objects.size()) {}
 
-        bvh_node(
-            const std::vector<shared_ptr<hittable>>& src_objects,
-            size_t start, size_t end, double time_start, double time_end
-        ) {
+        bvh_node(const std::vector<shared_ptr<hittable>>& src_objects, size_t start, size_t end) {
             // To be implemented later.
         }
 
@@ -886,7 +861,7 @@ I am a fan of the one class design when feasible. Here is such a class:
             return hit_left || hit_right;
         }
 
-        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+        bool bounding_box(aabb& output_box) const override {
             output_box = box;
             return true;
         }
@@ -933,10 +908,7 @@ we haven't yet defined.
     class bvh_node : public hittable {
       public:
         ...
-        bvh_node(
-            std::vector<shared_ptr<hittable>>& src_objects,
-            size_t start, size_t end, double time_start, double time_end
-        ) {
+        bvh_node(std::vector<shared_ptr<hittable>>& src_objects, size_t start, size_t end) {
             auto objects = src_objects; // Create a modifiable array of the source scene objects
 
             int axis = random_int(0,2);
@@ -960,15 +932,13 @@ we haven't yet defined.
                 std::sort(objects.begin() + start, objects.begin() + end, comparator);
 
                 auto mid = start + object_span/2;
-                left = make_shared<bvh_node>(objects, start, mid, time_start, time_end);
-                right = make_shared<bvh_node>(objects, mid, end, time_start, time_end);
+                left = make_shared<bvh_node>(objects, start, mid);
+                right = make_shared<bvh_node>(objects, mid, end);
             }
 
             aabb box_left, box_right;
 
-            if (  !left->bounding_box (time_start, time_end, box_left)
-               || !right->bounding_box(time_start, time_end, box_right)
-            )
+            if (!left->bounding_box(box_left) || !right->bounding_box(box_right))
                 std::cerr << "No bounding box in bvh_node constructor.\n";
 
             box = aabb(box_left, box_right);
@@ -1014,7 +984,7 @@ function.
             aabb box_a;
             aabb box_b;
 
-            if (!a->bounding_box(0,0, box_a) || !b->bounding_box(0,0, box_b))
+            if (!a->bounding_box(box_a) || !b->bounding_box(box_b))
                 std::cerr << "No bounding box in bvh_node constructor.\n";
 
             return box_a.axis(axis_index).min < box_b.axis(axis_index).min;
@@ -1035,6 +1005,32 @@ function.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [bvh-x-comp]: <kbd>[bvh.h]</kbd> BVH comparison function, X-axis]
 </div>
+
+At this point, we're ready to use our new BVH code. Let's use it on our `random_spheres()` scene.
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    ...
+
+    void random_spheres(scene& scene_desc) {
+        scene_desc.aspect_ratio      = 16.0 / 9.0;
+        scene_desc.image_width       = 400;
+        scene_desc.samples_per_pixel = 100;
+
+        ...
+
+        auto material2 = make_shared<lambertian>(color(0.4, 0.2, 0.1));
+        world.add(make_shared<sphere>(point3(-4, 1, 0), 1.0, material2));
+
+        auto material3 = make_shared<metal>(color(0.7, 0.6, 0.5), 0.0);
+        world.add(make_shared<sphere>(point3(4, 1, 0), 1.0, material3));
+
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+        scene_desc.world = hittable_list(make_shared<bvh_node>(world));
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    [Listing [random-spheres-bvh]: <kbd>[main.cc]</kbd> Random spheres, using BVH]
 
 
 
@@ -2443,7 +2439,7 @@ The actual `xy_rect` class is thus:
             return true;
         }
 
-        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+        bool bounding_box(aabb& output_box) const override {
             // The bounding box must have non-zero width in each dimension, so pad the Z
             // dimension a small amount.
             output_box = aabb(point3(x0, y0, k-0.0001), point3(x1, y1, k+0.0001));
@@ -2566,7 +2562,7 @@ This is xz and yz:
             return true;
         }
 
-        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+        bool bounding_box(aabb& output_box) const override {
             // The bounding box must have non-zero width in each dimension, so pad the Y
             // dimension a small amount.
             output_box = aabb(point3(x0, k-0.0001, z0), point3(x1, k+0.0001, z1));
@@ -2603,7 +2599,7 @@ This is xz and yz:
             return true;
         }
 
-        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+        bool bounding_box(aabb& output_box) const override {
             // The bounding box must have non-zero width in each dimension, so pad the X
             // dimension a small amount.
             output_box = aabb(point3(k-0.0001, y0, z0), point3(k+0.0001, y1, z1));
@@ -2717,7 +2713,7 @@ make an axis-aligned block primitive that holds 6 rectangles:
             return sides.hit(r, ray_t, rec);
         }
 
-        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+        bool bounding_box(aabb& output_box) const override {
             output_box = aabb(box_min, box_max);
             return true;
         }
@@ -2789,12 +2785,11 @@ move any underlying hittable is a _translate_ instance.
             return true;
         }
 
-        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
-            if (!ptr->bounding_box(time_start, time_end, output_box))
+        bool bounding_box(aabb& output_box) const override {
+            if (!ptr->bounding_box(output_box))
                 return false;
 
             output_box += offset;
-
             return true;
         }
 
@@ -2893,7 +2888,7 @@ For a y-rotation class we have:
             auto radians = degrees_to_radians(angle);
             sin_theta = sin(radians);
             cos_theta = cos(radians);
-            hasbox = ptr->bounding_box(0, 1, bbox);
+            hasbox = ptr->bounding_box(bbox);
 
             point3 min( infinity,  infinity,  infinity);
             point3 max(-infinity, -infinity, -infinity);
@@ -2951,7 +2946,7 @@ For a y-rotation class we have:
             return true;
         }
 
-        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+        bool bounding_box(aabb& output_box) const override {
             output_box = bbox;
             return hasbox;
         }
@@ -3100,8 +3095,8 @@ density $C$ and the boundary. I’ll use another hittable for the boundary. The 
             return true;
         }
 
-        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
-            return boundary->bounding_box(time_start, time_end, output_box);
+        bool bounding_box(aabb& output_box) const override {
+            return boundary->bounding_box(output_box);
         }
 
       public:
@@ -3272,7 +3267,7 @@ why we get caustics and subsurface for free. It’s a double-edged design decisi
 
         hittable_list& world = scene_desc.world;
 
-        world.add(make_shared<bvh_node>(boxes1, 0, 1));
+        world.add(make_shared<bvh_node>(boxes1));
 
         auto light = make_shared<diffuse_light>(color(7, 7, 7));
         world.add(make_shared<xz_rect>(123, 423, 147, 412, 554, light));
@@ -3307,7 +3302,7 @@ why we get caustics and subsurface for free. It’s a double-edged design decisi
 
         world.add(make_shared<translate>(
             make_shared<rotate_y>(
-                make_shared<bvh_node>(boxes2, 0.0, 1.0), 15),
+                make_shared<bvh_node>(boxes2), 15),
                 vec3(-100,270,395)
             )
         );

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -2351,8 +2351,8 @@ We also need to flip the light so its normals point in the $-y$ direction:
             return true;
         }
 
-        bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
-            return ptr->bounding_box(time_start, time_end, output_box);
+        bool bounding_box(aabb& output_box) const override {
+            return ptr->bounding_box(output_box);
         }
 
       public:
@@ -2558,8 +2558,7 @@ functions through to subclasses if you want a purely abstract `hittable` interfa
       public:
         virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const = 0;
 
-        virtual bool bounding_box(double time_start, double time_end, aabb& output_box)
-            const = 0;
+        virtual bool bounding_box(aabb& output_box) const = 0;
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight

--- a/src/TheNextWeek/aarect.h
+++ b/src/TheNextWeek/aarect.h
@@ -44,7 +44,7 @@ class xy_rect : public hittable {
         return true;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+    bool bounding_box(aabb& output_box) const override {
         // The bounding box must have non-zero width in each dimension, so pad the Z
         // dimension a small amount.
         output_box = aabb(point3(x0, y0, k-0.0001), point3(x1, y1, k+0.0001));
@@ -85,7 +85,7 @@ class xz_rect : public hittable {
         return true;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+    bool bounding_box(aabb& output_box) const override {
         // The bounding box must have non-zero width in each dimension, so pad the Y
         // dimension a small amount.
         output_box = aabb(point3(x0, k-0.0001, z0), point3(x1, k+0.0001, z1));
@@ -126,7 +126,7 @@ class yz_rect : public hittable {
         return true;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+    bool bounding_box(aabb& output_box) const override {
         // The bounding box must have non-zero width in each dimension, so pad the X
         // dimension a small amount.
         output_box = aabb(point3(k-0.0001, y0, z0), point3(k+0.0001, y1, z1));

--- a/src/TheNextWeek/box.h
+++ b/src/TheNextWeek/box.h
@@ -39,7 +39,7 @@ class box : public hittable {
         return sides.hit(r, ray_t, rec);
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+    bool bounding_box(aabb& output_box) const override {
         output_box = aabb(box_min, box_max);
         return true;
     }

--- a/src/TheNextWeek/constant_medium.h
+++ b/src/TheNextWeek/constant_medium.h
@@ -75,8 +75,8 @@ class constant_medium : public hittable {
         return true;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
-        return boundary->bounding_box(time_start, time_end, output_box);
+    bool bounding_box(aabb& output_box) const override {
+        return boundary->bounding_box(output_box);
     }
 
   public:

--- a/src/TheNextWeek/hittable.h
+++ b/src/TheNextWeek/hittable.h
@@ -40,7 +40,7 @@ class hittable {
   public:
     virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const = 0;
 
-    virtual bool bounding_box(double time_start, double time_end, aabb& output_box) const = 0;
+    virtual bool bounding_box(aabb& output_box) const = 0;
 };
 
 
@@ -60,12 +60,11 @@ class translate : public hittable {
         return true;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
-        if (!ptr->bounding_box(time_start, time_end, output_box))
+    bool bounding_box(aabb& output_box) const override {
+        if (!ptr->bounding_box(output_box))
             return false;
 
         output_box += offset;
-
         return true;
     }
 
@@ -81,7 +80,7 @@ class rotate_y : public hittable {
         auto radians = degrees_to_radians(angle);
         sin_theta = sin(radians);
         cos_theta = cos(radians);
-        hasbox = ptr->bounding_box(0, 1, bbox);
+        hasbox = ptr->bounding_box(bbox);
 
         point3 min( infinity,  infinity,  infinity);
         point3 max(-infinity, -infinity, -infinity);
@@ -139,7 +138,7 @@ class rotate_y : public hittable {
         return true;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+    bool bounding_box(aabb& output_box) const override {
         output_box = bbox;
         return hasbox;
     }

--- a/src/TheNextWeek/hittable_list.h
+++ b/src/TheNextWeek/hittable_list.h
@@ -44,14 +44,14 @@ class hittable_list : public hittable {
         return hit_anything;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+    bool bounding_box(aabb& output_box) const override {
         if (objects.empty()) return false;
 
         aabb temp_box;
         bool first_box = true;
 
         for (const auto& object : objects) {
-            if (!object->bounding_box(time_start, time_end, temp_box)) return false;
+            if (!object->bounding_box(temp_box)) return false;
             output_box = first_box ? temp_box : aabb(output_box, temp_box);
             first_box = false;
         }

--- a/src/TheNextWeek/main.cc
+++ b/src/TheNextWeek/main.cc
@@ -36,9 +36,6 @@ void random_spheres(scene& scene_desc) {
     scene_desc.cam.aperture   = 0.1;
     scene_desc.cam.focus_dist = 10.0;
 
-    scene_desc.cam.time_start = 0.0;
-    scene_desc.cam.time_end   = 1.0;
-
     hittable_list& world = scene_desc.world;
 
     auto checker = make_shared<checker_texture>(0.32, color(.2, .3, .1), color(.9, .9, .9));
@@ -58,7 +55,7 @@ void random_spheres(scene& scene_desc) {
                     sphere_material = make_shared<lambertian>(albedo);
                     auto center2 = center + vec3(0, random_double(0,.5), 0);
                     world.add(make_shared<moving_sphere>(
-                        center, center2, 0.2, sphere_material, 0.0, 1.0));
+                        center, center2, 0.2, sphere_material));
                 } else if (choose_mat < 0.95) {
                     // metal
                     auto albedo = color::random(0.5, 1);
@@ -83,7 +80,7 @@ void random_spheres(scene& scene_desc) {
     auto material3 = make_shared<metal>(color(0.7, 0.6, 0.5), 0.0);
     world.add(make_shared<sphere>(point3(4, 1, 0), 1.0, material3));
 
-    scene_desc.world = hittable_list(make_shared<bvh_node>(world, 0.0, 1.0));
+    scene_desc.world = hittable_list(make_shared<bvh_node>(world));
 }
 
 
@@ -271,7 +268,7 @@ void final_scene(scene& scene_desc) {
 
     hittable_list& world = scene_desc.world;
 
-    world.add(make_shared<bvh_node>(boxes1, 0, 1));
+    world.add(make_shared<bvh_node>(boxes1));
 
     auto light = make_shared<diffuse_light>(color(7, 7, 7));
     world.add(make_shared<xz_rect>(123, 423, 147, 412, 554, light));
@@ -279,7 +276,7 @@ void final_scene(scene& scene_desc) {
     auto center1 = point3(400, 400, 200);
     auto center2 = center1 + vec3(30,0,0);
     auto moving_sphere_material = make_shared<lambertian>(color(0.7, 0.3, 0.1));
-    world.add(make_shared<moving_sphere>(center1, center2, 50, moving_sphere_material, 0, 1));
+    world.add(make_shared<moving_sphere>(center1, center2, 50, moving_sphere_material));
 
     world.add(make_shared<sphere>(point3(260, 150, 45), 50, make_shared<dielectric>(1.5)));
     world.add(make_shared<sphere>(
@@ -306,7 +303,7 @@ void final_scene(scene& scene_desc) {
 
     world.add(make_shared<translate>(
         make_shared<rotate_y>(
-            make_shared<bvh_node>(boxes2, 0.0, 1.0), 15),
+            make_shared<bvh_node>(boxes2), 15),
             vec3(-100,270,395)
         )
     );
@@ -325,11 +322,8 @@ int main() {
     scene scene_desc;
 
     scene_desc.background = color(0.70, 0.80, 1.00);
-
     scene_desc.cam.vup = vec3(0,1,0);
     scene_desc.cam.focus_dist = 10.0;
-    scene_desc.cam.time_start = 0;
-    scene_desc.cam.time_end = 1;
 
     switch (0) {
         case 1:  random_spheres(scene_desc);     break;

--- a/src/TheNextWeek/moving_sphere.h
+++ b/src/TheNextWeek/moving_sphere.h
@@ -19,11 +19,14 @@
 class moving_sphere : public hittable {
   public:
     moving_sphere() {}
-    moving_sphere(
-        point3 ctr0, point3 ctr1, double r, shared_ptr<material> m,
-        double time_start, double time_end)
-      : center0(ctr0), center1(ctr1), radius(r), mat_ptr(m), time0(time_start), time1(time_end)
-    {};
+    moving_sphere(point3 c0, point3 c1, double r, shared_ptr<material> m)
+      : center0(c0), center1(c1), center_vec(c1 - c0), radius(r), mat_ptr(m)
+    {
+        const auto rvec = vec3(radius, radius, radius);
+        const aabb box0(center0 - rvec, center0 + rvec);
+        const aabb box1(center1 - rvec, center1 + rvec);
+        bounds = aabb(box0, box1);
+    };
 
     bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
         vec3 oc = r.origin() - center(r.time());
@@ -52,26 +55,23 @@ class moving_sphere : public hittable {
         return true;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
-        aabb box0(
-            center(time_start) - vec3(radius, radius, radius),
-            center(time_start) + vec3(radius, radius, radius));
-        aabb box1(
-            center(time_end) - vec3(radius, radius, radius),
-            center(time_end) + vec3(radius, radius, radius));
-        output_box = aabb(box0, box1);
+    bool bounding_box(aabb& output_box) const override {
+        output_box = bounds;
         return true;
     }
 
     point3 center(double time) const {
-        return center0 + ((time - time0) / (time1 - time0))*(center1 - center0);
+        // Linearly interpolate from center0 to center1 according to time, where t=0 yields
+        // center0, and t=1 yields center1.
+        return center0 + time * center_vec;
     }
 
   public:
     point3 center0, center1;
-    double time0, time1;
+    vec3 center_vec;
     double radius;
     shared_ptr<material> mat_ptr;
+    aabb bounds;
 };
 
 

--- a/src/TheNextWeek/moving_sphere.h
+++ b/src/TheNextWeek/moving_sphere.h
@@ -25,7 +25,7 @@ class moving_sphere : public hittable {
         const auto rvec = vec3(radius, radius, radius);
         const aabb box0(center0 - rvec, center0 + rvec);
         const aabb box1(center1 - rvec, center1 + rvec);
-        bounds = aabb(box0, box1);
+        bbox = aabb(box0, box1);
     };
 
     bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
@@ -56,7 +56,7 @@ class moving_sphere : public hittable {
     }
 
     bool bounding_box(aabb& output_box) const override {
-        output_box = bounds;
+        output_box = bbox;
         return true;
     }
 
@@ -71,7 +71,7 @@ class moving_sphere : public hittable {
     vec3 center_vec;
     double radius;
     shared_ptr<material> mat_ptr;
-    aabb bounds;
+    aabb bbox;
 };
 
 

--- a/src/TheNextWeek/sphere.h
+++ b/src/TheNextWeek/sphere.h
@@ -19,8 +19,10 @@
 class sphere : public hittable {
   public:
     sphere() {}
-    sphere(point3 ctr, double r, shared_ptr<material> m)
-      : center(ctr), radius(r), mat_ptr(m) {};
+    sphere(point3 ctr, double r, shared_ptr<material> m) : center(ctr), radius(r), mat_ptr(m) {
+        const auto rvec = vec3(radius, radius, radius);
+        bbox = aabb(center - rvec, center + rvec);
+    };
 
     bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
         vec3 oc = r.origin() - center;
@@ -50,10 +52,8 @@ class sphere : public hittable {
         return true;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
-        output_box = aabb(
-            center - vec3(radius, radius, radius),
-            center + vec3(radius, radius, radius));
+    bool bounding_box(aabb& output_box) const override {
+        output_box = bbox;
         return true;
     }
 
@@ -61,6 +61,7 @@ class sphere : public hittable {
     point3 center;
     double radius;
     shared_ptr<material> mat_ptr;
+    aabb bbox;
 
   private:
     static void get_sphere_uv(const point3& p, double& u, double& v) {

--- a/src/TheRestOfYourLife/aarect.h
+++ b/src/TheRestOfYourLife/aarect.h
@@ -44,7 +44,7 @@ class xy_rect : public hittable {
         return true;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+    bool bounding_box(aabb& output_box) const override {
         // The bounding box must have non-zero width in each dimension, so pad the Z
         // dimension a small amount.
         output_box = aabb(point3(x0, y0, k-0.0001), point3(x1, y1, k+0.0001));
@@ -85,7 +85,7 @@ class xz_rect : public hittable {
         return true;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+    bool bounding_box(aabb& output_box) const override {
         // The bounding box must have non-zero width in each dimension, so pad the Y
         // dimension a small amount.
         output_box = aabb(point3(x0, k-0.0001, z0), point3(x1, k+0.0001, z1));
@@ -143,7 +143,7 @@ class yz_rect : public hittable {
         return true;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+    bool bounding_box(aabb& output_box) const override {
         // The bounding box must have non-zero width in each dimension, so pad the X
         // dimension a small amount.
         output_box = aabb(point3(k-0.0001, y0, z0), point3(k+0.0001, y1, z1));

--- a/src/TheRestOfYourLife/box.h
+++ b/src/TheRestOfYourLife/box.h
@@ -39,7 +39,7 @@ class box : public hittable {
         return sides.hit(r, ray_t, rec);
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+    bool bounding_box(aabb& output_box) const override {
         output_box = aabb(box_min, box_max);
         return true;
     }

--- a/src/TheRestOfYourLife/bvh.h
+++ b/src/TheRestOfYourLife/bvh.h
@@ -60,9 +60,7 @@ class bvh_node : public hittable {
 
         aabb box_left, box_right;
 
-        if (  !left->bounding_box (time0, time1, box_left)
-           || !right->bounding_box(time0, time1, box_right)
-        )
+        if (!left->bounding_box(box_left) || !right->bounding_box(box_right))
             std::cerr << "No bounding box in bvh_node constructor.\n";
 
         box = surrounding_box(box_left, box_right);
@@ -78,7 +76,7 @@ class bvh_node : public hittable {
         return hit_left || hit_right;
     }
 
-    bool bounding_box(double time0, double time1, aabb& output_box) const override {
+    bool bounding_box(aabb& output_box) const override {
         output_box = box;
         return true;
     }
@@ -95,7 +93,7 @@ class bvh_node : public hittable {
         aabb box_a;
         aabb box_b;
 
-        if (!a->bounding_box(0,0, box_a) || !b->bounding_box(0,0, box_b))
+        if (!a->bounding_box(box_a) || !b->bounding_box(box_b))
             std::cerr << "No bounding box in bvh_node constructor.\n";
 
         return box_a.axis(axis_index).min < box_b.axis(axis_index).min;

--- a/src/TheRestOfYourLife/hittable.h
+++ b/src/TheRestOfYourLife/hittable.h
@@ -40,7 +40,7 @@ class hittable {
   public:
     virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const = 0;
 
-    virtual bool bounding_box(double time_start, double time_end, aabb& output_box) const = 0;
+    virtual bool bounding_box(aabb& output_box) const = 0;
 
     virtual double pdf_value(const vec3& o, const vec3& v) const {
         return 0.0;
@@ -64,8 +64,8 @@ class flip_face : public hittable {
         return true;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
-        return ptr->bounding_box(time_start, time_end, output_box);
+    bool bounding_box(aabb& output_box) const override {
+        return ptr->bounding_box(output_box);
     }
 
   public:
@@ -89,12 +89,11 @@ class translate : public hittable {
         return true;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
-        if (!ptr->bounding_box(time_start, time_end, output_box))
+    bool bounding_box(aabb& output_box) const override {
+        if (!ptr->bounding_box(output_box))
             return false;
 
         output_box += offset;
-
         return true;
     }
 
@@ -110,7 +109,7 @@ class rotate_y : public hittable {
         auto radians = degrees_to_radians(angle);
         sin_theta = sin(radians);
         cos_theta = cos(radians);
-        hasbox = ptr->bounding_box(0, 1, bbox);
+        hasbox = ptr->bounding_box(bbox);
 
         point3 min( infinity,  infinity,  infinity);
         point3 max(-infinity, -infinity, -infinity);
@@ -168,7 +167,7 @@ class rotate_y : public hittable {
         return true;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+    bool bounding_box(aabb& output_box) const override {
         output_box = bbox;
         return hasbox;
     }

--- a/src/TheRestOfYourLife/hittable_list.h
+++ b/src/TheRestOfYourLife/hittable_list.h
@@ -43,14 +43,14 @@ class hittable_list : public hittable {
         return hit_anything;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
+    bool bounding_box(aabb& output_box) const override {
         if (objects.empty()) return false;
 
         aabb temp_box;
         bool first_box = true;
 
         for (const auto& object : objects) {
-            if (!object->bounding_box(time_start, time_end, temp_box)) return false;
+            if (!object->bounding_box(temp_box)) return false;
             output_box = first_box ? temp_box : aabb(output_box, temp_box);
             first_box = false;
         }

--- a/src/TheRestOfYourLife/main.cc
+++ b/src/TheRestOfYourLife/main.cc
@@ -34,8 +34,6 @@ void cornell_box(scene& scene_desc) {
     scene_desc.cam.vfov         = 40.0;
     scene_desc.cam.aperture     = 0.0;
     scene_desc.cam.focus_dist   = 10.0;
-    scene_desc.cam.time_start   = 0.0;
-    scene_desc.cam.time_end     = 1.0;
 
     hittable_list& world = scene_desc.world;
 

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -20,8 +20,10 @@
 class sphere : public hittable {
   public:
     sphere() {}
-    sphere(point3 ctr, double r, shared_ptr<material> m)
-      : center(ctr), radius(r), mat_ptr(m) {};
+    sphere(point3 ctr, double r, shared_ptr<material> m) : center(ctr), radius(r), mat_ptr(m) {
+        const auto rvec = vec3(radius, radius, radius);
+        bbox = aabb(center - rvec, center + rvec);
+    };
 
     bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
         vec3 oc = r.origin() - center;
@@ -51,10 +53,8 @@ class sphere : public hittable {
         return true;
     }
 
-    bool bounding_box(double time_start, double time_end, aabb& output_box) const override {
-        output_box = aabb(
-            center - vec3(radius, radius, radius),
-            center + vec3(radius, radius, radius));
+    bool bounding_box(aabb& output_box) const override {
+        output_box = bbox;
         return true;
     }
 
@@ -81,6 +81,7 @@ class sphere : public hittable {
     point3 center;
     double radius;
     shared_ptr<material> mat_ptr;
+    aabb bbox;
 
   private:
     static void get_sphere_uv(const point3& p, double& u, double& v) {

--- a/src/common/camera.h
+++ b/src/common/camera.h
@@ -37,10 +37,11 @@ class camera {
     ray get_ray(double s, double t) const {
         vec3 rd = lens_radius * random_in_unit_disk();
         vec3 offset = u * rd.x() + v * rd.y();
+        const auto ray_time = random_double(0.00, 1.00);
         return ray(
             origin + offset,
             lower_left_corner + s*horizontal + t*vertical - origin - offset,
-            random_double(time_start, time_end)
+            ray_time
         );
     }
 
@@ -52,9 +53,6 @@ class camera {
     point3 lookfrom = point3(0,0,-1);
     point3 lookat   = point3(0,0,0);
     vec3   vup      = vec3(0,1,0);
-
-    double time_start = 0;
-    double time_end = 1;
 
   private:
     point3 origin;

--- a/src/common/camera.h
+++ b/src/common/camera.h
@@ -37,7 +37,8 @@ class camera {
     ray get_ray(double s, double t) const {
         vec3 rd = lens_radius * random_in_unit_disk();
         vec3 offset = u * rd.x() + v * rd.y();
-        const auto ray_time = random_double(0.00, 1.00);
+        const auto ray_time = random_double(0.0, 1.0);
+
         return ray(
             origin + offset,
             lower_left_corner + s*horizontal + t*vertical - origin - offset,


### PR DESCRIPTION
Initial draft. This updates the code, but lacks the corresponding text changes.

I believe that we can also eliminate the `bool` return from the `hittable::bounding_box()` methods, as I couldn't find a single derived that didn't (1) return true, or (2) return the logical-and of its child returns. Been wanting to fix this for a long time, as it would be much cleaner to just return the `aabb`. I'd like to introduce the concept of _empty_ or _universe_ to AABB if this is necessary, but I don't think it is.

Also note that in the text changes, I plan to comment on how one might extend time management more generally, as the original (incomplete) design attempted. Not planning on going deep; just enumerating some of the aspects that should be considered.