### PR TITLE
git-ignore: ignore PPM files in the project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Git Ignore Rules for raytracing.github.io
 
 /build/
+/*.ppm


### PR DESCRIPTION
These are typically files created as a result of testing. We have no official PPM files in the project root directory.