### PR TITLE
Remove unnecessary const specifiers

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -293,14 +293,14 @@ utility functions in the bottom half:
             return *this;
         }
 
-        vec3& operator*=(const double t) {
+        vec3& operator*=(double t) {
             e[0] *= t;
             e[1] *= t;
             e[2] *= t;
             return *this;
         }
 
-        vec3& operator/=(const double t) {
+        vec3& operator/=(double t) {
             return *this *= 1/t;
         }
 
@@ -2258,7 +2258,7 @@ the vector is very close to zero in all dimensions.
         ...
         bool near_zero() const {
             // Return true if the vector is close to zero in all dimensions.
-            const auto s = 1e-8;
+            auto s = 1e-8;
             return (fabs(e[0]) < s) && (fabs(e[1]) < s) && (fabs(e[2]) < s);
         }
         ...

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -138,7 +138,7 @@ a time period.
             vec3 rd = lens_radius * random_in_unit_disk();
             vec3 offset = u * rd.x() + v * rd.y();
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-            const auto ray_time = random_double(0.0, 1.0);
+            auto ray_time = random_double(0.0, 1.0);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
             return ray(
@@ -609,7 +609,7 @@ because in a ray tracer all cases come up eventually). Here's the implementation
         }
 
         interval expand(double delta) const {
-            const auto padding = delta/2;
+            auto padding = delta/2;
             return interval(min - padding, max + padding);
         }
         ...
@@ -682,8 +682,8 @@ as my go-to method:
         ...
         bool hit(const ray& r, interval ray_t) const {
             for (int a = 0; a < 3; a++) {
-                const auto invD = 1 / r.direction()[a];
-                const auto orig = r.origin()[a];
+                auto invD = 1 / r.direction()[a];
+                auto orig = r.origin()[a];
 
                 auto t0 = (axis(a).min - orig) * invD;
                 auto t1 = (axis(a).max - orig) * invD;
@@ -754,7 +754,7 @@ For a sphere, the `bounding_box` function is easy:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         sphere(point3 ctr, double r, shared_ptr<material> m) : center(ctr), radius(r), mat(m) {
-            const auto rvec = vec3(radius, radius, radius);
+            auto rvec = vec3(radius, radius, radius);
             bbox = aabb(center - rvec, center + rvec);
         };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -796,9 +796,9 @@ two boxes.
         moving_sphere(point3 c0, point3 c1, double r, shared_ptr<material> m)
           : center0(c0), center1(c1), center_vec(c1 - c0), radius(r), mat(m)
         {
-            const auto rvec = vec3(radius, radius, radius);
-            const aabb box0(center0 - rvec, center0 + rvec);
-            const aabb box1(center1 - rvec, center1 + rvec);
+            auto rvec = vec3(radius, radius, radius);
+            aabb box0(center0 - rvec, center0 + rvec);
+            aabb box1(center1 - rvec, center1 + rvec);
             bbox = aabb(box0, box1);
         };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1546,7 +1546,7 @@ Adjust according to your directory structure.
             // width() and height() will return 0.
 
             auto filename = std::string(image_filename);
-            const auto imagedir = getenv("RTW_IMAGES");
+            auto imagedir = getenv("RTW_IMAGES");
 
             // Hunt for the image file in some likely locations.
             if (imagedir && load(std::string(imagedir) + "/" + image_filename)) return;
@@ -1642,7 +1642,7 @@ The `image_texture` class uses the `rtw_image` class:
             auto j = static_cast<int>(v * image.height());
             auto pixel = image.pixel_data(i,j);
 
-            const auto color_scale = 1.0 / 255.0;
+            auto color_scale = 1.0 / 255.0;
             return color(color_scale*pixel[0], color_scale*pixel[1], color_scale*pixel[2]);
         }
 
@@ -2347,7 +2347,7 @@ actual shape anyway. To this end, we add a new `aabb::pad()` method that remedie
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         aabb pad() {
             // Return an AABB that has no side narrower than some delta, padding if necessary.
-            const double delta = 0.0001;
+            double delta = 0.0001;
             interval new_x = (x.size() >= delta) ? x : x.expand(delta);
             interval new_y = (y.size() >= delta) ? y : y.expand(delta);
             interval new_z = (z.size() >= delta) ? z : z.expand(delta);
@@ -3602,9 +3602,9 @@ density $C$ and the boundary. I’ll use another hittable for the boundary. The 
             if (rec1.t < 0)
                 rec1.t = 0;
 
-            const auto ray_length = r.direction().length();
-            const auto distance_inside_boundary = (rec2.t - rec1.t) * ray_length;
-            const auto hit_distance = neg_inv_density * log(random_double());
+            auto ray_length = r.direction().length();
+            auto distance_inside_boundary = (rec2.t - rec1.t) * ray_length;
+            auto hit_distance = neg_inv_density * log(random_double());
 
             if (hit_distance > distance_inside_boundary)
                 return false;
@@ -3777,7 +3777,7 @@ why we get caustics and subsurface for free. It’s a double-edged design decisi
         hittable_list boxes1;
         auto ground = make_shared<lambertian>(color(0.48, 0.83, 0.53));
 
-        const int boxes_per_side = 20;
+        int boxes_per_side = 20;
         for (int i = 0; i < boxes_per_side; i++) {
             for (int j = 0; j < boxes_per_side; j++) {
                 auto w = 100.0;

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -330,7 +330,7 @@ location.
     class scene {
       public:
         void render() {
-            const int image_height = static_cast<int>(image_width / aspect_ratio);
+            int image_height = static_cast<int>(image_width / aspect_ratio);
 
             cam.initialize(aspect_ratio);
 
@@ -2240,10 +2240,10 @@ class because it won't really be more complicated than utility functions:
         }
 
         void build_from_w(const vec3& w) {
-            const vec3 unit_w = unit_vector(w);
-            const vec3 a = (fabs(unit_w.x()) > 0.9) ? vec3(0,1,0) : vec3(1,0,0);
-            const vec3 v = unit_vector(cross(unit_w, a));
-            const vec3 u = cross(unit_w, v);
+            vec3 unit_w = unit_vector(w);
+            vec3 a = (fabs(unit_w.x()) > 0.9) ? vec3(0,1,0) : vec3(1,0,0);
+            vec3 v = unit_vector(cross(unit_w, a));
+            vec3 u = cross(unit_w, v);
             axis[0] = u;
             axis[1] = v;
             axis[2] = unit_w;

--- a/src/InOneWeekend/scene.h
+++ b/src/InOneWeekend/scene.h
@@ -20,7 +20,7 @@
 class scene {
   public:
     void render() {
-        const int image_height = static_cast<int>(image_width / aspect_ratio);
+        int image_height = static_cast<int>(image_width / aspect_ratio);
 
         cam.initialize(aspect_ratio);
 

--- a/src/TheNextWeek/constant_medium.h
+++ b/src/TheNextWeek/constant_medium.h
@@ -52,9 +52,9 @@ class constant_medium : public hittable {
         if (rec1.t < 0)
             rec1.t = 0;
 
-        const auto ray_length = r.direction().length();
-        const auto distance_inside_boundary = (rec2.t - rec1.t) * ray_length;
-        const auto hit_distance = neg_inv_density * log(random_double());
+        auto ray_length = r.direction().length();
+        auto distance_inside_boundary = (rec2.t - rec1.t) * ray_length;
+        auto hit_distance = neg_inv_density * log(random_double());
 
         if (hit_distance > distance_inside_boundary)
             return false;

--- a/src/TheNextWeek/main.cc
+++ b/src/TheNextWeek/main.cc
@@ -279,7 +279,7 @@ void final_scene(scene& scene_desc) {
     hittable_list boxes1;
     auto ground = make_shared<lambertian>(color(0.48, 0.83, 0.53));
 
-    const int boxes_per_side = 20;
+    int boxes_per_side = 20;
     for (int i = 0; i < boxes_per_side; i++) {
         for (int j = 0; j < boxes_per_side; j++) {
             auto w = 100.0;

--- a/src/TheNextWeek/moving_sphere.h
+++ b/src/TheNextWeek/moving_sphere.h
@@ -22,9 +22,9 @@ class moving_sphere : public hittable {
     moving_sphere(point3 c0, point3 c1, double r, shared_ptr<material> m)
       : center0(c0), center1(c1), center_vec(c1 - c0), radius(r), mat(m)
     {
-        const auto rvec = vec3(radius, radius, radius);
-        const aabb box0(center0 - rvec, center0 + rvec);
-        const aabb box1(center1 - rvec, center1 + rvec);
+        auto rvec = vec3(radius, radius, radius);
+        aabb box0(center0 - rvec, center0 + rvec);
+        aabb box1(center1 - rvec, center1 + rvec);
         bbox = aabb(box0, box1);
     };
 

--- a/src/TheNextWeek/scene.h
+++ b/src/TheNextWeek/scene.h
@@ -20,7 +20,7 @@
 class scene {
   public:
     void render() {
-        const int image_height = static_cast<int>(image_width / aspect_ratio);
+        int image_height = static_cast<int>(image_width / aspect_ratio);
 
         cam.initialize(aspect_ratio);
 

--- a/src/TheNextWeek/sphere.h
+++ b/src/TheNextWeek/sphere.h
@@ -21,7 +21,7 @@ class sphere : public hittable {
     sphere() {}
 
     sphere(point3 ctr, double r, shared_ptr<material> m) : center(ctr), radius(r), mat(m) {
-        const auto rvec = vec3(radius, radius, radius);
+        auto rvec = vec3(radius, radius, radius);
         bbox = aabb(center - rvec, center + rvec);
     }
 

--- a/src/TheRestOfYourLife/constant_medium.h
+++ b/src/TheRestOfYourLife/constant_medium.h
@@ -52,9 +52,9 @@ class constant_medium : public hittable {
         if (rec1.t < 0)
             rec1.t = 0;
 
-        const auto ray_length = r.direction().length();
-        const auto distance_inside_boundary = (rec2.t - rec1.t) * ray_length;
-        const auto hit_distance = neg_inv_density * log(random_double());
+        auto ray_length = r.direction().length();
+        auto distance_inside_boundary = (rec2.t - rec1.t) * ray_length;
+        auto hit_distance = neg_inv_density * log(random_double());
 
         if (hit_distance > distance_inside_boundary)
             return false;

--- a/src/TheRestOfYourLife/onb.h
+++ b/src/TheRestOfYourLife/onb.h
@@ -34,10 +34,10 @@ class onb
     }
 
     void build_from_w(const vec3& w) {
-        const vec3 unit_w = unit_vector(w);
-        const vec3 a = (fabs(unit_w.x()) > 0.9) ? vec3(0,1,0) : vec3(1,0,0);
-        const vec3 v = unit_vector(cross(unit_w, a));
-        const vec3 u = cross(unit_w, v);
+        vec3 unit_w = unit_vector(w);
+        vec3 a = (fabs(unit_w.x()) > 0.9) ? vec3(0,1,0) : vec3(1,0,0);
+        vec3 v = unit_vector(cross(unit_w, a));
+        vec3 u = cross(unit_w, v);
         axis[0] = u;
         axis[1] = v;
         axis[2] = unit_w;

--- a/src/TheRestOfYourLife/scene.h
+++ b/src/TheRestOfYourLife/scene.h
@@ -20,7 +20,7 @@
 class scene {
   public:
     void render() {
-        const int image_height = static_cast<int>(image_width / aspect_ratio);
+        int image_height = static_cast<int>(image_width / aspect_ratio);
 
         cam.initialize(aspect_ratio);
 

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -22,7 +22,7 @@ class sphere : public hittable {
     sphere() {}
 
     sphere(point3 ctr, double r, shared_ptr<material> m) : center(ctr), radius(r), mat(m) {
-        const auto rvec = vec3(radius, radius, radius);
+        auto rvec = vec3(radius, radius, radius);
         bbox = aabb(center - rvec, center + rvec);
     }
 

--- a/src/common/aabb.h
+++ b/src/common/aabb.h
@@ -37,7 +37,7 @@ class aabb {
 
     aabb pad() {
         // Return an AABB that has no side narrower than some delta, padding if necessary.
-        const double delta = 0.0001;
+        double delta = 0.0001;
         interval new_x = (x.size() >= delta) ? x : x.expand(delta);
         interval new_y = (y.size() >= delta) ? y : y.expand(delta);
         interval new_z = (z.size() >= delta) ? z : z.expand(delta);
@@ -53,8 +53,8 @@ class aabb {
 
     bool hit(const ray& r, interval ray_t) const {
         for (int a = 0; a < 3; a++) {
-            const auto invD = 1 / r.direction()[a];
-            const auto orig = r.origin()[a];
+            auto invD = 1 / r.direction()[a];
+            auto orig = r.origin()[a];
 
             auto t0 = (axis(a).min - orig) * invD;
             auto t1 = (axis(a).max - orig) * invD;

--- a/src/common/camera.h
+++ b/src/common/camera.h
@@ -41,7 +41,7 @@ class camera {
 
         vec3 rd = lens_radius * random_in_unit_disk();
         vec3 offset = u * rd.x() + v * rd.y();
-        const auto ray_time = random_double(0.0, 1.0);
+        auto ray_time = random_double(0.0, 1.0);
 
         return ray(
             origin + offset,

--- a/src/common/interval.h
+++ b/src/common/interval.h
@@ -23,7 +23,7 @@ class interval {
     }
 
     interval expand(double delta) const {
-        const auto padding = delta/2;
+        auto padding = delta/2;
         return interval(min - padding, max + padding);
     }
 

--- a/src/common/rtw_stb_image.h
+++ b/src/common/rtw_stb_image.h
@@ -27,7 +27,7 @@ class rtw_image {
         // width() and height() will return 0.
 
         auto filename = std::string(image_filename);
-        const auto imagedir = getenv("RTW_IMAGES");
+        auto imagedir = getenv("RTW_IMAGES");
 
         // Hunt for the image file in some likely locations.
         if (imagedir && load(std::string(imagedir) + "/" + image_filename)) return;

--- a/src/common/texture.h
+++ b/src/common/texture.h
@@ -105,7 +105,7 @@ class image_texture : public texture {
         auto j = static_cast<int>(v * image.height());
         auto pixel = image.pixel_data(i,j);
 
-        const auto color_scale = 1.0 / 255.0;
+        auto color_scale = 1.0 / 255.0;
         return color(color_scale*pixel[0], color_scale*pixel[1], color_scale*pixel[2]);
     }
 

--- a/src/common/vec3.h
+++ b/src/common/vec3.h
@@ -37,14 +37,14 @@ class vec3 {
         return *this;
     }
 
-    vec3& operator*=(const double t) {
+    vec3& operator*=(double t) {
         e[0] *= t;
         e[1] *= t;
         e[2] *= t;
         return *this;
     }
 
-    vec3& operator/=(const double t) {
+    vec3& operator/=(double t) {
         return *this *= 1/t;
     }
 
@@ -58,7 +58,7 @@ class vec3 {
 
     bool near_zero() const {
         // Return true if the vector is close to zero in all dimensions.
-        const auto s = 1e-8;
+        auto s = 1e-8;
         return (fabs(e[0]) < s) && (fabs(e[1]) < s) && (fabs(e[2]) < s);
     }
 


### PR DESCRIPTION
Generally, remove function-level variable const declarations unless actually necessary.

Resolves #1131