### PR TITLE
Mop up conversion from cerr to clog

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -186,12 +186,12 @@ loop or other problem.
 
 <div class='together'>
 Our program outputs the image to the standard output stream (`std::cout`), so leave that alone and
-instead write to the error output stream (`std::cerr`):
+instead write to the logging output stream (`std::clog`):
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         for (int j = image_height-1; j >= 0; --j) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-            std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;
+            std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             for (int i = 0; i < image_width; ++i) {
                 auto r = double(i) / (image_width-1);
@@ -208,7 +208,7 @@ instead write to the error output stream (`std::cerr`):
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        std::cerr << "\nDone.\n";
+        std::clog << "\nDone.\n";
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-progress]: <kbd>[main.cc]</kbd> Main render loop with progress reporting]
 </div>
@@ -402,7 +402,7 @@ Now we can change our main to use this:
         std::cout << "P3\n" << image_width << ' ' << image_height << "\n255\n";
 
         for (int j = image_height-1; j >= 0; --j) {
-            std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;
+            std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 color pixel_color(double(i)/(image_width-1), double(j)/(image_height-1), 0.25);
@@ -411,7 +411,7 @@ Now we can change our main to use this:
             }
         }
 
-        std::cerr << "\nDone.\n";
+        std::clog << "\nDone.\n";
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ppm-2]: <kbd>[main.cc]</kbd> Final code for the first PPM image]
@@ -548,7 +548,7 @@ for now because we’ll add antialiasing later):
         std::cout << "P3\n" << image_width << " " << image_height << "\n255\n";
 
         for (int j = image_height-1; j >= 0; --j) {
-            std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;
+            std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 auto u = double(i) / (image_width-1);
@@ -560,7 +560,7 @@ for now because we’ll add antialiasing later):
             }
         }
 
-        std::cerr << "\nDone.\n";
+        std::clog << "\nDone.\n";
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-blue-white-blend]: <kbd>[main.cc]</kbd> Rendering a blue-to-white gradient]
@@ -1254,7 +1254,7 @@ And the new main:
         std::cout << "P3\n" << image_width << ' ' << image_height << "\n255\n";
 
         for (int j = image_height-1; j >= 0; --j) {
-            std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;
+            std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
                 auto u = double(i) / (image_width-1);
                 auto v = double(j) / (image_height-1);
@@ -1266,7 +1266,7 @@ And the new main:
             }
         }
 
-        std::cerr << "\nDone.\n";
+        std::clog << "\nDone.\n";
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-with-rtweekend-h]: <kbd>[main.cc]</kbd> The new main with hittables]
@@ -1591,7 +1591,7 @@ Main is also changed:
         std::cout << "P3\n" << image_width << " " << image_height << "\n255\n";
 
         for (int j = image_height-1; j >= 0; --j) {
-            std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;
+            std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 color pixel_color(0, 0, 0);
@@ -1606,7 +1606,7 @@ Main is also changed:
             }
         }
 
-        std::cerr << "\nDone.\n";
+        std::clog << "\nDone.\n";
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-multi-sample]: <kbd>[main.cc]</kbd> Rendering with multi-sampled pixels]
@@ -1770,7 +1770,7 @@ depth, returning no light contribution at the maximum depth:
         std::cout << "P3\n" << image_width << " " << image_height << "\n255\n";
 
         for (int j = image_height-1; j >= 0; --j) {
-            std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;
+            std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
                 color pixel_color(0, 0, 0);
                 for (int s = 0; s < samples_per_pixel; ++s) {
@@ -1785,7 +1785,7 @@ depth, returning no light contribution at the maximum depth:
             }
         }
 
-        std::cerr << "\nDone.\n";
+        std::clog << "\nDone.\n";
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-depth]: <kbd>[main.cc]</kbd> ray_color() with depth limiting]
@@ -2370,7 +2370,7 @@ Now let’s add some metal spheres to our scene:
         std::cout << "P3\n" << image_width << " " << image_height << "\n255\n";
 
         for (int j = image_height-1; j >= 0; --j) {
-            std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;
+            std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
                 color pixel_color(0, 0, 0);
                 for (int s = 0; s < samples_per_pixel; ++s) {
@@ -2383,7 +2383,7 @@ Now let’s add some metal spheres to our scene:
             }
         }
 
-        std::cerr << "\nDone.\n";
+        std::clog << "\nDone.\n";
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-with-metal]: <kbd>[main.cc]</kbd> Scene with metal spheres]
@@ -2829,7 +2829,7 @@ Naturally, we'll name this the `scene` class.
             std::cout << "P3\n" << image_width << " " << image_height << "\n255\n";
 
             for (int j = image_height-1; j >= 0; --j) {
-                std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;
+                std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
                 for (int i = 0; i < image_width; ++i) {
                     color pixel_color(0,0,0);
                     for (int s = 0; s < samples_per_pixel; ++s) {
@@ -2842,7 +2842,7 @@ Naturally, we'll name this the `scene` class.
                 }
             }
 
-            std::cerr << "\nDone.\n";
+            std::clog << "\nDone.\n";
         }
 
       public:

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -3388,7 +3388,7 @@ density $C$ and the boundary. I’ll use another hittable for the boundary. The 
             if (!boundary->hit(r, interval(rec1.t+0.0001, infinity), rec2))
                 return false;
 
-            if (debugging) std::cerr << "\nray_tmin=" << rec1.t << ", ray_tmax=" << rec2.t << '\n';
+            if (debugging) std::clog << "\nray_tmin=" << rec1.t << ", ray_tmax=" << rec2.t << '\n';
 
             if (rec1.t < ray_t.min) rec1.t = ray_t.min;
             if (rec2.t > ray_t.max) rec2.t = ray_t.max;
@@ -3410,7 +3410,7 @@ density $C$ and the boundary. I’ll use another hittable for the boundary. The 
             rec.p = r.at(rec.t);
 
             if (debugging) {
-                std::cerr << "hit_distance = " <<  hit_distance << '\n'
+                std::clog << "hit_distance = " <<  hit_distance << '\n'
                           << "rec.t = " <<  rec.t << '\n'
                           << "rec.p = " <<  rec.p << '\n';
             }

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -340,7 +340,7 @@ location.
             int sqrt_spp = int(sqrt(samples_per_pixrel));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             for (int j = image_height-1; j >= 0; --j) {
-                std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;
+                std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
                 for (int i = 0; i < image_width; ++i) {
                     color pixel_color(0,0,0);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -357,7 +357,7 @@ location.
                 }
             }
 
-            std::cerr << "\nDone.\n";
+            std::clog << "\nDone.\n";
         }
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/TheNextWeek/constant_medium.h
+++ b/src/TheNextWeek/constant_medium.h
@@ -41,7 +41,7 @@ class constant_medium : public hittable {
         if (!boundary->hit(r, interval(rec1.t+0.0001, infinity), rec2))
             return false;
 
-        if (debugging) std::cerr << "\nt_min=" << rec1.t << ", t_max=" << rec2.t << '\n';
+        if (debugging) std::clog << "\nt_min=" << rec1.t << ", t_max=" << rec2.t << '\n';
 
         if (rec1.t < ray_t.min) rec1.t = ray_t.min;
         if (rec2.t > ray_t.max) rec2.t = ray_t.max;
@@ -63,7 +63,7 @@ class constant_medium : public hittable {
         rec.p = r.at(rec.t);
 
         if (debugging) {
-            std::cerr << "hit_distance = " <<  hit_distance << '\n'
+            std::clog << "hit_distance = " <<  hit_distance << '\n'
                       << "rec.t = " <<  rec.t << '\n'
                       << "rec.p = " <<  rec.p << '\n';
         }

--- a/src/TheNextWeek/scene.h
+++ b/src/TheNextWeek/scene.h
@@ -27,7 +27,7 @@ class scene {
         std::cout << "P3\n" << image_width << ' ' << image_height << "\n255\n";
 
         for (int j = image_height-1; j >= 0; --j) {
-            std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;
+            std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
                 color pixel_color(0,0,0);
                 for (int s = 0; s < samples_per_pixel; ++s) {
@@ -40,7 +40,7 @@ class scene {
             }
         }
 
-        std::cerr << "\nDone.\n";
+        std::clog << "\nDone.\n";
     }
 
   public:

--- a/src/TheRestOfYourLife/constant_medium.h
+++ b/src/TheRestOfYourLife/constant_medium.h
@@ -41,7 +41,7 @@ class constant_medium : public hittable {
         if (!boundary->hit(r, interval(rec1.t+0.0001, infinity), rec2))
             return false;
 
-        if (debugging) std::cerr << "\nt_min=" << rec1.t << ", t_max=" << rec2.t << '\n';
+        if (debugging) std::clog << "\nt_min=" << rec1.t << ", t_max=" << rec2.t << '\n';
 
         if (rec1.t < ray_t.min) rec1.t = ray_t.min;
         if (rec2.t > ray_t.max) rec2.t = ray_t.max;
@@ -63,7 +63,7 @@ class constant_medium : public hittable {
         rec.p = r.at(rec.t);
 
         if (debugging) {
-            std::cerr << "hit_distance = " <<  hit_distance << '\n'
+            std::clog << "hit_distance = " <<  hit_distance << '\n'
                       << "rec.t = " <<  rec.t << '\n'
                       << "rec.p = " <<  rec.p << '\n';
         }

--- a/src/TheRestOfYourLife/scene.h
+++ b/src/TheRestOfYourLife/scene.h
@@ -25,7 +25,7 @@ class scene {
         std::cout << "P3\n" << image_width << ' ' << image_height << "\n255\n";
 
         for (int j = image_height-1; j >= 0; --j) {
-            std::cerr << "\rScanlines remaining: " << j << ' ' << std::flush;
+            std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
                 color pixel_color(0,0,0);
                 for (int s = 0; s < samples_per_pixel; ++s) {
@@ -38,7 +38,7 @@ class scene {
             }
         }
 
-        std::cerr << "\nDone.\n";
+        std::clog << "\nDone.\n";
     }
 
   public:


### PR DESCRIPTION
Missed SO MANY places where we should use `std::clog` instead of
`std::cerr`.

- Convert _all_ scanline progress loops and corresponding text.
- Convert debugging output to use `std::clog` instead of `std::cerr`, as
  well as corresponding text.