### PR TITLE
scene: include iostream for std::clog

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -2835,6 +2835,7 @@ Naturally, we'll name this the `scene` class.
     #include "camera.h"
     #include "hittable_list.h"
 
+    #include <iostream>
 
     class scene {
       public:

--- a/src/TheRestOfYourLife/scene.h
+++ b/src/TheRestOfYourLife/scene.h
@@ -14,6 +14,8 @@
 #include "camera.h"
 #include "hittable_list.h"
 
+#include <iostream>
+
 
 class scene {
   public:


### PR DESCRIPTION
This wasn't uniformly present in all three versions of scene.h.