### PR TITLE
scene: rename loop variable in pixel sampling loop

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1595,7 +1595,7 @@ Main is also changed:
             for (int i = 0; i < image_width; ++i) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 color pixel_color(0, 0, 0);
-                for (int sample = samples_per_pixel; sample > 0; --sample) {
+                for (int sample = 0; sample < samples_per_pixel; ++sample) {
                     auto u = (i + random_double()) / (image_width-1);
                     auto v = (j + random_double()) / (image_height-1);
                     ray r = cam.get_ray(u, v);
@@ -1773,7 +1773,7 @@ depth, returning no light contribution at the maximum depth:
             std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
                 color pixel_color(0, 0, 0);
-                for (int sample = samples_per_pixel; sample > 0; --sample) {
+                for (int sample = 0; sample < samples_per_pixel; ++sample) {
                     auto u = (i + random_double()) / (image_width-1);
                     auto v = (j + random_double()) / (image_height-1);
                     ray r = cam.get_ray(u, v);
@@ -2373,7 +2373,7 @@ Now let’s add some metal spheres to our scene:
             std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
                 color pixel_color(0, 0, 0);
-                for (int sample = samples_per_pixel; sample > 0; --sample) {
+                for (int sample = 0; sample < samples_per_pixel; ++sample) {
                     auto u = (i + random_double()) / (image_width-1);
                     auto v = (j + random_double()) / (image_height-1);
                     ray r = cam.get_ray(u, v);
@@ -2832,7 +2832,7 @@ Naturally, we'll name this the `scene` class.
                 std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
                 for (int i = 0; i < image_width; ++i) {
                     color pixel_color(0,0,0);
-                    for (int sample = samples_per_pixel; sample > 0; --sample) {
+                    for (int sample = 0; sample < samples_per_pixel; ++sample) {
                         auto u = (i + random_double()) / (image_width-1);
                         auto v = (j + random_double()) / (image_height-1);
                         ray r = cam.get_ray(u, v);

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1595,7 +1595,7 @@ Main is also changed:
             for (int i = 0; i < image_width; ++i) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 color pixel_color(0, 0, 0);
-                for (int s = 0; s < samples_per_pixel; ++s) {
+                for (int sample = samples_per_pixel; sample > 0; --sample) {
                     auto u = (i + random_double()) / (image_width-1);
                     auto v = (j + random_double()) / (image_height-1);
                     ray r = cam.get_ray(u, v);
@@ -1773,7 +1773,7 @@ depth, returning no light contribution at the maximum depth:
             std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
                 color pixel_color(0, 0, 0);
-                for (int s = 0; s < samples_per_pixel; ++s) {
+                for (int sample = samples_per_pixel; sample > 0; --sample) {
                     auto u = (i + random_double()) / (image_width-1);
                     auto v = (j + random_double()) / (image_height-1);
                     ray r = cam.get_ray(u, v);
@@ -2373,7 +2373,7 @@ Now let’s add some metal spheres to our scene:
             std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
                 color pixel_color(0, 0, 0);
-                for (int s = 0; s < samples_per_pixel; ++s) {
+                for (int sample = samples_per_pixel; sample > 0; --sample) {
                     auto u = (i + random_double()) / (image_width-1);
                     auto v = (j + random_double()) / (image_height-1);
                     ray r = cam.get_ray(u, v);
@@ -2832,7 +2832,7 @@ Naturally, we'll name this the `scene` class.
                 std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
                 for (int i = 0; i < image_width; ++i) {
                     color pixel_color(0,0,0);
-                    for (int s = 0; s < samples_per_pixel; ++s) {
+                    for (int sample = samples_per_pixel; sample > 0; --sample) {
                         auto u = (i + random_double()) / (image_width-1);
                         auto v = (j + random_double()) / (image_height-1);
                         ray r = cam.get_ray(u, v);

--- a/src/InOneWeekend/scene.h
+++ b/src/InOneWeekend/scene.h
@@ -30,7 +30,7 @@ class scene {
             std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
                 color pixel_color(0,0,0);
-                for (int sample = samples_per_pixel; sample > 0; --sample) {
+                for (int sample = 0; sample < samples_per_pixel; ++sample) {
                     auto u = (i + random_double()) / (image_width-1);
                     auto v = (j + random_double()) / (image_height-1);
                     ray r = cam.get_ray(u, v);

--- a/src/InOneWeekend/scene.h
+++ b/src/InOneWeekend/scene.h
@@ -30,7 +30,7 @@ class scene {
             std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
                 color pixel_color(0,0,0);
-                for (int s = 0; s < samples_per_pixel; ++s) {
+                for (int sample = samples_per_pixel; sample > 0; --sample) {
                     auto u = (i + random_double()) / (image_width-1);
                     auto v = (j + random_double()) / (image_height-1);
                     ray r = cam.get_ray(u, v);

--- a/src/TheNextWeek/scene.h
+++ b/src/TheNextWeek/scene.h
@@ -30,7 +30,7 @@ class scene {
             std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
                 color pixel_color(0,0,0);
-                for (int sample = samples_per_pixel; sample > 0; --sample) {
+                for (int sample = 0; sample < samples_per_pixel; ++sample) {
                     auto u = (i + random_double()) / (image_width-1);
                     auto v = (j + random_double()) / (image_height-1);
                     ray r = cam.get_ray(u, v);

--- a/src/TheNextWeek/scene.h
+++ b/src/TheNextWeek/scene.h
@@ -30,7 +30,7 @@ class scene {
             std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
                 color pixel_color(0,0,0);
-                for (int s = 0; s < samples_per_pixel; ++s) {
+                for (int sample = samples_per_pixel; sample > 0; --sample) {
                     auto u = (i + random_double()) / (image_width-1);
                     auto v = (j + random_double()) / (image_height-1);
                     ray r = cam.get_ray(u, v);

--- a/src/TheRestOfYourLife/scene.h
+++ b/src/TheRestOfYourLife/scene.h
@@ -28,7 +28,7 @@ class scene {
             std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
                 color pixel_color(0,0,0);
-                for (int s = 0; s < samples_per_pixel; ++s) {
+                for (int sample = samples_per_pixel; sample > 0; --sample) {
                     auto u = (i + random_double()) / (image_width-1);
                     auto v = (j + random_double()) / (image_height-1);
                     ray r = cam.get_ray(u, v);

--- a/src/TheRestOfYourLife/scene.h
+++ b/src/TheRestOfYourLife/scene.h
@@ -28,7 +28,7 @@ class scene {
             std::clog << "\rScanlines remaining: " << j << ' ' << std::flush;
             for (int i = 0; i < image_width; ++i) {
                 color pixel_color(0,0,0);
-                for (int sample = samples_per_pixel; sample > 0; --sample) {
+                for (int sample = 0; sample < samples_per_pixel; ++sample) {
                     auto u = (i + random_double()) / (image_width-1);
                     auto v = (j + random_double()) / (image_height-1);
                     ray r = cam.get_ray(u, v);


### PR DESCRIPTION
The old name 's' is easily confused with the image s/t coordinates.

Fixes #1043