### PR TITLE
Book 3 Section 12.1 Listing 33: fix typos in the book

### DIFF
--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -2037,7 +2037,7 @@ The Lambertian material becomes simpler:
             ) const override {
                 srec.is_specular = false;
                 srec.attenuation = albedo->value(rec.u, rec.v, rec.p);
-                srec.pdf_ptr = new cosine_pdf(rec.normal);
+                srec.pdf_ptr = make_shared<cosine_pdf>(rec.normal);
                 return true;
             }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++


### PR DESCRIPTION
url is https://raytracing.github.io/books/RayTracingTheRestOfYourLife.html#cleaninguppdfmanagement/diffuseversusspecular
![image](https://user-images.githubusercontent.com/58605529/162881041-6c38529f-37a4-4bc4-bef4-5484cd96a187.png)

The correct way to write it should be:
```cpp
srec.pdf_ptr = make_shared<cosine_pdf>(rec.normal);
```
![image](https://user-images.githubusercontent.com/58605529/162881150-449db8fa-5816-431c-bff0-7b9bb840e43e.png)
