### PR TITLE
Tweak sphere::hit() method to address dark shading

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -930,9 +930,9 @@ And here’s the sphere:
 
             // Find the nearest root that lies in the acceptable range.
             auto root = (-half_b - sqrtd) / a;
-            if (root < ray_tmin || ray_tmax < root) {
+            if (root <= ray_tmin || ray_tmax <= root) {
                 root = (-half_b + sqrtd) / a;
-                if (root < ray_tmin || ray_tmax < root)
+                if (root <= ray_tmin || ray_tmax <= root)
                     return false;
             }
 
@@ -1377,34 +1377,6 @@ and a maximum. We'll end up using this class quite often as we proceed.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [hittable-list-with-interval]: <kbd>[hittable_list.h]</kbd>
         hittable_list::hit() using interval]
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    class sphere : public hittable {
-      public:
-        ...
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-            ...
-
-            // Find the nearest root that lies in the acceptable range.
-            auto root = (-half_b - sqrtd) / a;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-            if (!ray_t.contains(root)) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-                root = (-half_b + sqrtd) / a;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-                if (!ray_t.contains(root))
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-                    return false;
-            }
-            ...
-        }
-        ...
-    };
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [sphere-with-interval]: <kbd>[sphere.h]</kbd> sphere using interval]
-
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     ...

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1323,6 +1323,10 @@ and a maximum. We'll end up using this class quite often as we proceed.
             return min <= x && x <= max;
         }
 
+        bool surrounds(double x) const {
+            return min < x && x < max;
+        }
+
         static const interval empty, universe;
 
       public:
@@ -1377,6 +1381,35 @@ and a maximum. We'll end up using this class quite often as we proceed.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [hittable-list-with-interval]: <kbd>[hittable_list.h]</kbd>
         hittable_list::hit() using interval]
+
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    class sphere : public hittable {
+      public:
+        ...
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+        bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+            ...
+
+            // Find the nearest root that lies in the acceptable range.
+            auto root = (-half_b - sqrtd) / a;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+            if (!ray_t.surrounds(root)) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+                root = (-half_b + sqrtd) / a;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+                if (!ray_t.surrounds(root))
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+                    return false;
+            }
+            ...
+        }
+        ...
+    };
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    [Listing [sphere-with-interval]: <kbd>[sphere.h]</kbd> sphere using interval]
+
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     ...

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -225,9 +225,9 @@ just needs to become a function `center(time)`:
 
             // Find the nearest root that lies in the acceptable range.
             auto root = (-half_b - sqrtd) / a;
-            if (!ray_t.contains(root)) {
+            if (root <= ray_t.min || ray_t.max <= root) {
                 root = (-half_b + sqrtd) / a;
-                if (!ray_t.contains(root))
+                if (root <= ray_t.min || ray_t.max <= root) {
                     return false;
             }
 

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -225,9 +225,9 @@ just needs to become a function `center(time)`:
 
             // Find the nearest root that lies in the acceptable range.
             auto root = (-half_b - sqrtd) / a;
-            if (root <= ray_t.min || ray_t.max <= root) {
+            if (!ray_t.surrounds(root)) {
                 root = (-half_b + sqrtd) / a;
-                if (root <= ray_t.min || ray_t.max <= root) {
+                if (!ray_t.surrounds(root))
                     return false;
             }
 

--- a/src/InOneWeekend/sphere.h
+++ b/src/InOneWeekend/sphere.h
@@ -33,9 +33,9 @@ class sphere : public hittable {
 
         // Find the nearest root that lies in the acceptable range.
         auto root = (-half_b - sqrtd) / a;
-        if (!ray_t.contains(root)) {
+        if (root <= ray_t.min || ray_t.max <= root) {
             root = (-half_b + sqrtd) / a;
-            if (!ray_t.contains(root))
+            if (root <= ray_t.min || ray_t.max <= root) {
                 return false;
         }
 

--- a/src/InOneWeekend/sphere.h
+++ b/src/InOneWeekend/sphere.h
@@ -33,9 +33,9 @@ class sphere : public hittable {
 
         // Find the nearest root that lies in the acceptable range.
         auto root = (-half_b - sqrtd) / a;
-        if (root <= ray_t.min || ray_t.max <= root) {
+        if (!ray_t.surrounds(root)) {
             root = (-half_b + sqrtd) / a;
-            if (root <= ray_t.min || ray_t.max <= root) {
+            if (!ray_t.surrounds(root))
                 return false;
         }
 

--- a/src/TheNextWeek/moving_sphere.h
+++ b/src/TheNextWeek/moving_sphere.h
@@ -40,9 +40,9 @@ class moving_sphere : public hittable {
 
         // Find the nearest root that lies in the acceptable range.
         auto root = (-half_b - sqrtd) / a;
-        if (!ray_t.contains(root)) {
+        if (!ray_t.surrounds(root)) {
             root = (-half_b + sqrtd) / a;
-            if (!ray_t.contains(root))
+            if (!ray_t.surrounds(root))
                 return false;
         }
 

--- a/src/TheNextWeek/sphere.h
+++ b/src/TheNextWeek/sphere.h
@@ -37,9 +37,9 @@ class sphere : public hittable {
 
         // Find the nearest root that lies in the acceptable range.
         auto root = (-half_b - sqrtd) / a;
-        if (root <= ray_t.min || ray_t.max <= root) {
+        if (!ray_t.surrounds(root)) {
             root = (-half_b + sqrtd) / a;
-            if (root <= ray_t.min || ray_t.max <= root) {
+            if (!ray_t.surrounds(root))
                 return false;
         }
 

--- a/src/TheNextWeek/sphere.h
+++ b/src/TheNextWeek/sphere.h
@@ -37,9 +37,9 @@ class sphere : public hittable {
 
         // Find the nearest root that lies in the acceptable range.
         auto root = (-half_b - sqrtd) / a;
-        if (!ray_t.contains(root)) {
+        if (root <= ray_t.min || ray_t.max <= root) {
             root = (-half_b + sqrtd) / a;
-            if (!ray_t.contains(root))
+            if (root <= ray_t.min || ray_t.max <= root) {
                 return false;
         }
 

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -38,9 +38,9 @@ class sphere : public hittable {
 
         // Find the nearest root that lies in the acceptable range.
         auto root = (-half_b - sqrtd) / a;
-        if (root <= ray_t.min || ray_t.max <= root) {
+        if (!ray_t.surrounds(root)) {
             root = (-half_b + sqrtd) / a;
-            if (root <= ray_t.min || ray_t.max <= root) {
+            if (!ray_t.surrounds(root))
                 return false;
         }
 

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -38,9 +38,9 @@ class sphere : public hittable {
 
         // Find the nearest root that lies in the acceptable range.
         auto root = (-half_b - sqrtd) / a;
-        if (!ray_t.contains(root)) {
+        if (root <= ray_t.min || ray_t.max <= root) {
             root = (-half_b + sqrtd) / a;
-            if (!ray_t.contains(root))
+            if (root <= ray_t.min || ray_t.max <= root) {
                 return false;
         }
 

--- a/src/common/interval.h
+++ b/src/common/interval.h
@@ -31,6 +31,10 @@ class interval {
         return min <= x && x <= max;
     }
 
+    bool surrounds(double x) const {
+        return min < x && x < max;
+    }
+
     double clamp(double x) const {
         if (x < min) return min;
         if (x > max) return max;


### PR DESCRIPTION
This is in response to issues raised in issue #875, where the sphere rendering image appears darker than it used to. The issue is that points that lie exactly on the ray interval used to be excluded, but then were not. The issue was compounded when we started to use the `interval::contains()` method, because this subtlety was one step removed.

This should fix the issue as raised, but we will verify in the v4.0.0 release milestone, when we regenerate all of the images.