### PR TITLE
Made little spheres sit flush with world sphere surface.

### DIFF
--- a/src/InOneWeekend/main.cc
+++ b/src/InOneWeekend/main.cc
@@ -45,12 +45,16 @@ hittable_list random_scene() {
     hittable_list world;
 
     auto ground_material = make_shared<lambertian>(color(0.5, 0.5, 0.5));
-    world.add(make_shared<sphere>(point3(0,-1000,0), 1000, ground_material));
+    point3 world_center = point3(0,-1000,0);
+    world.add(make_shared<sphere>(world_center, 1000, ground_material));
 
     for (int a = -11; a < 11; a++) {
         for (int b = -11; b < 11; b++) {
             auto choose_mat = random_double();
             point3 center(a + 0.9*random_double(), 0.2, b + 0.9*random_double());
+            // Adjust sphere to sit neatly on world sphere surface.
+            vec3 to_center = center - world_center;
+            center = world_center + to_center * (1000.2 / to_center.length());
 
             if ((center - point3(4, 0.2, 0)).length() > 0.9) {
                 shared_ptr<material> sphere_material;


### PR DESCRIPTION
From viewpoints around the edge of the scene, the little spheres float far enough above the big world sphere to see under them. 

![Screenshot from 2021-10-19 20-23-55](https://user-images.githubusercontent.com/1584013/137985536-b334bb7f-0342-41e3-867f-37d43a9a6fae.png)

This change places them touching the large sphere surface. It is a noticeable difference even with the default viewpoint. Animation of with and without this change:

![inOneWeekend_stick_down](https://user-images.githubusercontent.com/1584013/137985255-a8b882d4-776c-4d6f-a372-ef90542c7b8a.gif)

This change fixes #948.