### PR TITLE
Fix typo in optimised aabb::hit method

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -664,7 +664,7 @@ as my go-to method:
                 auto invD = 1.0f / r.direction()[a];
                 auto t0 = (min()[a] - r.origin()[a]) * invD;
                 auto t1 = (max()[a] - r.origin()[a]) * invD;
-                if (invD < 0.0f)
+                if (t1 < t0)
                     std::swap(t0, t1);
                 auto ray_tmin = t0 > ray_t.min ? t0 : ray_t.min;
                 auto ray_tmax = t1 < ray_t.max ? t1 : ray_t.max;


### PR DESCRIPTION
Fixes #892.
I believe there is a typo optimised aabb::hit method. What is important is that `t0 < t1`, not that the inverse of direction < 0.
Consider two AABBs with reversed minimum and maximum: for the same ray, t0 and t1 will be reversed.