### PR TITLE
Book1: Fix hit_sphere() discriminant test

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -697,7 +697,7 @@ that hits a small sphere we place at -1 on the z-axis:
         auto b = 2.0 * dot(oc, r.direction());
         auto c = dot(oc, oc) - radius*radius;
         auto discriminant = b*b - 4*a*c;
-        return (discriminant > 0);
+        return (discriminant >= 0);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 


### PR DESCRIPTION
Earlier in the text, we assert that a positive discriminant indicates two real solutions to the quadratic formula, a negative discriminant indicates no real solutions, and a zero discriminant indicates a single real solution.

This change fixes the hit_sphere() function to properly reflect this.

Resolves #1057