### PR TITLE
DRAFT: For consideration, new `quad` primitive to replace `xy_rect`, `xz_rect`, `yz_rect`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ set ( SOURCE_NEXT_WEEK
   src/TheNextWeek/hittable_list.h
   src/TheNextWeek/material.h
   src/TheNextWeek/moving_sphere.h
+  src/TheNextWeek/planar.h
   src/TheNextWeek/scene.h
   src/TheNextWeek/sphere.h
   src/TheNextWeek/main.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ set ( CMAKE_CXX_EXTENSIONS        OFF )
 set ( COMMON_ALL
   src/common/rtweekend.h
   src/common/camera.h
+  src/common/color.h
+  src/common/interval.h
   src/common/ray.h
   src/common/vec3.h
 )

--- a/src/TheNextWeek/main.cc
+++ b/src/TheNextWeek/main.cc
@@ -339,10 +339,23 @@ void planar_test(scene& scene_desc) {
 ///// triangles, ellipses, annuli and other 2D shapes as possibilities. Hmmm, I haven't yet
 ///// done stencil for giggles; think I'll do that too for my own fun.
 
-    //auto thing = make_shared<quad>(point3(-2,-2,4), vec3(4,0,0), vec3(0,4,0), mat);
-    auto thing = make_shared<ellipse>(point3(0,0,0), vec3(2,0,0), vec3(0,1,0), mat);
-    //auto thing = make_shared<annulus>(point3(0,0,0), vec3(1,0,0), vec3(0,1,0), 1.0, 2.0, mat);
-    //auto thing = make_shared<tri>(point3(-2,-2,0), vec3(4,0,0), vec3(0,4,0), mat);
+    shared_ptr<hittable> thing;
+    switch (0) {
+        default:
+        case 0:
+            thing = make_shared<quad>(point3(-2,-2,4), vec3(4,0,0), vec3(0,4,0), mat);
+            break;
+        case 1:
+            thing = make_shared<ellipse>(point3(0,0,0), vec3(2,0,0), vec3(0,1,0), mat);
+            break;
+        case 2:
+            thing =
+                make_shared<annulus>(point3(0,0,0), vec3(1,0,0), vec3(0,1,0), 1.0, 2.0, mat);
+            break;
+        case 3:
+            thing = make_shared<tri>(point3(-2,-2,0), vec3(4,0,0), vec3(0,4,0), mat);
+            break;
+    }
 
     scene_desc.world.add(thing);
 }

--- a/src/TheNextWeek/main.cc
+++ b/src/TheNextWeek/main.cc
@@ -19,6 +19,7 @@
 #include "hittable_list.h"
 #include "material.h"
 #include "moving_sphere.h"
+#include "planar.h"
 #include "scene.h"
 #include "sphere.h"
 #include "texture.h"
@@ -318,6 +319,35 @@ void default_scene(scene& scene_desc) {
 }
 
 
+void planar_test(scene& scene_desc) {
+    scene_desc.image_width       = 400;
+    scene_desc.aspect_ratio      = 1.0;
+    scene_desc.samples_per_pixel = 4;
+    scene_desc.max_depth         = 4;
+
+    scene_desc.cam.aperture = 0.0;
+    scene_desc.cam.vfov     = 20.0;
+    scene_desc.cam.lookfrom = point3(0,0,12);
+    scene_desc.cam.lookat   = point3(0,0,0);
+
+    auto earth_texture = make_shared<image_texture>("earthmap.jpg");
+    auto mat = make_shared<lambertian>(earth_texture);
+
+    //scene_desc.world.add(make_shared<sphere>(point3(0,0,0), 2, earth_surface));
+
+///// Four new primitive types below. I'm leaning toward keeping only quads, but hinting at
+///// triangles, ellipses, annuli and other 2D shapes as possibilities. Hmmm, I haven't yet
+///// done stencil for giggles; think I'll do that too for my own fun.
+
+    //auto thing = make_shared<quad>(point3(-2,-2,4), vec3(4,0,0), vec3(0,4,0), mat);
+    auto thing = make_shared<ellipse>(point3(0,0,0), vec3(2,0,0), vec3(0,1,0), mat);
+    //auto thing = make_shared<annulus>(point3(0,0,0), vec3(1,0,0), vec3(0,1,0), 1.0, 2.0, mat);
+    //auto thing = make_shared<tri>(point3(-2,-2,0), vec3(4,0,0), vec3(0,4,0), mat);
+
+    scene_desc.world.add(thing);
+}
+
+
 int main() {
     scene scene_desc;
 
@@ -335,6 +365,8 @@ int main() {
         case 7:  cornell_smoke(scene_desc);      break;
         case 8:  final_scene(scene_desc);        break;
         default: default_scene(scene_desc);      break;
+
+        case 0: planar_test(scene_desc); break;
     }
 
     scene_desc.render();

--- a/src/TheNextWeek/planar.h
+++ b/src/TheNextWeek/planar.h
@@ -1,0 +1,158 @@
+#ifndef PLANAR_H
+#define PLANAR_H
+//==============================================================================================
+// To the extent possible under law, the author(s) have dedicated all copyright and related and
+// neighboring rights to this software to the public domain worldwide. This software is
+// distributed without any warranty.
+//
+// You should have received a copy (see file COPYING.txt) of the CC0 Public Domain Dedication
+// along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//==============================================================================================
+
+#include "rtweekend.h"
+
+#include "hittable.h"
+
+#include <cmath>
+
+//// This class is somewhat complex, but that's because it serves as a base class for very
+//// simple derived classes, where you really only need to worry about construction, bounds,
+//// and UV hit determination.
+
+class planar : public hittable {
+  public:
+    planar(const point3& o, const vec3& side_A, const vec3& side_B, shared_ptr<material> m)
+      : origin(o), a(side_A), b(side_B), mat(m)
+    {
+        normal = unit_vector(cross(a, b));
+        D = -dot(normal, origin);
+        a /= dot(a,a);
+        b /= dot(b,b);
+
+/////// By default, bounded to the world coordinates of UV<0,0> to UV<1,1>.
+
+        interval u_bounds, v_bounds;
+        get_uv_bounds(u_bounds, v_bounds);
+        bbox = aabb(
+            origin + (u_bounds.min * side_A) + (v_bounds.min * side_B),
+            origin + (u_bounds.max * side_A) + (v_bounds.max * side_B)
+        );
+    }
+
+    virtual void get_uv_bounds(interval& u_bounds, interval& v_bounds) {
+        u_bounds = interval::unit;
+        v_bounds = interval::unit;
+    }
+
+    virtual bool hit_uv(double u, double v) const = 0;
+
+/// The distinction of this method is that it calls `hit_uv()` to filter on UV coordinates.
+
+    bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
+        auto denom = dot(normal, r.direction());
+        if (fabs(denom) < 1e-8) return false;
+
+        auto t = (-D - dot(normal, r.origin())) / denom;
+        if (!ray_t.contains(t))
+            return false;
+
+        auto intersection = r.at(t);
+
+        vec3 planar_hitpt_vector = intersection - origin;
+
+        auto u = dot(planar_hitpt_vector, a);
+        auto v = dot(planar_hitpt_vector, b);
+        if (!hit_uv(u,v))
+            return false;
+
+        rec.t = t;
+        rec.p = intersection;
+        rec.u = u;
+        rec.v = v;
+        rec.mat = mat;
+        rec.set_face_normal(r, normal);
+
+        return true;
+    }
+
+    aabb bounding_box() const { return bbox; }
+
+  protected:
+    point3 origin;
+    vec3 normal;
+    double D;
+    vec3 a, b;
+    shared_ptr<material> mat;
+    aabb bbox;
+};
+
+
+class quad : public planar {
+  public:
+    quad(const point3& o, const vec3& side_A, const vec3& side_B, shared_ptr<material> m)
+      : planar(o, side_A, side_B, m)
+    {}
+
+    bool hit_uv(double u, double v) const override {
+        return interval::unit.contains(u) && interval::unit.contains(v);
+    }
+};
+
+
+class tri : public planar {
+  public:
+    tri(const point3& o, const vec3& side_A, const vec3& side_B, shared_ptr<material> m)
+      : planar(o, side_A, side_B, m)
+    {}
+
+    bool hit_uv(double u, double v) const override {
+        return u > 0
+            && v > 0
+            && u + v <= 1;
+    }
+};
+
+
+class ellipse : public planar {
+  public:
+    ellipse(
+        const point3& center, const vec3& radius_A, const vec3& radius_B,
+        shared_ptr<material> m)
+      : planar(center - radius_A - radius_B, 2 * radius_A, 2 * radius_B, m)
+    { }
+
+    bool hit_uv(double u, double v) const override {
+        auto px = 2 * (u - 0.5);
+        auto py = 2 * (v - 0.5);
+        return (px*px + py*py) <= 1;
+    }
+};
+
+
+class annulus : public planar {
+  public:
+    annulus(
+        const point3& center, const vec3& side_A, const vec3& side_B,
+        double radius_inner, double radius_outer, shared_ptr<material> m)
+      : planar(
+            center - radius_outer*unit_vector(side_A) - radius_outer*unit_vector(side_B),
+            2 * radius_outer * unit_vector(side_A),
+            2 * radius_outer * unit_vector(side_B),
+            m
+        ),
+        inner(radius_inner/radius_outer)
+    {}
+
+    bool hit_uv(double u, double v) const override {
+        auto px = 2 * (u - 0.5);
+        auto py = 2 * (v - 0.5);
+        auto radius = px*px + py*py;
+        return interval(inner*inner, 1.0).contains(radius);
+    }
+
+  private:
+    double inner;
+};
+
+
+#endif

--- a/src/common/aabb.h
+++ b/src/common/aabb.h
@@ -49,9 +49,9 @@ class aabb {
 
     aabb pad() {
         const double delta = 0.0001;
-        interval& new_x = (x.size() >= delta) ? x : x.expand(delta);
-        interval& new_y = (y.size() >= delta) ? y : y.expand(delta);
-        interval& new_z = (z.size() >= delta) ? z : z.expand(delta);
+        interval new_x = (x.size() >= delta) ? x : x.expand(delta);
+        interval new_y = (y.size() >= delta) ? y : y.expand(delta);
+        interval new_z = (z.size() >= delta) ? z : z.expand(delta);
 
         return aabb(new_x, new_y, new_z);
     }

--- a/src/common/aabb.h
+++ b/src/common/aabb.h
@@ -35,6 +35,27 @@ class aabb {
         z = interval(box0.z, box1.z);
     }
 
+    const interval& axis(int n) const {
+        if (n == 1) return y;
+        if (n == 2) return z;
+        return x;
+    }
+
+/// Bounding-box padding is currently done for each derived class of `aarect`. However, padding
+/// is required for all 2D primitives, so it seems better to make such padding an option on the
+/// AABB class instead. This method is called whenever one or more dimensions might have zero
+/// thickness. In this case, I continue with a buried, hard-coded pad -- not production quality,
+/// but certainly appropriate for this project.
+
+    aabb pad() {
+        const double delta = 0.0001;
+        interval& new_x = (x.size() >= delta) ? x : x.expand(delta);
+        interval& new_y = (y.size() >= delta) ? y : y.expand(delta);
+        interval& new_z = (z.size() >= delta) ? z : z.expand(delta);
+
+        return aabb(new_x, new_y, new_z);
+    }
+
     #if 1
         // GitHub Issue #817
         // For some reason I haven't figured out yet, this version is 10x faster than the
@@ -72,12 +93,6 @@ class aabb {
             return true;
         }
     #endif
-
-    const interval& axis(int n) const {
-        if (n == 1) return y;
-        if (n == 2) return z;
-        return x;
-    }
 
   public:
     interval x, y, z;

--- a/src/common/interval.h
+++ b/src/common/interval.h
@@ -23,7 +23,7 @@ class interval {
     }
 
     interval expand(double delta) const {
-        return interval(min - delta, max + delta);
+        return interval(min - delta/2, max + delta/2);
     }
 
     bool contains(double x) const {
@@ -39,7 +39,7 @@ class interval {
 /// Toying with the idea of a global constant [0,1] interval, since it's used in multiple
 /// places. Alternate name: `interval::zero_one`.
 
-    static const interval empty, universe, unit;
+    static const interval empty, universe;
 
   public:
     double min, max;
@@ -47,7 +47,6 @@ class interval {
 
 const interval interval::empty    = interval(+infinity, -infinity);
 const interval interval::universe = interval(-infinity, +infinity);
-const interval interval::unit     = interval(0, 1);
 
 interval operator+(const interval& ival, double displacement) {
     return interval(ival.min + displacement, ival.max + displacement);

--- a/src/common/interval.h
+++ b/src/common/interval.h
@@ -18,6 +18,14 @@ class interval {
     interval(const interval& a, const interval& b)
       : min(fmin(a.min, b.min)), max(fmax(a.max, b.max)) {}
 
+    double size() const {
+        return max - min;
+    }
+
+    interval expand(double delta) const {
+        return interval(min - delta, max + delta);
+    }
+
     bool contains(double x) const {
         return min <= x && x <= max;
     }
@@ -28,7 +36,10 @@ class interval {
         return x;
     }
 
-    static const interval empty, universe;
+/// Toying with the idea of a global constant [0,1] interval, since it's used in multiple
+/// places. Alternate name: `interval::zero_one`.
+
+    static const interval empty, universe, unit;
 
   public:
     double min, max;
@@ -36,6 +47,7 @@ class interval {
 
 const interval interval::empty    = interval(+infinity, -infinity);
 const interval interval::universe = interval(-infinity, +infinity);
+const interval interval::unit     = interval(0, 1);
 
 interval operator+(const interval& ival, double displacement) {
     return interval(ival.min + displacement, ival.max + displacement);


### PR DESCRIPTION
DRAFT ONLY

Sharing my new `quad` and other planar primitives for comments. Design commentary flush left.