### PR TITLE
Clean up class access specifiers and other aspects

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -275,6 +275,8 @@ utility functions in the bottom half:
 
     class vec3 {
       public:
+        double e[3];
+
         vec3() : e{0,0,0} {}
         vec3(double e0, double e1, double e2) : e{e0, e1, e2} {}
 
@@ -311,9 +313,6 @@ utility functions in the bottom half:
         double length_squared() const {
             return e[0]*e[0] + e[1]*e[1] + e[2]*e[2];
         }
-
-      public:
-        double e[3];
     };
 
     // point3 is just an alias for vec3, but useful for geometric clarity in the code.
@@ -474,6 +473,7 @@ The function $\mathbf{P}(t)$ in more verbose code form I call `ray::at(t)`:
     class ray {
       public:
         ray() {}
+
         ray(const point3& origin, const vec3& direction)
           : orig(origin), dir(direction)
         {}
@@ -485,7 +485,7 @@ The function $\mathbf{P}(t)$ in more verbose code form I call `ray::at(t)`:
             return orig + t*dir;
         }
 
-      public:
+      private:
         point3 orig;
         vec3 dir;
     };
@@ -968,7 +968,7 @@ And here’s the sphere:
             return true;
         }
 
-      public:
+      private:
         point3 center;
         double radius;
     };
@@ -1114,11 +1114,16 @@ that stores a list of `hittable`s:
 
     class hittable_list : public hittable {
       public:
+        std::vector<shared_ptr<hittable>> objects;
+
         hittable_list() {}
         hittable_list(shared_ptr<hittable> object) { add(object); }
 
         void clear() { objects.clear(); }
-        void add(shared_ptr<hittable> object) { objects.push_back(object); }
+
+        void add(shared_ptr<hittable> object) {
+            objects.push_back(object);
+        }
 
         bool hit(const ray& r, double ray_tmin, double ray_tmax, hit_record& rec) const override {
             hit_record temp_rec;
@@ -1135,9 +1140,6 @@ that stores a list of `hittable`s:
 
             return hit_anything;
         }
-
-      public:
-        std::vector<shared_ptr<hittable>> objects;
     };
 
     #endif
@@ -1340,6 +1342,8 @@ and a maximum. We'll end up using this class quite often as we proceed.
 
     class interval {
       public:
+        double min, max;
+
         interval() : min(+infinity), max(-infinity) {} // Default interval is empty
 
         interval(double _min, double _max) : min(_min), max(_max) {}
@@ -1353,9 +1357,6 @@ and a maximum. We'll end up using this class quite often as we proceed.
         }
 
         static const interval empty, universe;
-
-      public:
-        double min, max;
     };
 
     const static interval empty   (+infinity, -infinity);
@@ -1403,6 +1404,7 @@ and a maximum. We'll end up using this class quite often as we proceed.
 
             return hit_anything;
         }
+        ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [hittable-list-with-interval]: <kbd>[hittable_list.h]</kbd>
         hittable_list::hit() using interval]
@@ -2181,7 +2183,6 @@ within `hit_record`. See the highlighted lines below:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class sphere : public hittable {
       public:
-        sphere() {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         sphere(point3 ctr, double r, shared_ptr<material> m)
           : center(ctr), radius(r), mat(m) {};
@@ -2201,7 +2202,7 @@ within `hit_record`. See the highlighted lines below:
             return true;
         }
 
-      public:
+      private:
         point3 center;
         double radius;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -2234,7 +2235,7 @@ it could be a mixture of those strategies. For Lambertian materials we get this 
             return true;
         }
 
-      public:
+      private:
         color albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2287,7 +2288,7 @@ the vector is very close to zero in all dimensions.
             return true;
         }
 
-      public:
+      private:
         color albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2334,7 +2335,7 @@ The metal material just reflects rays using that formula:
             return (dot(scattered.direction(), rec.normal) > 0);
         }
 
-      public:
+      private:
         color albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2473,7 +2474,7 @@ absorb those.
             return (dot(scattered.direction(), rec.normal) > 0);
         }
 
-      public:
+      private:
         color albedo;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         double fuzz;
@@ -2611,7 +2612,7 @@ And the dielectric material that always refracts is:
             return true;
         }
 
-      public:
+      private:
         double ir; // Index of Refraction
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2733,7 +2734,7 @@ And the dielectric material that always refracts (when possible) is:
             return true;
         }
 
-      public:
+      private:
         double ir; // Index of Refraction
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2796,11 +2797,11 @@ material:
             return true;
         }
 
-      public:
-        double ir; // Index of Refraction
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-
       private:
+        double ir; // Index of Refraction
+
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         static double reflectance(double cosine, double ref_idx) {
             // Use Schlick's approximation for reflectance.
             auto r0 = (1-ref_idx) / (1+ref_idx);
@@ -2869,6 +2870,14 @@ Naturally, we'll name this the `scene` class.
 
     class scene {
       public:
+        hittable_list world;
+        camera cam;
+
+        int image_width       = 100;
+        int image_height      = 100;
+        int samples_per_pixel =  10;
+        int max_depth         =  50;
+
         void render() {
             std::cout << "P3\n" << image_width << " " << image_height << "\n255\n";
 
@@ -2888,15 +2897,6 @@ Naturally, we'll name this the `scene` class.
 
             std::clog << "\rDone.                 \n";
         }
-
-      public:
-        hittable_list world;
-        camera cam;
-
-        int image_width       = 100;
-        int image_height      = 100;
-        int samples_per_pixel =  10;
-        int max_depth         =  50;
 
       private:
         color ray_color(const ray& r, int depth) {
@@ -3012,6 +3012,7 @@ width, and everything else will adjust accordingly.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class camera {
       public:
+        ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         void initialize(double aspect_ratio = 1.0) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -3025,11 +3026,10 @@ width, and everything else will adjust accordingly.
             lower_left_corner = origin - horizontal/2 - vertical/2 - vec3(0, 0, focal_length);
         }
 
-        ray get_ray(double s, double t) const {
         ...
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [cam-initialize]: <kbd>[camera.h]</kbd> camera.h with explicit initialization]
+    [Listing [cam-initialize]: <kbd>[camera.h]</kbd> camera class with explicit initialization]
 
 <div class='together'>
 The scene class now needs to initialize the camera before rendering. Note that any changes to camera
@@ -3039,6 +3039,16 @@ settings after the call to `initialize()` will not update camera behavior until 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class scene {
       public:
+        hittable_list world;
+        camera cam;
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+        double aspect_ratio      = 1.0;
+        int    image_width       = 100;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+        int    samples_per_pixel =  10;
+        int    max_depth         =  50;
+
         void render() {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             const int image_height = static_cast<int>(image_width / aspect_ratio);
@@ -3049,17 +3059,6 @@ settings after the call to `initialize()` will not update camera behavior until 
             std::cout << "P3\n" << image_width << " " << image_height << "\n255\n";
             ...
         }
-
-      public:
-        hittable_list world;
-        camera cam;
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        double aspect_ratio      = 1.0;
-        int    image_width       = 100;
-        int    samples_per_pixel =  10;
-        int    max_depth         =  50;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         ...
     }
@@ -3114,6 +3113,10 @@ This implies $h = \tan(\frac{\theta}{2})$. Our camera now becomes:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class camera {
       public:
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+        double vfov = 40;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
         void initialize(double aspect_ratio = 1.0) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             auto theta = degrees_to_radians(vfov);
@@ -3129,21 +3132,7 @@ This implies $h = \tan(\frac{\theta}{2})$. Our camera now becomes:
             lower_left_corner = origin - horizontal/2 - vertical/2 - vec3(0, 0, focal_length);
         }
 
-        ray get_ray(double s, double t) const {
-            return ray(origin, lower_left_corner + s*horizontal + t*vertical - origin);
-        }
-
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-      public:
-        double vfov = 40;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-
-      private:
-        point3 origin;
-        point3 lower_left_corner;
-        vec3 horizontal;
-        vec3 vertical;
+        ...
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [camera-fov]: <kbd>[camera.h]</kbd> Camera with adjustable field-of-view (fov)]
@@ -3218,6 +3207,13 @@ camera horizontally level until you decide to experiment with crazy camera angle
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class camera {
       public:
+        double vfov = 40;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+        point3 lookfrom = point3(0,0,-1);
+        point3 lookat   = point3(0,0,0);
+        vec3   vup      = vec3(0,1,0);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
         void initialize(double aspect_ratio = 1.0) {
             auto theta = degrees_to_radians(vfov);
             auto h = tan(theta/2);
@@ -3235,20 +3231,6 @@ camera horizontally level until you decide to experiment with crazy camera angle
             lower_left_corner = origin - horizontal/2 - vertical/2 - w;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
-
-        ray get_ray(double s, double t) const {
-            return ray(origin, lower_left_corner + s*horizontal + t*vertical - origin);
-        }
-
-      public:
-        double vfov = 40;
-
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        point3 lookfrom = point3(0,0,-1);
-        point3 lookat   = point3(0,0,0);
-        vec3   vup      = vec3(0,1,0);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3381,6 +3363,16 @@ defocus disk of radius zero (no blur at all), so all rays originated at the disk
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class camera {
       public:
+        double vfov       = 40;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+        double aperture   = 0;
+        double focus_dist = 10;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
+        point3 lookfrom = point3(0,0,-1);
+        point3 lookat   = point3(0,0,0);
+        vec3   vup      = vec3(0,1,0);
+
         void initialize(double aspect_ratio = 1.0) {
             auto theta = degrees_to_radians(vfov);
             auto h = tan(theta/2);
@@ -3416,17 +3408,6 @@ defocus disk of radius zero (no blur at all), so all rays originated at the disk
             );
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
-
-      public:
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        double vfov       = 40;
-        double aperture   = 0;
-        double focus_dist = 10;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-
-        point3 lookfrom = point3(0,0,-1);
-        point3 lookat   = point3(0,0,0);
-        vec3   vup      = vec3(0,1,0);
 
       private:
         point3 origin;

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -67,7 +67,12 @@ time for each ray:
     class ray {
       public:
         ray() {}
+
+
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+        ray(const point3& origin, const vec3& direction) : orig(origin), dir(direction), tm(0)
+        {}
+
         ray(const point3& origin, const vec3& direction, double time = 0.0)
           : orig(origin), dir(direction), tm(time)
         {}
@@ -134,6 +139,7 @@ a time period.
     class camera {
       public:
         ...
+
         ray get_ray(double s, double t) const {
             vec3 rd = lens_radius * random_in_unit_disk();
             vec3 offset = u * rd.x() + v * rd.y();
@@ -173,7 +179,6 @@ interval, so it really can be sampled at any time.)
 
     class moving_sphere : public hittable {
       public:
-        moving_sphere() {}
         moving_sphere(point3 c0, point3 c1, double r, shared_ptr<material> m)
           : center0(c0), center1(c1), center_vec(c1 - c0), radius(r), mat(m)
         { };
@@ -188,7 +193,7 @@ interval, so it really can be sampled at any time.)
             return center0 + time * center_vec;
         }
 
-      public:
+      private:
         point3 center0, center1;
         vec3 center_vec;
         double radius;
@@ -626,6 +631,8 @@ because in a ray tracer all cases come up eventually). Here's the implementation
 
     class aabb {
       public:
+        interval x, y, z;
+
         aabb() {} // The default AABB is empty, since intervals are empty by default.
 
         aabb(const interval& ix, const interval& iy, const interval& iz)
@@ -658,9 +665,6 @@ because in a ray tracer all cases come up eventually). Here's the implementation
             }
             return true;
         }
-
-      public:
-        interval x, y, z;
     };
 
     #endif
@@ -748,10 +752,6 @@ For a sphere, the `bounding_box` function is easy:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class sphere : public hittable {
       public:
-        ...
-        sphere() {}
-
-
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         sphere(point3 ctr, double r, shared_ptr<material> m) : center(ctr), radius(r), mat(m) {
             const auto rvec = vec3(radius, radius, radius);
@@ -759,14 +759,11 @@ For a sphere, the `bounding_box` function is easy:
         };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         ...
-
-
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         aabb bounding_box() const override { return bbox; }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-        ...
 
-      public:
+      private:
         point3 center;
         double radius;
         shared_ptr<material> mat;
@@ -810,7 +807,7 @@ two boxes.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         ...
 
-      public:
+      private:
         point3 center0, center1;
         vec3 center_vec;
         double radius;
@@ -872,24 +869,25 @@ bounding box incrementally as each new child is added.
 
     class hittable_list : public hittable {
       public:
+        std::vector<shared_ptr<hittable>> objects;
+
         ...
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         void add(shared_ptr<hittable> object) {
             objects.push_back(object);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             bbox = aabb(bbox, object->bounding_box());
-        }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-        ...
+        }
+
+        bool hit(const ray& r, double ray_tmin, double ray_tmax, hit_record& rec) const override {
+            ...
+        }
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         aabb bounding_box() const override { return bbox; }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-        ...
 
-      public:
-        std::vector<shared_ptr<hittable>> objects;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+      private:
         aabb bbox;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     };
@@ -921,8 +919,6 @@ I am a fan of the one class design when feasible. Here is such a class:
 
     class bvh_node : public hittable {
       public:
-        bvh_node();
-
         bvh_node(const hittable_list& list) : bvh_node(list.objects, 0, list.objects.size()) {}
 
         bvh_node(const std::vector<shared_ptr<hittable>>& src_objects, size_t start, size_t end) {
@@ -941,7 +937,7 @@ I am a fan of the one class design when feasible. Here is such a class:
 
         aabb bounding_box() const override { return bbox; }
 
-      public:
+      private:
         shared_ptr<hittable> left;
         shared_ptr<hittable> right;
         aabb bbox;
@@ -1048,6 +1044,8 @@ function.
     class bvh_node : public hittable {
       ...
       private:
+        ...
+
         static bool box_compare(
             const shared_ptr<hittable> a, const shared_ptr<hittable> b, int axis_index
         ) {
@@ -1146,7 +1144,6 @@ Constant Color Texture
 
     class solid_color : public texture {
       public:
-        solid_color() {}
         solid_color(color c) : color_value(c) {}
 
         solid_color(double red, double green, double blue) : solid_color(color(red,green,blue)) {}
@@ -1213,8 +1210,6 @@ pattern in the scene.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class checker_texture : public texture {
       public:
-        checker_texture() {}
-
         checker_texture(double _scale, shared_ptr<texture> _even, shared_ptr<texture> _odd)
           : inv_scale(1.0 / _scale), even(_even), odd(_odd) {}
 
@@ -1234,7 +1229,7 @@ pattern in the scene.
             return isEven ? even->value(u, v, p) : odd->value(u, v, p);
         }
 
-      public:
+      private:
         double inv_scale;
         shared_ptr<texture> even;
         shared_ptr<texture> odd;
@@ -1404,6 +1399,8 @@ points on the unit sphere centered at the origin, and computes $u$ and $v$:
     class sphere : public hittable {
       ...
       private:
+        ...
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         static void get_sphere_uv(const point3& p, double& u, double& v) {
             // p: a given point on the sphere of radius one, centered at the origin.
             // u: returned value [0,1] of angle around the Y axis from X=-1.
@@ -1418,6 +1415,7 @@ points on the unit sphere centered at the origin, and computes $u$ and $v$:
             u = phi / (2*pi);
             v = theta / pi;
         }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [get-sphere-uv]: <kbd>[sphere.h]</kbd> get_sphere_uv function]
@@ -1480,7 +1478,7 @@ Now we can make textured materials by replacing the `const color& a` with a text
             return true;
         }
 
-      public:
+      private:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         shared_ptr<texture> albedo;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1627,7 +1625,6 @@ The `image_texture` class uses the `rtw_image` class:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
     class image_texture : public texture {
       public:
-        image_texture() {}
         image_texture(const char* filename) : image(filename) {}
 
         color value(double u, double v, const point3& p) const override {
@@ -1827,7 +1824,7 @@ Now if we create an actual texture that takes these floats between 0 and 1 and c
             return color(1,1,1) * noise.noise(p);
         }
 
-      public:
+      private:
         perlin noise;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1915,6 +1912,7 @@ To make it smooth, we can linearly interpolate:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
         ...
+
       private:
         ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -1992,6 +1990,8 @@ It is also a bit low frequency. We can scale the input point to make it vary mor
     class noise_texture : public texture {
       public:
         noise_texture() {}
+
+
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         noise_texture(double sc) : scale(sc) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2002,7 +2002,7 @@ It is also a bit low frequency. We can scale the input point to make it vary mor
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
 
-      public:
+      private:
         perlin noise;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         double scale;
@@ -2173,6 +2173,7 @@ perlin output back to between 0 and 1.
     class noise_texture : public texture {
       public:
         noise_texture() {}
+
         noise_texture(double sc) : scale(sc) {}
 
         color value(double u, double v, const point3& p) const override {
@@ -2181,7 +2182,7 @@ perlin output back to between 0 and 1.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
 
-      public:
+      private:
         perlin noise;
         double scale;
     };
@@ -2234,6 +2235,7 @@ Here `fabs()` is the absolute value function defined in `<cmath>`.
     class noise_texture : public texture {
       public:
         noise_texture() {}
+
         noise_texture(double sc) : scale(sc) {}
 
         color value(double u, double v, const point3& p) const override {
@@ -2243,7 +2245,7 @@ Here `fabs()` is the absolute value function defined in `<cmath>`.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
 
-      public:
+      private:
         perlin noise;
         double scale;
     };
@@ -2272,6 +2274,7 @@ effect is:
     class noise_texture : public texture {
       public:
         noise_texture() {}
+
         noise_texture(double sc) : scale(sc) {}
 
         color value(double u, double v, const point3& p) const override {
@@ -2281,7 +2284,7 @@ effect is:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
 
-      public:
+      private:
         perlin noise;
         double scale;
     };
@@ -2867,7 +2870,7 @@ the ray what color it is and performs no reflection. It’s very simple:
             return emit->value(u, v, p);
         }
 
-      public:
+      private:
         shared_ptr<texture> emit;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2907,7 +2910,6 @@ the new `color_from_emission` value.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class scene {
-        ...
       public:
         hittable_list world;
         camera cam;
@@ -3211,8 +3213,6 @@ make this happen.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class translate : public hittable {
       public:
-        ...
-
         bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
             // Move the ray backwards by the offset
             ray offset_r(r.origin() - offset, r.direction(), r.time());
@@ -3227,7 +3227,9 @@ make this happen.
             return true;
         }
 
-        ...
+      private:
+        shared_ptr<hittable> object;
+        vec3 offset;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [translate-hit]: <kbd>[hittable.h]</kbd> Hittable translation hit function]
@@ -3262,10 +3264,12 @@ make this happen.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         aabb bounding_box() const override { return bbox; }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-      public:
+      private:
         shared_ptr<hittable> object;
         vec3 offset;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         aabb bbox;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     };
@@ -3395,7 +3399,6 @@ We can now create a class for y-rotation:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class rotate_y : public hittable {
       public:
-        ...
 
         bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
             // Change the ray from world space to object space
@@ -3429,8 +3432,6 @@ We can now create a class for y-rotation:
 
             return true;
         }
-
-        ...
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [rot-y-hit]: <kbd>[hittable.h]</kbd> Hittable rotate-Y hit function]
@@ -3440,9 +3441,8 @@ We can now create a class for y-rotation:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class rotate_y : public hittable {
       public:
-
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-            rotate_y(shared_ptr<hittable> p, double angle) : object(p) {
+        rotate_y(shared_ptr<hittable> p, double angle) : object(p) {
             auto radians = degrees_to_radians(angle);
             sin_theta = sin(radians);
             cos_theta = cos(radians);
@@ -3483,7 +3483,7 @@ We can now create a class for y-rotation:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         aabb bounding_box() const override { return bbox; }
 
-      public:
+      private:
         shared_ptr<hittable> object;
         double sin_theta;
         double cos_theta;
@@ -3512,6 +3512,7 @@ And the changes to Cornell are:
         box2 = make_shared<rotate_y>(box2, -18);
         box2 = make_shared<translate>(box2, vec3(130,0,65));
         world.add(box2);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-rot-y]: <kbd>[main.cc]</kbd> Cornell scene with Y-rotated boxes]
@@ -3627,7 +3628,7 @@ density $C$ and the boundary. I’ll use another hittable for the boundary. The 
 
         aabb bounding_box() const override { return boundary->bounding_box(); }
 
-      public:
+      private:
         shared_ptr<hittable> boundary;
         double neg_inv_density;
         shared_ptr<material> phase_function;
@@ -3653,7 +3654,7 @@ The scattering function of isotropic picks a uniform random direction:
             return true;
         }
 
-      public:
+      private:
         shared_ptr<texture> albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -1651,7 +1651,7 @@ And the `lambertian` material becomes:
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-      public:
+      private:
         shared_ptr<texture> albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1820,6 +1820,8 @@ PDF:
             return 1 / (2*pi);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
+
+        ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scatter-mod]: <kbd>[material.h]</kbd> Modified PDF and scatter function]
 </div>
@@ -2219,8 +2221,7 @@ class because it won't really be more complicated than utility functions:
 
     #include "rtweekend.h"
 
-    class onb
-    {
+    class onb {
       public:
         onb() {}
 
@@ -2328,7 +2329,7 @@ But first, let's quickly update the `isotropic` material:
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-        public:
+      private:
         shared_ptr<texture> albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2574,17 +2575,17 @@ create a uniform density over the unit sphere:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class sphere_pdf : public pdf {
-        public:
-          sphere_pdf() { }
+      public:
+        sphere_pdf() { }
 
-          double value(const vec3& direction) const override {
-              return 1/ (4 * pi);
-          }
+        double value(const vec3& direction) const override {
+            return 1/ (4 * pi);
+        }
 
-          vec3 generate() const override {
-              return random_unit_vector();
-          }
-      };
+        vec3 generate() const override {
+            return random_unit_vector();
+        }
+    };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-uni-pdf]: <kbd>[pdf.h]</kbd> The uniform_pdf class]
 
@@ -2604,7 +2605,7 @@ Next, let’s try a cosine density:
             return uvw.local(random_cosine_direction());
         }
 
-      public:
+      private:
         onb uvw;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2688,7 +2689,7 @@ Now we can try sampling directions toward a `hittable`, like the light.
             return objects.random(origin);
         }
 
-      public:
+      private:
         const hittable_list& objects;
         point3 origin;
     };
@@ -2924,7 +2925,7 @@ density class is actually pretty straightforward:
                 return p[1]->generate();
         }
 
-      public:
+      private:
         shared_ptr<pdf> p[2];
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3112,7 +3113,7 @@ The `lambertian` material becomes simpler:
             return cosine < 0 ? 0 : cosine/pi;
         }
 
-      public:
+      private:
         shared_ptr<texture> albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3124,7 +3125,7 @@ As does the `isotropic` material:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class isotropic : public material {
-        public:
+      public:
         isotropic(color c) : albedo(make_shared<solid_color>(c)) {}
         isotropic(shared_ptr<texture> a) : albedo(a) {}
 
@@ -3144,7 +3145,7 @@ As does the `isotropic` material:
             return 1 / (4 * pi);
         }
 
-        public:
+      private:
         shared_ptr<texture> albedo;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3227,7 +3228,7 @@ and dielectric materials are easy to fix.
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-      public:
+      private:
         color albedo;
         double fuzz;
     };
@@ -3575,7 +3576,7 @@ scene:
     class scene {
         ...
 
-    public:
+      public:
         hittable_list world;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         hittable_list lights;

--- a/src/InOneWeekend/hittable_list.h
+++ b/src/InOneWeekend/hittable_list.h
@@ -21,11 +21,16 @@
 
 class hittable_list : public hittable {
   public:
+    std::vector<shared_ptr<hittable>> objects;
+
     hittable_list() {}
     hittable_list(shared_ptr<hittable> object) { add(object); }
 
     void clear() { objects.clear(); }
-    void add(shared_ptr<hittable> object) { objects.push_back(object); }
+
+    void add(shared_ptr<hittable> object) {
+        objects.push_back(object);
+    }
 
     bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
         hit_record temp_rec;
@@ -42,9 +47,6 @@ class hittable_list : public hittable {
 
         return hit_anything;
     }
-
-  public:
-    std::vector<shared_ptr<hittable>> objects;
 };
 
 

--- a/src/InOneWeekend/material.h
+++ b/src/InOneWeekend/material.h
@@ -44,7 +44,7 @@ class lambertian : public material {
         return true;
     }
 
-  public:
+  private:
     color albedo;
 };
 
@@ -61,7 +61,7 @@ class metal : public material {
         return (dot(scattered.direction(), rec.normal) > 0);
     }
 
-  public:
+  private:
     color albedo;
     double fuzz;
 };
@@ -92,10 +92,9 @@ class dielectric : public material {
         return true;
     }
 
-  public:
+  private:
     double ir; // Index of Refraction
 
-  private:
     static double reflectance(double cosine, double ref_idx) {
         // Use Schlick's approximation for reflectance.
         auto r0 = (1-ref_idx) / (1+ref_idx);

--- a/src/InOneWeekend/scene.h
+++ b/src/InOneWeekend/scene.h
@@ -19,6 +19,14 @@
 
 class scene {
   public:
+    hittable_list world;
+    camera cam;
+
+    double aspect_ratio      = 1.0;
+    int    image_width       = 100;
+    int    samples_per_pixel = 10;
+    int    max_depth         = 20;
+
     void render() {
         const int image_height = static_cast<int>(image_width / aspect_ratio);
 
@@ -42,15 +50,6 @@ class scene {
 
         std::clog << "\rDone.                 \n";
     }
-
-  public:
-    hittable_list world;
-    camera cam;
-
-    double aspect_ratio      = 1.0;
-    int    image_width       = 100;
-    int    samples_per_pixel = 10;
-    int    max_depth         = 20;
 
   private:
     color ray_color(const ray& r, int depth) {

--- a/src/InOneWeekend/sphere.h
+++ b/src/InOneWeekend/sphere.h
@@ -18,8 +18,7 @@
 
 class sphere : public hittable {
   public:
-    sphere() {}
-    sphere(point3 ctr, double r, shared_ptr<material> m) : center(ctr), radius(r), mat(m) {};
+    sphere(point3 ctr, double r, shared_ptr<material> m) : center(ctr), radius(r), mat(m) {}
 
     bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
         vec3 oc = r.origin() - center;
@@ -48,7 +47,7 @@ class sphere : public hittable {
         return true;
     }
 
-  public:
+  private:
     point3 center;
     double radius;
     shared_ptr<material> mat;

--- a/src/TheNextWeek/bvh.h
+++ b/src/TheNextWeek/bvh.h
@@ -21,8 +21,6 @@
 
 class bvh_node : public hittable {
   public:
-    bvh_node();
-
     bvh_node(const hittable_list& list) : bvh_node(list.objects, 0, list.objects.size()) {}
 
     bvh_node(const std::vector<shared_ptr<hittable>>& src_objects, size_t start, size_t end) {
@@ -68,12 +66,11 @@ class bvh_node : public hittable {
 
     aabb bounding_box() const override { return bbox; }
 
-  public:
+  private:
     shared_ptr<hittable> left;
     shared_ptr<hittable> right;
     aabb bbox;
 
-  private:
     static bool box_compare(
         const shared_ptr<hittable> a, const shared_ptr<hittable> b, int axis_index
     ) {

--- a/src/TheNextWeek/constant_medium.h
+++ b/src/TheNextWeek/constant_medium.h
@@ -77,7 +77,7 @@ class constant_medium : public hittable {
 
     aabb bounding_box() const override { return boundary->bounding_box(); }
 
-  public:
+  private:
     shared_ptr<hittable> boundary;
     double neg_inv_density;
     shared_ptr<material> phase_function;

--- a/src/TheNextWeek/hittable.h
+++ b/src/TheNextWeek/hittable.h
@@ -70,7 +70,7 @@ class translate : public hittable {
 
     aabb bounding_box() const override { return bbox; }
 
-  public:
+  private:
     shared_ptr<hittable> object;
     vec3 offset;
     aabb bbox;
@@ -146,7 +146,7 @@ class rotate_y : public hittable {
 
     aabb bounding_box() const override { return bbox; }
 
-  public:
+  private:
     shared_ptr<hittable> object;
     double sin_theta;
     double cos_theta;

--- a/src/TheNextWeek/hittable_list.h
+++ b/src/TheNextWeek/hittable_list.h
@@ -22,6 +22,8 @@
 
 class hittable_list : public hittable {
   public:
+    std::vector<shared_ptr<hittable>> objects;
+
     hittable_list() {}
     hittable_list(shared_ptr<hittable> object) { add(object); }
 
@@ -50,8 +52,7 @@ class hittable_list : public hittable {
 
     aabb bounding_box() const override { return bbox; }
 
-  public:
-    std::vector<shared_ptr<hittable>> objects;
+  private:
     aabb bbox;
 };
 

--- a/src/TheNextWeek/material.h
+++ b/src/TheNextWeek/material.h
@@ -49,7 +49,7 @@ class lambertian : public material {
         return true;
     }
 
-  public:
+  private:
     shared_ptr<texture> albedo;
 };
 
@@ -66,7 +66,7 @@ class metal : public material {
         return (dot(scattered.direction(), rec.normal) > 0);
     }
 
-  public:
+  private:
     color albedo;
     double fuzz;
 };
@@ -97,10 +97,9 @@ class dielectric : public material {
         return true;
     }
 
-  public:
+  private:
     double ir; // Index of Refraction
 
-  private:
     static double reflectance(double cosine, double ref_idx) {
         // Use Schlick's approximation for reflectance.
         auto r0 = (1-ref_idx) / (1+ref_idx);
@@ -124,7 +123,7 @@ class diffuse_light : public material {
         return emit->value(u, v, p);
     }
 
-  public:
+  private:
     shared_ptr<texture> emit;
 };
 
@@ -141,7 +140,7 @@ class isotropic : public material {
         return true;
     }
 
-  public:
+  private:
     shared_ptr<texture> albedo;
 };
 

--- a/src/TheNextWeek/moving_sphere.h
+++ b/src/TheNextWeek/moving_sphere.h
@@ -18,7 +18,6 @@
 
 class moving_sphere : public hittable {
   public:
-    moving_sphere() {}
     moving_sphere(point3 c0, point3 c1, double r, shared_ptr<material> m)
       : center0(c0), center1(c1), center_vec(c1 - c0), radius(r), mat(m)
     {
@@ -63,7 +62,7 @@ class moving_sphere : public hittable {
         return center0 + time * center_vec;
     }
 
-  public:
+  private:
     point3 center0, center1;
     vec3 center_vec;
     double radius;

--- a/src/TheNextWeek/scene.h
+++ b/src/TheNextWeek/scene.h
@@ -19,6 +19,15 @@
 
 class scene {
   public:
+    hittable_list world;
+    camera cam;
+
+    double aspect_ratio      = 1.0;
+    int    image_width       = 100;
+    int    samples_per_pixel = 10;
+    int    max_depth         = 50;
+    color  background        = color(0,0,0);
+
     void render() {
         const int image_height = static_cast<int>(image_width / aspect_ratio);
 
@@ -42,16 +51,6 @@ class scene {
 
         std::clog << "\rDone.                 \n";
     }
-
-  public:
-    hittable_list world;
-    camera cam;
-
-    double aspect_ratio      = 1.0;
-    int    image_width       = 100;
-    int    samples_per_pixel = 10;
-    int    max_depth         = 50;
-    color  background        = color(0,0,0);
 
   private:
     color ray_color(const ray& r, int depth) {

--- a/src/TheNextWeek/sphere.h
+++ b/src/TheNextWeek/sphere.h
@@ -18,8 +18,6 @@
 
 class sphere : public hittable {
   public:
-    sphere() {}
-
     sphere(point3 ctr, double r, shared_ptr<material> m) : center(ctr), radius(r), mat(m) {
         const auto rvec = vec3(radius, radius, radius);
         bbox = aabb(center - rvec, center + rvec);
@@ -55,13 +53,12 @@ class sphere : public hittable {
 
     aabb bounding_box() const override { return bbox; }
 
-  public:
+  private:
     point3 center;
     double radius;
     shared_ptr<material> mat;
     aabb bbox;
 
-  private:
     static void get_sphere_uv(const point3& p, double& u, double& v) {
         // p: a given point on the sphere of radius one, centered at the origin.
         // u: returned value [0,1] of angle around the Y axis from X=-1.

--- a/src/TheRestOfYourLife/bvh.h
+++ b/src/TheRestOfYourLife/bvh.h
@@ -21,8 +21,6 @@
 
 class bvh_node : public hittable {
   public:
-    bvh_node();
-
     bvh_node(const hittable_list& list) : bvh_node(list.objects, 0, list.objects.size()) {}
 
     bvh_node(const std::vector<shared_ptr<hittable>>& src_objects, size_t start, size_t end) {
@@ -68,12 +66,11 @@ class bvh_node : public hittable {
 
     aabb bounding_box() const override { return bbox; }
 
-  public:
+  private:
     shared_ptr<hittable> left;
     shared_ptr<hittable> right;
     aabb bbox;
 
-  private:
     static bool box_compare(
         const shared_ptr<hittable> a, const shared_ptr<hittable> b, int axis_index
     ) {

--- a/src/TheRestOfYourLife/constant_medium.h
+++ b/src/TheRestOfYourLife/constant_medium.h
@@ -77,7 +77,7 @@ class constant_medium : public hittable {
 
     aabb bounding_box() const override { return boundary->bounding_box(); }
 
-  public:
+  private:
     shared_ptr<hittable> boundary;
     double neg_inv_density;
     shared_ptr<material> phase_function;

--- a/src/TheRestOfYourLife/hittable.h
+++ b/src/TheRestOfYourLife/hittable.h
@@ -78,7 +78,7 @@ class translate : public hittable {
 
     aabb bounding_box() const override { return bbox; }
 
-  public:
+  private:
     shared_ptr<hittable> object;
     vec3 offset;
     aabb bbox;
@@ -154,7 +154,7 @@ class rotate_y : public hittable {
 
     aabb bounding_box() const override { return bbox; }
 
-  public:
+  private:
     shared_ptr<hittable> object;
     double sin_theta;
     double cos_theta;

--- a/src/TheRestOfYourLife/hittable_list.h
+++ b/src/TheRestOfYourLife/hittable_list.h
@@ -22,6 +22,8 @@
 
 class hittable_list : public hittable {
   public:
+    std::vector<shared_ptr<hittable>> objects;
+
     hittable_list() {}
     hittable_list(shared_ptr<hittable> object) { add(object); }
 
@@ -65,8 +67,7 @@ class hittable_list : public hittable {
         return objects[random_int(0, int_size-1)]->random(o);
     }
 
-  public:
-    std::vector<shared_ptr<hittable>> objects;
+  private:
     aabb bbox;
 };
 

--- a/src/TheRestOfYourLife/material.h
+++ b/src/TheRestOfYourLife/material.h
@@ -65,7 +65,7 @@ class lambertian : public material {
         return cos_theta < 0 ? 0 : cos_theta/pi;
     }
 
-  public:
+  private:
     shared_ptr<texture> albedo;
 };
 
@@ -84,7 +84,7 @@ class metal : public material {
         return true;
     }
 
-  public:
+  private:
     color albedo;
     double fuzz;
 };
@@ -116,10 +116,9 @@ class dielectric : public material {
         return true;
     }
 
-  public:
+  private:
     double ir; // Index of Refraction
 
-  private:
     static double reflectance(double cosine, double ref_idx) {
         // Use Schlick's approximation for reflectance.
         auto r0 = (1-ref_idx) / (1+ref_idx);
@@ -141,7 +140,7 @@ class diffuse_light : public material {
         return emit->value(u, v, p);
     }
 
-  public:
+  private:
     shared_ptr<texture> emit;
 };
 
@@ -163,7 +162,7 @@ class isotropic : public material {
         return 1 / (4 * pi);
     }
 
-  public:
+  private:
     shared_ptr<texture> albedo;
 };
 

--- a/src/TheRestOfYourLife/onb.h
+++ b/src/TheRestOfYourLife/onb.h
@@ -13,8 +13,7 @@
 
 #include "rtweekend.h"
 
-class onb
-{
+class onb {
   public:
     onb() {}
 
@@ -43,7 +42,7 @@ class onb
         axis[2] = unit_w;
     }
 
-  public:
+  private:
     vec3 axis[3];
 };
 

--- a/src/TheRestOfYourLife/pdf.h
+++ b/src/TheRestOfYourLife/pdf.h
@@ -39,7 +39,7 @@ class cosine_pdf : public pdf {
         return uvw.local(random_cosine_direction());
     }
 
-  public:
+  private:
     onb uvw;
 };
 
@@ -72,7 +72,7 @@ class hittable_pdf : public pdf {
         return objects.random(origin);
     }
 
-  public:
+  private:
     const hittable_list& objects;
     point3 origin;
 };
@@ -96,7 +96,7 @@ class mixture_pdf : public pdf {
             return p[1]->generate();
     }
 
-  public:
+  private:
     shared_ptr<pdf> p[2];
 };
 

--- a/src/TheRestOfYourLife/scene.h
+++ b/src/TheRestOfYourLife/scene.h
@@ -19,6 +19,16 @@
 
 class scene {
   public:
+    hittable_list world;
+    hittable_list lights;
+    camera        cam;
+
+    double aspect_ratio      = 1.0;
+    int    image_width       = 100;
+    int    samples_per_pixel = 10;
+    int    max_depth         = 20;
+    color  background        = color(0,0,0);
+
     void render() {
         const int image_height = static_cast<int>(image_width / aspect_ratio);
 
@@ -46,17 +56,6 @@ class scene {
 
         std::clog << "\rDone.                 \n";
     }
-
-  public:
-    hittable_list world;
-    hittable_list lights;
-    camera        cam;
-
-    double aspect_ratio      = 1.0;
-    int    image_width       = 100;
-    int    samples_per_pixel = 10;
-    int    max_depth         = 20;
-    color  background        = color(0,0,0);
 
   private:
     color ray_color(const ray& r, int depth) {

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -19,8 +19,6 @@
 
 class sphere : public hittable {
   public:
-    sphere() {}
-
     sphere(point3 ctr, double r, shared_ptr<material> m) : center(ctr), radius(r), mat(m) {
         const auto rvec = vec3(radius, radius, radius);
         bbox = aabb(center - rvec, center + rvec);
@@ -75,13 +73,12 @@ class sphere : public hittable {
         return uvw.local(random_to_sphere(radius, distance_squared));
     }
 
-  public:
+  private:
     point3 center;
     double radius;
     shared_ptr<material> mat;
     aabb bbox;
 
-  private:
     static void get_sphere_uv(const point3& p, double& u, double& v) {
         // p: a given point on the sphere of radius one, centered at the origin.
         // u: returned value [0,1] of angle around the Y axis from X=-1.

--- a/src/common/aabb.h
+++ b/src/common/aabb.h
@@ -16,6 +16,8 @@
 
 class aabb {
   public:
+    interval x, y, z;
+
     aabb() {} // The default AABB is empty, since intervals are empty by default.
 
     aabb(const interval& ix, const interval& iy, const interval& iz)
@@ -70,9 +72,6 @@ class aabb {
         }
         return true;
     }
-
-  public:
-    interval x, y, z;
 };
 
 aabb operator+(const aabb& bbox, const vec3& offset) {

--- a/src/common/camera.h
+++ b/src/common/camera.h
@@ -16,6 +16,14 @@
 
 class camera {
   public:
+    double vfov       = 40;
+    double aperture   = 0;
+    double focus_dist = 10;
+
+    point3 lookfrom = point3(0,0,-1);
+    point3 lookat   = point3(0,0,0);
+    vec3   vup      = vec3(0,1,0);
+
     void initialize(double aspect_ratio = 1.0) {
         auto theta = degrees_to_radians(vfov);
         auto h = tan(theta/2);
@@ -49,15 +57,6 @@ class camera {
             ray_time
         );
     }
-
-  public:
-    double vfov       = 40;
-    double aperture   = 0;
-    double focus_dist = 10;
-
-    point3 lookfrom = point3(0,0,-1);
-    point3 lookat   = point3(0,0,0);
-    vec3   vup      = vec3(0,1,0);
 
   private:
     point3 origin;

--- a/src/common/interval.h
+++ b/src/common/interval.h
@@ -11,6 +11,8 @@
 
 class interval {
   public:
+    double min, max;
+
     interval() : min(+infinity), max(-infinity) {} // Default interval is empty
 
     interval(double _min, double _max) : min(_min), max(_max) {}
@@ -42,9 +44,6 @@ class interval {
     }
 
     static const interval empty, universe;
-
-  public:
-    double min, max;
 };
 
 const interval interval::empty    = interval(+infinity, -infinity);

--- a/src/common/ray.h
+++ b/src/common/ray.h
@@ -17,6 +17,7 @@
 class ray {
   public:
     ray() {}
+
     ray(const point3& origin, const vec3& direction) : orig(origin), dir(direction), tm(0)
     {}
 
@@ -32,7 +33,7 @@ class ray {
         return orig + t*dir;
     }
 
-  public:
+  private:
     point3 orig;
     vec3 dir;
     double tm;

--- a/src/common/texture.h
+++ b/src/common/texture.h
@@ -27,7 +27,6 @@ class texture {
 
 class solid_color : public texture {
   public:
-    solid_color() {}
     solid_color(color c) : color_value(c) {}
 
     solid_color(double red, double green, double blue)
@@ -44,8 +43,6 @@ class solid_color : public texture {
 
 class checker_texture : public texture {
   public:
-    checker_texture() {}
-
     checker_texture(double _scale, shared_ptr<texture> _even, shared_ptr<texture> _odd)
       : inv_scale(1.0 / _scale), even(_even), odd(_odd) {}
 
@@ -65,7 +62,7 @@ class checker_texture : public texture {
         return isEven ? even->value(u, v, p) : odd->value(u, v, p);
     }
 
-  public:
+  private:
     double inv_scale;
     shared_ptr<texture> even;
     shared_ptr<texture> odd;
@@ -75,6 +72,7 @@ class checker_texture : public texture {
 class noise_texture : public texture {
   public:
     noise_texture() {}
+
     noise_texture(double sc) : scale(sc) {}
 
     color value(double u, double v, const point3& p) const override {
@@ -82,7 +80,7 @@ class noise_texture : public texture {
         return color(1,1,1)*0.5*(1 + sin(s.z() + 10*noise.turb(s)));
     }
 
-  public:
+  private:
     perlin noise;
     double scale;
 };
@@ -90,7 +88,6 @@ class noise_texture : public texture {
 
 class image_texture : public texture {
   public:
-    image_texture() {}
     image_texture(const char* filename) : image(filename) {}
 
     color value(double u, double v, const point3& p) const override {

--- a/src/common/vec3.h
+++ b/src/common/vec3.h
@@ -19,6 +19,8 @@ using std::fabs;
 
 class vec3 {
   public:
+    double e[3];
+
     vec3() : e{0,0,0} {}
     vec3(double e0, double e1, double e2) : e{e0, e1, e2} {}
 
@@ -69,9 +71,6 @@ class vec3 {
     static vec3 random(double min, double max) {
         return vec3(random_double(min,max), random_double(min,max), random_double(min,max));
     }
-
-  public:
-    double e[3];
 };
 
 // point3 is just an alias for vec3, but useful for geometric clarity in the code.


### PR DESCRIPTION
This includes a number of whole-codebase changes to tidy up some inconsistent aspects of our classes, and to firm up class interfaces.

- If class clients are expected to write or read member variables, those variables must be public, and are listed at the top of the class, immediately after the leading `public:` specifier. Constructors follow, followed by other public methods. After this is the `private:` section, beginning with private member variables, and concluding with other private functions.

- Some classes are effectively immutable. Such classes should generally not have a default constructor unless such an object has useful meaning or other utility. These are basically classes with useful constructors and a body of private resulting member variables.

- Fix some indentation errors in the books in code listings.

- Tweaked some blank line spacing.

- Fixed some code listing highlighting.

All code recompiled, all renders executed and validated.

Resolves #869