### PR TITLE
Move image width & aspect ratio from scene to cam

### DIFF
--- a/src/InOneWeekend/main.cc
+++ b/src/InOneWeekend/main.cc
@@ -20,16 +20,19 @@
 
 
 void random_spheres(scene& scene_desc) {
-    scene_desc.image_width       = 1200;
-    scene_desc.aspect_ratio      = 16.0 / 9.0;
-    scene_desc.samples_per_pixel = 10;
+    scene_desc.cam.lookfrom = vec3(13,2,3);
+    scene_desc.cam.lookat   = vec3(0,0,0);
+    scene_desc.cam.vup      = vec3(0,1,0);
+    scene_desc.cam.vfov     = 20;
 
-    scene_desc.cam.vfov       = 20;
-    scene_desc.cam.focus_dist = 10.0;
-    scene_desc.cam.aperture   = 0.1;
-    scene_desc.cam.lookfrom   = vec3(13,2,3);
-    scene_desc.cam.lookat     = vec3(0,0,0);
-    scene_desc.cam.vup        = vec3(0,1,0);
+    scene_desc.cam.aspect_ratio = 16.0 / 9.0;
+    scene_desc.cam.image_width  = 1200;
+
+    scene_desc.cam.defocus_diameter = 0.1;
+    scene_desc.cam.focus_dist       = 10;
+
+    scene_desc.samples_per_pixel = 10;
+    scene_desc.max_depth         = 20;
 
     hittable_list& world = scene_desc.world;
 

--- a/src/InOneWeekend/scene.h
+++ b/src/InOneWeekend/scene.h
@@ -20,9 +20,10 @@
 class scene {
   public:
     void render() {
-        const int image_height = static_cast<int>(image_width / aspect_ratio);
+        cam.initialize();
 
-        cam.initialize(aspect_ratio);
+        auto image_width = cam.image_width;
+        auto image_height = cam.get_image_height();
 
         std::cout << "P3\n" << image_width << ' ' << image_height << "\n255\n";
 
@@ -47,8 +48,7 @@ class scene {
     hittable_list world;
     camera cam;
 
-    double aspect_ratio      = 1.0;
-    int    image_width       = 100;
+    // Scene sampling parameters
     int    samples_per_pixel = 10;
     int    max_depth         = 20;
 

--- a/src/TheNextWeek/main.cc
+++ b/src/TheNextWeek/main.cc
@@ -25,16 +25,20 @@
 
 
 void random_spheres(scene& scene_desc) {
-    scene_desc.aspect_ratio      = 16.0 / 9.0;
-    scene_desc.image_width       = 400;
-    scene_desc.samples_per_pixel = 100;
+    scene_desc.cam.lookfrom = point3(13,2,3);
+    scene_desc.cam.lookat   = point3(0,0,0);
+    scene_desc.cam.vup      = vec3(0,1,0);
+    scene_desc.cam.vfov     = 20.0;
 
-    scene_desc.cam.lookfrom   = point3(13,2,3);
-    scene_desc.cam.lookat     = point3(0,0,0);
-    scene_desc.cam.vup        = vec3(0,1,0);
-    scene_desc.cam.vfov       = 20.0;
-    scene_desc.cam.aperture   = 0.1;
-    scene_desc.cam.focus_dist = 10.0;
+    scene_desc.cam.aspect_ratio = 16.0 / 9.0;
+    scene_desc.cam.image_width  = 400;
+
+    scene_desc.cam.defocus_diameter = 0.1;
+    scene_desc.cam.focus_dist       = 10;
+
+    scene_desc.samples_per_pixel = 100;
+    scene_desc.max_depth  = 20;
+    scene_desc.background = color(0.70, 0.80, 1.00);
 
     hittable_list& world = scene_desc.world;
 
@@ -85,14 +89,19 @@ void random_spheres(scene& scene_desc) {
 
 
 void two_spheres(scene& scene_desc) {
-    scene_desc.image_width       = 400;
-    scene_desc.aspect_ratio      = 16.0 / 9.0;
-    scene_desc.samples_per_pixel = 100;
-
-    scene_desc.cam.aperture = 0.0;
-    scene_desc.cam.vfov     = 20.0;
     scene_desc.cam.lookfrom = point3(13,2,3);
     scene_desc.cam.lookat   = point3(0,0,0);
+    scene_desc.cam.vup      = vec3(0,1,0);
+    scene_desc.cam.vfov     = 20.0;
+
+    scene_desc.cam.aspect_ratio = 16.0 / 9.0;
+    scene_desc.cam.image_width  = 400;
+
+    scene_desc.cam.defocus_diameter = 0.0;
+
+    scene_desc.samples_per_pixel = 100;
+    scene_desc.max_depth  = 20;
+    scene_desc.background = color(0.70, 0.80, 1.00);
 
     hittable_list& world = scene_desc.world;
 
@@ -104,14 +113,19 @@ void two_spheres(scene& scene_desc) {
 
 
 void two_perlin_spheres(scene& scene_desc) {
-    scene_desc.image_width       = 400;
-    scene_desc.aspect_ratio      = 16.0 / 9.0;
-    scene_desc.samples_per_pixel = 100;
-
-    scene_desc.cam.aperture = 0.0;
-    scene_desc.cam.vfov     = 20.0;
     scene_desc.cam.lookfrom = point3(13,2,3);
     scene_desc.cam.lookat   = point3(0,0,0);
+    scene_desc.cam.vup      = vec3(0,1,0);
+    scene_desc.cam.vfov     = 20.0;
+
+    scene_desc.cam.aspect_ratio = 16.0 / 9.0;
+    scene_desc.cam.image_width  = 400;
+
+    scene_desc.cam.defocus_diameter = 0.0;
+
+    scene_desc.samples_per_pixel = 100;
+    scene_desc.max_depth  = 20;
+    scene_desc.background = color(0.70, 0.80, 1.00);
 
     hittable_list& world = scene_desc.world;
 
@@ -122,14 +136,19 @@ void two_perlin_spheres(scene& scene_desc) {
 
 
 void earth(scene& scene_desc) {
-    scene_desc.image_width       = 400;
-    scene_desc.aspect_ratio      = 16.0 / 9.0;
-    scene_desc.samples_per_pixel = 100;
-
-    scene_desc.cam.aperture = 0.0;
-    scene_desc.cam.vfov     = 20.0;
     scene_desc.cam.lookfrom = point3(0,0,12);
     scene_desc.cam.lookat   = point3(0,0,0);
+    scene_desc.cam.vup      = vec3(0,1,0);
+    scene_desc.cam.vfov     = 20.0;
+
+    scene_desc.cam.aspect_ratio = 16.0 / 9.0;
+    scene_desc.cam.image_width  = 400;
+
+    scene_desc.cam.defocus_diameter = 0.0;
+
+    scene_desc.samples_per_pixel = 100;
+    scene_desc.max_depth  = 20;
+    scene_desc.background = color(0.70, 0.80, 1.00);
 
     auto earth_texture = make_shared<image_texture>("earthmap.jpg");
     auto earth_surface = make_shared<lambertian>(earth_texture);
@@ -140,14 +159,19 @@ void earth(scene& scene_desc) {
 
 
 void quads(scene& scene_desc) {
-    scene_desc.image_width       = 400;
-    scene_desc.aspect_ratio      = 1.0;
-    scene_desc.samples_per_pixel = 100;
-
-    scene_desc.cam.aperture = 0.0;
-    scene_desc.cam.vfov     = 80.0;
     scene_desc.cam.lookfrom = point3(0,0,9);
     scene_desc.cam.lookat   = point3(0,0,0);
+    scene_desc.cam.vup      = vec3(0,1,0);
+    scene_desc.cam.vfov     = 80.0;
+
+    scene_desc.cam.aspect_ratio = 1.0;
+    scene_desc.cam.image_width  = 400;
+
+    scene_desc.cam.defocus_diameter = 0.0;
+
+    scene_desc.samples_per_pixel = 100;
+    scene_desc.max_depth  = 20;
+    scene_desc.background = color(0.70, 0.80, 1.00);
 
     hittable_list& world = scene_desc.world;
 
@@ -168,15 +192,19 @@ void quads(scene& scene_desc) {
 
 
 void simple_light(scene& scene_desc) {
-    scene_desc.image_width       = 400;
-    scene_desc.aspect_ratio      = 16.0 / 9.0;
-    scene_desc.samples_per_pixel = 100;
-    scene_desc.background        = color(0,0,0);
-
-    scene_desc.cam.aperture = 0.0;
-    scene_desc.cam.vfov     = 20.0;
     scene_desc.cam.lookfrom = point3(26,3,6);
     scene_desc.cam.lookat   = point3(0,2,0);
+    scene_desc.cam.vup      = vec3(0,1,0);
+    scene_desc.cam.vfov     = 20.0;
+
+    scene_desc.cam.aspect_ratio = 16.0 / 9.0;
+    scene_desc.cam.image_width  = 400;
+
+    scene_desc.cam.defocus_diameter = 0.0;
+
+    scene_desc.samples_per_pixel = 100;
+    scene_desc.max_depth  = 20;
+    scene_desc.background = color(0,0,0);
 
     hittable_list& world = scene_desc.world;
 
@@ -191,15 +219,19 @@ void simple_light(scene& scene_desc) {
 
 
 void cornell_box(scene& scene_desc) {
-    scene_desc.image_width       = 600;
-    scene_desc.aspect_ratio      = 1.0;
-    scene_desc.samples_per_pixel = 200;
-    scene_desc.background        = color(0,0,0);
-
     scene_desc.cam.lookfrom = point3(278, 278, -800);
     scene_desc.cam.lookat   = point3(278, 278, 0);
+    scene_desc.cam.vup      = vec3(0,1,0);
     scene_desc.cam.vfov     = 40.0;
-    scene_desc.cam.aperture = 0.0;
+
+    scene_desc.cam.aspect_ratio = 1.0;
+    scene_desc.cam.image_width  = 600;
+
+    scene_desc.cam.defocus_diameter = 0.0;
+
+    scene_desc.samples_per_pixel = 200;
+    scene_desc.max_depth  = 20;
+    scene_desc.background = color(0,0,0);
 
     hittable_list& world = scene_desc.world;
 
@@ -228,15 +260,19 @@ void cornell_box(scene& scene_desc) {
 
 
 void cornell_smoke(scene& scene_desc) {
-    scene_desc.image_width       = 600;
-    scene_desc.aspect_ratio      = 1.0;
-    scene_desc.samples_per_pixel = 200;
-    scene_desc.background        = color(0,0,0);
-
-    scene_desc.cam.aperture = 0.0;
-    scene_desc.cam.vfov     = 40.0;
     scene_desc.cam.lookfrom = point3(278, 278, -800);
     scene_desc.cam.lookat   = point3(278, 278, 0);
+    scene_desc.cam.vup      = vec3(0,1,0);
+    scene_desc.cam.vfov     = 40.0;
+
+    scene_desc.cam.aspect_ratio = 1.0;
+    scene_desc.cam.image_width  = 600;
+
+    scene_desc.cam.defocus_diameter = 0.0;
+
+    scene_desc.samples_per_pixel = 200;
+    scene_desc.max_depth  = 20;
+    scene_desc.background = color(0,0,0);
 
     hittable_list& world = scene_desc.world;
 
@@ -266,15 +302,19 @@ void cornell_smoke(scene& scene_desc) {
 
 
 void final_scene(scene& scene_desc) {
-    scene_desc.image_width       = 800;
-    scene_desc.aspect_ratio      = 1.0;
-    scene_desc.samples_per_pixel = 10000;
-    scene_desc.background        = color(0,0,0);
-
-    scene_desc.cam.aperture = 0.0;
-    scene_desc.cam.vfov     = 40.0;
     scene_desc.cam.lookfrom = point3(478, 278, -600);
     scene_desc.cam.lookat   = point3(278, 278, 0);
+    scene_desc.cam.vup      = vec3(0,1,0);
+    scene_desc.cam.vfov     = 40.0;
+
+    scene_desc.cam.aspect_ratio = 1.0;
+    scene_desc.cam.image_width  = 800;
+
+    scene_desc.cam.defocus_diameter = 0.0;
+
+    scene_desc.samples_per_pixel = 10000;
+    scene_desc.max_depth  = 20;
+    scene_desc.background = color(0,0,0);
 
     hittable_list boxes1;
     auto ground = make_shared<lambertian>(color(0.48, 0.83, 0.53));
@@ -340,7 +380,8 @@ void final_scene(scene& scene_desc) {
 
 void default_scene(scene& scene_desc) {
     final_scene(scene_desc);
-    scene_desc.image_width       = 400;
+
+    scene_desc.cam.image_width   = 400;
     scene_desc.samples_per_pixel = 250;
     scene_desc.max_depth         = 4;
 }
@@ -348,10 +389,6 @@ void default_scene(scene& scene_desc) {
 
 int main() {
     scene scene_desc;
-
-    scene_desc.background = color(0.70, 0.80, 1.00);
-    scene_desc.cam.vup = vec3(0,1,0);
-    scene_desc.cam.focus_dist = 10.0;
 
     switch (0) {
         case 1:  random_spheres(scene_desc);     break;

--- a/src/TheNextWeek/scene.h
+++ b/src/TheNextWeek/scene.h
@@ -20,9 +20,10 @@
 class scene {
   public:
     void render() {
-        const int image_height = static_cast<int>(image_width / aspect_ratio);
+        cam.initialize();
 
-        cam.initialize(aspect_ratio);
+        auto image_width = cam.image_width;
+        auto image_height = cam.get_image_height();
 
         std::cout << "P3\n" << image_width << ' ' << image_height << "\n255\n";
 
@@ -47,8 +48,7 @@ class scene {
     hittable_list world;
     camera cam;
 
-    double aspect_ratio      = 1.0;
-    int    image_width       = 100;
+    // Scene sampling parameters
     int    samples_per_pixel = 10;
     int    max_depth         = 50;
     color  background        = color(0,0,0);

--- a/src/TheRestOfYourLife/main.cc
+++ b/src/TheRestOfYourLife/main.cc
@@ -22,18 +22,19 @@
 
 
 void cornell_box(scene& scene_desc) {
-    scene_desc.image_width       = 600;
-    scene_desc.aspect_ratio      = 1.0;
-    scene_desc.samples_per_pixel = 100;
-    scene_desc.max_depth         = 50;
-    scene_desc.background        = color(0,0,0);
+    scene_desc.cam.lookfrom = point3(278, 278, -800);
+    scene_desc.cam.lookat   = point3(278, 278, 0);
+    scene_desc.cam.vup      = vec3(0, 1, 0);
+    scene_desc.cam.vfov     = 40.0;
 
-    scene_desc.cam.lookfrom     = point3(278, 278, -800);
-    scene_desc.cam.lookat       = point3(278, 278, 0);
-    scene_desc.cam.vup          = vec3(0, 1, 0);
-    scene_desc.cam.vfov         = 40.0;
-    scene_desc.cam.aperture     = 0.0;
-    scene_desc.cam.focus_dist   = 10.0;
+    scene_desc.cam.aspect_ratio = 1.0;
+    scene_desc.cam.image_width  = 600;
+
+    scene_desc.cam.defocus_diameter = 0.0;
+
+    scene_desc.samples_per_pixel = 100;
+    scene_desc.max_depth  = 50;
+    scene_desc.background = color(0,0,0);
 
     hittable_list& world = scene_desc.world;
 

--- a/src/TheRestOfYourLife/scene.h
+++ b/src/TheRestOfYourLife/scene.h
@@ -20,16 +20,17 @@
 class scene {
   public:
     void render() {
-        const int image_height = static_cast<int>(image_width / aspect_ratio);
+        cam.initialize();
 
-        cam.initialize(aspect_ratio);
+        auto image_width = cam.image_width;
+        auto image_height = cam.get_image_height();
+
+        int sqrt_spp = int(sqrt(samples_per_pixel));
 
         std::cout << "P3\n" << image_width << ' ' << image_height << "\n255\n";
 
-        int sqrt_spp = int(sqrt(samples_per_pixel));
         for (int j = 0; j < image_height; ++j) {
             std::clog << "\rScanlines remaining: " << (image_height - j) << ' ' << std::flush;
-
             for (int i = 0; i < image_width; ++i) {
                 color pixel_color(0,0,0);
                 for (int s_j = 0; s_j < sqrt_spp; ++s_j) {
@@ -50,10 +51,9 @@ class scene {
   public:
     hittable_list world;
     hittable_list lights;
-    camera        cam;
+    camera cam;
 
-    double aspect_ratio      = 1.0;
-    int    image_width       = 100;
+    // Scene sampling parameters
     int    samples_per_pixel = 10;
     int    max_depth         = 20;
     color  background        = color(0,0,0);

--- a/src/common/camera.h
+++ b/src/common/camera.h
@@ -16,11 +16,14 @@
 
 class camera {
   public:
-    void initialize(double aspect_ratio = 1.0) {
+    void initialize() {
         auto theta = degrees_to_radians(vfov);
         auto h = tan(theta/2);
         auto viewport_height = 2.0 * h;
-        auto viewport_width = aspect_ratio * viewport_height;
+
+        // Calculate the actual aspect ratio of the integer image width and height.
+        auto actual_aspect_ratio = static_cast<double>(image_width) / get_image_height();
+        auto viewport_width = actual_aspect_ratio * viewport_height;
 
         w = unit_vector(lookfrom - lookat);
         u = unit_vector(cross(vup, w));
@@ -31,7 +34,7 @@ class camera {
         vertical = focus_dist * viewport_height * v;
         lower_left_corner = origin - horizontal/2 - vertical/2 - focus_dist*w;
 
-        lens_radius = aperture / 2;
+        defocus_radius = defocus_diameter / 2;
     }
 
     ray get_ray(double s, double t) const {
@@ -39,7 +42,7 @@ class camera {
         // the normalized image-based coordinates of the pixel. Image left is s=0, image right
         // is s=1, image top is t=0, image bottom is t=1.
 
-        vec3 rd = lens_radius * random_in_unit_disk();
+        vec3 rd = defocus_radius * random_in_unit_disk();
         vec3 offset = u * rd.x() + v * rd.y();
         const auto ray_time = random_double(0.0, 1.0);
 
@@ -50,22 +53,29 @@ class camera {
         );
     }
 
-  public:
-    double vfov       = 40;
-    double aperture   = 0;
-    double focus_dist = 10;
+    int get_image_height() const {
+        return static_cast<int>(image_width / aspect_ratio);
+    }
 
+  public:
     point3 lookfrom = point3(0,0,-1);
     point3 lookat   = point3(0,0,0);
     vec3   vup      = vec3(0,1,0);
+    double vfov     = 40;  // Vertical field of view
+
+    double aspect_ratio = 1.0;  // Ideal real-valued aspect ratio
+    int    image_width  = 100;
+
+    double defocus_diameter = 0;  // Diameter of defocus disk around projection point
+    double focus_dist = 10;       // Distance at which objects are in perfect focus
 
   private:
     point3 origin;
     point3 lower_left_corner;
     vec3 horizontal;
     vec3 vertical;
-    vec3 u, v, w;
-    double lens_radius;
+    vec3 u, v, w;            // Camera unit basis vectors
+    double defocus_radius;   // Radius of defocus disk around projection point
 };
 
 #endif


### PR DESCRIPTION
This is a draft PR before I dive into the associated text changes.

--

This change does several things. Primarily, it's a refinement of the division between the scene class and the camera class.

The scene class holds the world description (which includes all scene geometry and lighting) and the camera. It is responsible for using the camera to interrogate the world, using the main render loop (all samples for all pixels).

The camera class is responsible for all 2D rendered image parameters, and uses these to generate rays one at a time.

The net effect of these changes are:

1. The image_width and aspect_ratio member variables move from the scene class to the camera class.

2. camera::initialize() no longer needs to take the aspect ratio argument.

3. camera::get_image_height() is a new public function that returns the image height, computed from the image width and the desired aspect ratio.

4. `camera::aperture` is now `camera::defocus_diameter`. `camera::lens_radius` is now `camera::defocus_radius`.

5. The scene and camera parameter assignments have been reordered to logical groupings based on the updated mental model.

6. In TheNextWeek/main.cc, we assigned background color, camera up, and focus distance before handing the scene off to the scene generators. There's been at least one case where a reader was confused about the state of the scene object because values were set in two different locations. This saved repeating some lines of code, but the simplicity of assigning everything in one place for each scene is better.

These two changes solidify the responsibilities of the two classes in preparation for future changes to the camera class, addressing the following issues:

- #546 Confusion surrounding use of the word "aperture"
- #682 Camera UV coordinates - handle images with width or height of one
- #858 Improve camera.h naming, commentary
- #1042 camera::get_ray() function should perform all sample jittering
- #1076 Book 1 Chapter 13.2 dev-major: Generating Sample Rays

One question left is that now that everything's assigned in the scene generator functions, why not just have them allocate and return the generated scene? I've decided to leave the current approach of mutating the scene -- passed by reference -- purely because it's simpler code. In my opinion, there's not a whole lot of advantage to the returned value approach.