### PR TITLE
Lint pass: ctor initializer order + virtual dtors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Change Log -- Ray Tracing in One Weekend
   - Change: `hittable` member variable `ptr` renamed to `object`
   - Change: general rename of `mat_ptr` to `mat` (material)
   - Change: hittable::bounding_box() signature has changed to always return a value (#859)
+  - Fix: Enabled compiler warnings for MSVC, Clang, GNU. Cleaned up warnings as fit (#865)
 
 ### In One Weekend
   - Added: More commentary about the choice between `double` and `float` (#752)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ set ( CMAKE_CXX_EXTENSIONS        OFF )
 set ( COMMON_ALL
   src/common/rtweekend.h
   src/common/camera.h
+  src/common/color.h
+  src/common/interval.h
   src/common/ray.h
   src/common/vec3.h
 )
@@ -71,6 +73,18 @@ set ( SOURCE_REST_OF_YOUR_LIFE
   src/TheRestOfYourLife/main.cc
 )
 
+include_directories(src/common)
+
+# Specific Compiler Flags
+
+message (STATUS "Compiler ID: " ${CMAKE_CXX_COMPILER_ID})
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    add_compile_options("/we 4265") # Class has virtual functions, but its non-trivial destructor is not virtual
+    add_compile_options("/w3 5038") # Data member will be initialized after [other] data member
+    add_compile_options("/we 5204") # Class has virtual functions, but its trivial destructor is not virtual
+endif()
+
 # Executables
 add_executable(inOneWeekend      ${SOURCE_ONE_WEEKEND})
 add_executable(theNextWeek       ${SOURCE_NEXT_WEEK})
@@ -82,5 +96,3 @@ add_executable(pi                src/TheRestOfYourLife/pi.cc                ${CO
 add_executable(estimate_halfway  src/TheRestOfYourLife/estimate_halfway.cc  ${COMMON_ALL})
 add_executable(sphere_importance src/TheRestOfYourLife/sphere_importance.cc ${COMMON_ALL})
 add_executable(sphere_plot       src/TheRestOfYourLife/sphere_plot.cc       ${COMMON_ALL})
-
-include_directories(src/common)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,16 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     add_compile_options("/we 4265") # Class has virtual functions, but its non-trivial destructor is not virtual
     add_compile_options("/w3 5038") # Data member will be initialized after [other] data member
     add_compile_options("/we 5204") # Class has virtual functions, but its trivial destructor is not virtual
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    add_compile_options(-Wnon-virtual-dtor) # Class has virtual functions, but its destructor is not virtual
+    add_compile_options(-Wreorder) # Data member will be initialized after [other] data member
+    add_compile_options(-Wmaybe-uninitialized) # Variable improperly initialized
+    add_compile_options(-Wunused-variable) # Variable is defined but unused
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wnon-virtual-dtor) # Class has virtual functions, but its destructor is not virtual
+    add_compile_options(-Wreorder) # Data member will be initialized after [other] data member
+    add_compile_options(-Wsometimes-uninitialized) # Variable improperly initialized
+    add_compile_options(-Wunused-variable) # Variable is defined but unused
 endif()
 
 # Executables

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -867,6 +867,8 @@ the abstract class:
 
     class hittable {
       public:
+        virtual ~hittable() = default;
+
         virtual bool hit(const ray& r, double ray_tmin, double ray_tmax, hit_record& rec) const = 0;
     };
 
@@ -2033,6 +2035,8 @@ This suggests the abstract class:
 
     class material {
       public:
+        virtual ~material() = default;
+
         virtual bool scatter(
             const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered) const = 0;
     };

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -1099,6 +1099,8 @@ Constant Color Texture
 
     class texture {
       public:
+        virtual ~texture() = default;
+
         virtual color value(double u, double v, const point3& p) const = 0;
     };
 
@@ -1194,8 +1196,8 @@ pattern in the scene.
 
       public:
         double inv_scale;
-        shared_ptr<texture> odd;
         shared_ptr<texture> even;
+        shared_ptr<texture> odd;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [checker-texture]: <kbd>[texture.h]</kbd> Checkered texture]
@@ -2293,12 +2295,15 @@ class return black:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class material {
       public:
+        ...
+
+
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         virtual color emitted(double u, double v, const point3& p) const {
             return color(0,0,0);
         }
-
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
         virtual bool scatter(
             const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
         ) const = 0;
@@ -2466,8 +2471,8 @@ The actual `xy_rect` class is thus:
         aabb bounding_box() const override { return bbox; }
 
       public:
-        shared_ptr<material> mat;
         double x0, x1, y0, y1, k;
+        shared_ptr<material> mat;
         aabb bbox;
     };
 
@@ -2590,8 +2595,8 @@ This is xz and yz:
         aabb bounding_box() const override { return bbox; }
 
       public:
-        shared_ptr<material> mat;
         double x0, x1, z0, z1, k;
+        shared_ptr<material> mat;
         aabb bbox;
     };
 
@@ -2625,8 +2630,8 @@ This is xz and yz:
         aabb bounding_box() const override { return bbox; }
 
       public:
-        shared_ptr<material> mat;
         double y0, y1, z0, z1, k;
+        shared_ptr<material> mat;
         aabb bbox;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3120,8 +3125,8 @@ density $C$ and the boundary. I’ll use another hittable for the boundary. The 
 
       public:
         shared_ptr<hittable> boundary;
-        shared_ptr<material> phase_function;
         double neg_inv_density;
+        shared_ptr<material> phase_function;
     };
 
     #endif

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -212,7 +212,6 @@ because we need to know the grid. Let’s take a million and try it both ways:
             }
         }
 
-        auto N = static_cast<double>(sqrt_N) * sqrt_N;
         std::cout << std::fixed << std::setprecision(12);
         std::cout
             << "Regular    Estimate of Pi = "
@@ -886,7 +885,7 @@ more and count up until we find an area that is half of the total. From $0$ to $
 
         // Find out the sample at which we have half of our area
         double half_sum = sum / 2.0;
-        double halfway_point;
+        double halfway_point = 0.0;
         double accum = 0.0;
         for (int i = 0; i < N; i++){
             accum += samples[i].p_x;

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -1504,9 +1504,7 @@ We modify the base-class `material` to enable this importance sampling:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class material {
       public:
-        virtual color emitted(double u, double v, const point3& p) const {
-            return color(0,0,0);
-        }
+        ...
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -2305,6 +2303,9 @@ down. We can do that by letting the emitted member function of hittable take ext
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class material {
       public:
+        ...
+
+
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         virtual color emitted(
             const ray& r_in, const hit_record& rec, double u, double v, const point3& p
@@ -2312,7 +2313,6 @@ down. We can do that by letting the emitted member function of hittable take ext
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             return color(0,0,0);
         }
-
         ...
     };
 
@@ -2523,21 +2523,21 @@ Now we can try sampling directions toward a `hittable`, like the light.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class hittable_pdf : public pdf {
       public:
-        hittable_pdf(const hittable_list& _hittable_ptr, const point3& _origin)
-          : hittable_ptr(_hittable_ptr), origin(_origin)
+        hittable_pdf(const hittable_list& _objects, const point3& _origin)
+          : objects(_objects), origin(_origin)
         {}
 
         double value(const vec3& direction) const override {
-            return hittable_ptr->pdf_value(origin, direction);
+            return objects.pdf_value(origin, direction);
         }
 
         vec3 generate() const override {
-            return hittable_ptr->random(origin);
+            return objects.random(origin);
         }
 
       public:
+        const hittable_list& objects;
         point3 origin;
-        shared_ptr<hittable> hittable_ptr;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-hittable-pdf]: <kbd>[pdf.h]</kbd> The hittable_pdf class]
@@ -2555,9 +2555,7 @@ functions through to subclasses if you want a purely abstract `hittable` interfa
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class hittable {
       public:
-        virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const = 0;
-
-        virtual aabb bounding_box() const = 0;
+        ...
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -2890,11 +2888,7 @@ We can redesign `material` and stuff all the new arguments into a class like we 
 
     class material {
       public:
-        virtual color emitted(
-            const ray& r_in, const hit_record& rec, double u, double v, const point3& p
-        ) const {
-            return color(0,0,0);
-        }
+        ...
 
         virtual bool scatter(
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -2903,11 +2897,7 @@ We can redesign `material` and stuff all the new arguments into a class like we 
         ) const {
             return false;
         }
-
-        virtual double scattering_pdf(const ray& r_in, const hit_record& rec, const ray& scattered)
-        const {
-            return 0;
-        }
+        ...
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [material-refactor]: <kbd>[material.h]</kbd> Refactoring the material class]

--- a/src/InOneWeekend/hittable.h
+++ b/src/InOneWeekend/hittable.h
@@ -33,6 +33,8 @@ class hit_record {
 
 class hittable {
   public:
+    virtual ~hittable() = default;
+
     virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const = 0;
 };
 

--- a/src/InOneWeekend/material.h
+++ b/src/InOneWeekend/material.h
@@ -19,6 +19,8 @@ class hit_record;
 
 class material {
   public:
+    virtual ~material() = default;
+
     virtual bool scatter(
         const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
     ) const = 0;

--- a/src/TheNextWeek/aarect.h
+++ b/src/TheNextWeek/aarect.h
@@ -49,8 +49,8 @@ class xy_rect : public hittable {
     aabb bounding_box() const override { return bbox; }
 
   public:
-    shared_ptr<material> mat;
     double x0, x1, y0, y1, k;
+    shared_ptr<material> mat;
     aabb bbox;
 };
 
@@ -88,8 +88,8 @@ class xz_rect : public hittable {
     aabb bounding_box() const override { return bbox; }
 
   public:
-    shared_ptr<material> mat;
     double x0, x1, z0, z1, k;
+    shared_ptr<material> mat;
     aabb bbox;
 };
 
@@ -127,8 +127,8 @@ class yz_rect : public hittable {
     aabb bounding_box() const override { return bbox; }
 
   public:
-    shared_ptr<material> mat;
     double y0, y1, z0, z1, k;
+    shared_ptr<material> mat;
     aabb bbox;
 };
 

--- a/src/TheNextWeek/constant_medium.h
+++ b/src/TheNextWeek/constant_medium.h
@@ -79,8 +79,8 @@ class constant_medium : public hittable {
 
   public:
     shared_ptr<hittable> boundary;
-    shared_ptr<material> phase_function;
     double neg_inv_density;
+    shared_ptr<material> phase_function;
 };
 
 

--- a/src/TheNextWeek/hittable.h
+++ b/src/TheNextWeek/hittable.h
@@ -38,6 +38,8 @@ class hit_record {
 
 class hittable {
   public:
+    virtual ~hittable() = default;
+
     virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const = 0;
 
     virtual aabb bounding_box() const = 0;

--- a/src/TheNextWeek/material.h
+++ b/src/TheNextWeek/material.h
@@ -19,6 +19,8 @@
 
 class material {
   public:
+    virtual ~material() = default;
+
     virtual color emitted(double u, double v, const point3& p) const {
         return color(0,0,0);
     }

--- a/src/TheRestOfYourLife/aarect.h
+++ b/src/TheRestOfYourLife/aarect.h
@@ -49,8 +49,8 @@ class xy_rect : public hittable {
     aabb bounding_box() const override { return bbox; }
 
   public:
-    shared_ptr<material> mat;
     double x0, x1, y0, y1, k;
+    shared_ptr<material> mat;
     aabb bbox;
 };
 
@@ -105,8 +105,8 @@ class xz_rect : public hittable {
     }
 
   public:
-    shared_ptr<material> mat;
     double x0, x1, z0, z1, k;
+    shared_ptr<material> mat;
     aabb bbox;
 };
 
@@ -143,8 +143,8 @@ class yz_rect : public hittable {
 
     aabb bounding_box() const override { return bbox; }
   public:
-    shared_ptr<material> mat;
     double y0, y1, z0, z1, k;
+    shared_ptr<material> mat;
     aabb bbox;
 };
 

--- a/src/TheRestOfYourLife/estimate_halfway.cc
+++ b/src/TheRestOfYourLife/estimate_halfway.cc
@@ -48,7 +48,7 @@ int main() {
 
     // Find out the sample at which we have half of our area
     double half_sum = sum / 2.0;
-    double halfway_point;
+    double halfway_point = 0.0;
     double accum = 0.0;
     for (int i = 0; i < N; i++){
         accum += samples[i].p_x;

--- a/src/TheRestOfYourLife/hittable.h
+++ b/src/TheRestOfYourLife/hittable.h
@@ -38,6 +38,8 @@ class hit_record {
 
 class hittable {
   public:
+    virtual ~hittable() = default;
+
     virtual bool hit(const ray& r, interval ray_t, hit_record& rec) const = 0;
 
     virtual aabb bounding_box() const = 0;

--- a/src/TheRestOfYourLife/integrate_x_sq.cc
+++ b/src/TheRestOfYourLife/integrate_x_sq.cc
@@ -25,8 +25,6 @@ double pdf(double x) {
 }
 
 int main() {
-    int inside_circle = 0;
-    int inside_circle_stratified = 0;
     int N = 1;
 
     auto sum = 0.0;

--- a/src/TheRestOfYourLife/material.h
+++ b/src/TheRestOfYourLife/material.h
@@ -28,6 +28,8 @@ class scatter_record {
 
 class material {
   public:
+    virtual ~material() = default;
+
     virtual color emitted(
         const ray& r_in, const hit_record& rec, double u, double v, const point3& p
     ) const {

--- a/src/TheRestOfYourLife/pdf.h
+++ b/src/TheRestOfYourLife/pdf.h
@@ -45,21 +45,21 @@ class cosine_pdf : public pdf {
 
 class hittable_pdf : public pdf {
   public:
-    hittable_pdf(const hittable_list& _hittable_ptr, const point3& _origin)
-      : hittable_ptr(_hittable_ptr), origin(_origin)
+    hittable_pdf(const hittable_list& _objects, const point3& _origin)
+      : objects(_objects), origin(_origin)
     {}
 
     double value(const vec3& direction) const override {
-        return hittable_ptr.pdf_value(origin, direction);
+        return objects.pdf_value(origin, direction);
     }
 
     vec3 generate() const override {
-        return hittable_ptr.random(origin);
+        return objects.random(origin);
     }
 
   public:
+    const hittable_list& objects;
     point3 origin;
-    const hittable_list& hittable_ptr;
 };
 
 

--- a/src/TheRestOfYourLife/pi.cc
+++ b/src/TheRestOfYourLife/pi.cc
@@ -38,7 +38,6 @@ int main() {
         }
     }
 
-    auto N = static_cast<double>(sqrt_N) * sqrt_N;
     std::cout << std::fixed << std::setprecision(12);
     std::cout << "Regular    Estimate of Pi = "
         << (4.0 * inside_circle) / (sqrt_N*sqrt_N) << '\n';

--- a/src/common/texture.h
+++ b/src/common/texture.h
@@ -19,6 +19,8 @@
 
 class texture {
   public:
+    virtual ~texture() = default;
+
     virtual color value(double u, double v, const point3& p) const = 0;
 };
 
@@ -65,8 +67,8 @@ class checker_texture : public texture {
 
   public:
     double inv_scale;
-    shared_ptr<texture> odd;
     shared_ptr<texture> even;
+    shared_ptr<texture> odd;
 };
 
 


### PR DESCRIPTION
This commit enables new warnings for the MSVC compiler:

- C4265: Class has virtual functions, but its non-trivial destructor is
  not virtual.
- C5204: Class has virtual functions, but its trivial destructor is not
  virtual.
- C5038: Data member will be initialized after [other] data member

The first two warnings catch cases where destructors don't cascade when
someone forgets to specify that a derived class's destructor is virtual.

The third warning flags the situation where a class's data members are
specified in one order, and the initializers are listed in a different
order. Member variables are always initialized in class declaration
order, so programmers who expect initialization in initializer list
order may be surprised, particularly when some members depend on other
members being initialized first.

I've cleaned the code and books from the above warnings.