### PR TITLE
Add comment about final render image 1 SPP

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -3475,7 +3475,7 @@ scene with its own helper function:
     void random_spheres(scene& scene_desc) {
         scene_desc.aspect_ratio      = 16.0 / 9.0;
         scene_desc.image_width       = 1200;
-        scene_desc.samples_per_pixel = 10;
+        scene_desc.samples_per_pixel = 500;
 
         scene_desc.cam.lookfrom   = vec3(13,2,3);
         scene_desc.cam.lookat     = vec3(0,0,0);
@@ -3536,6 +3536,11 @@ scene with its own helper function:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-final]: <kbd>[main.cc]</kbd> Final scene]
 </div>
+
+(Note that the code above differs slightly from the project sample code: the `samples_per_pixel` is
+set to 500 above for a high-quality image that will take quite a while to render.
+The sample code uses a value of 10 in the interest of reasonable run times while developing and
+validating.)
 
 <div class='together'>
 This gives:


### PR DESCRIPTION
The code in the book has `samples_per_pixel = 500`, while the code in the codebase has `samples_per_pixel = 10`. Add explanatory note and warning for the reader.

This change also fixes an accidental reversion to the sample code value.

Resolves #908