### PR TITLE
Separate out ternary results with space

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1034,7 +1034,7 @@ calculation for us.
 
         void set_face_normal(const ray& r, const vec3& outward_normal) {
             front_face = dot(r.direction(), outward_normal) < 0;
-            normal = front_face ? outward_normal :-outward_normal;
+            normal = front_face ? outward_normal : -outward_normal;
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     };
@@ -2136,7 +2136,7 @@ that the pointer is to a class, which the “class material” in the hittable c
 
         void set_face_normal(const ray& r, const vec3& outward_normal) {
             front_face = dot(r.direction(), outward_normal) < 0;
-            normal = front_face ? outward_normal :-outward_normal;
+            normal = front_face ? outward_normal : -outward_normal;
         }
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/InOneWeekend/hittable.h
+++ b/src/InOneWeekend/hittable.h
@@ -26,7 +26,7 @@ class hit_record {
 
     void set_face_normal(const ray& r, const vec3& outward_normal) {
         front_face = dot(r.direction(), outward_normal) < 0;
-        normal = front_face ? outward_normal :-outward_normal;
+        normal = front_face ? outward_normal : -outward_normal;
     }
 };
 

--- a/src/TheNextWeek/hittable.h
+++ b/src/TheNextWeek/hittable.h
@@ -31,7 +31,7 @@ class hit_record {
 
     void set_face_normal(const ray& r, const vec3& outward_normal) {
         front_face = dot(r.direction(), outward_normal) < 0;
-        normal = front_face ? outward_normal :-outward_normal;
+        normal = front_face ? outward_normal : -outward_normal;
     }
 };
 

--- a/src/TheRestOfYourLife/hittable.h
+++ b/src/TheRestOfYourLife/hittable.h
@@ -31,7 +31,7 @@ class hit_record {
 
     void set_face_normal(const ray& r, const vec3& outward_normal) {
         front_face = dot(r.direction(), outward_normal) < 0;
-        normal = front_face ? outward_normal :-outward_normal;
+        normal = front_face ? outward_normal : -outward_normal;
     }
 };
 


### PR DESCRIPTION
Formatting improvement only