### PR TITLE
Redo keep-together markup

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -130,6 +130,7 @@ Let’s make some C++ code to output such a thing:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-initial]: <kbd>[main.cc]</kbd> Creating your first image]
+
 </div>
 
 There are some things to note in that code:
@@ -149,7 +150,6 @@ There are some things to note in that code:
 
 Creating an Image File
 -----------------------
-<div class='together'>
 Because the file is written to the program output, you'll need to redirect it to an image file.
 Typically this is done from the command-line by using the `>` redirection operator, like so:
 
@@ -162,17 +162,12 @@ This is how things would look on Windows. On Mac or Linux, it would look like th
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     build/inOneWeekend > image.ppm
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-</div>
 
-<div class='together'>
 Opening the output file (in `ToyViewer` on my Mac, but try it in your favorite viewer and Google
 “ppm viewer” if your viewer doesn’t support it) shows this result:
 
   ![Image 1: First PPM image](../images/img-1.01-first-ppm-image.png class=pixel)
 
-</div>
-
-<div class='together'>
 Hooray! This is the graphics “hello world”. If your image doesn’t look like that, open the output
 file in a text editor and see what it looks like. It should start something like this:
 
@@ -193,7 +188,6 @@ file in a text editor and see what it looks like. It should start something like
     ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [first-img]: First image output]
-</div>
 
 If your PPM file doesn't look like this, then double-check your formatting code.
 If it _does_ look like this, then you may have line-ending differences or something similar that is
@@ -244,6 +238,7 @@ instead write to the logging output stream (`std::clog`):
         std::clog << "\rDone.                 \n";
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-progress]: <kbd>[main.cc]</kbd> Main render loop with progress reporting]
+
 </div>
 
 
@@ -261,7 +256,6 @@ types are just aliases for `vec3`, you won't get warnings if you pass a `color` 
 expecting a `point3`, and nothing is stopping you from adding a `point3` to a `color`, but it makes
 the code a little bit easier to read and understand.
 
-<div class='together'>
 We define the `vec3` class in the top half of a new `vec3.h` header file, and a set of useful vector
 utility functions in the bottom half:
 
@@ -369,7 +363,6 @@ utility functions in the bottom half:
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [vec3-class]: <kbd>[vec3.h]</kbd> vec3 definitions and helper functions]
-</div>
 
 We use `double` here, but some ray tracers use `float`. `double` has greater precision and range,
 but is twice the size compared to `float`. This increase in size may be important if you're
@@ -402,8 +395,6 @@ the standard output stream.
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [color]: <kbd>[color.h]</kbd> color utility functions]
-
-
 
 <div class='together'>
 Now we can change our main to use this:
@@ -441,8 +432,9 @@ Now we can change our main to use this:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ppm-2]: <kbd>[main.cc]</kbd> Final code for the first PPM image]
 
-And you should get the exact same picture as before.
 </div>
+
+And you should get the exact same picture as before.
 
 
 
@@ -451,7 +443,6 @@ Rays, a Simple Camera, and Background
 
 The ray Class
 --------------
-<div class='together'>
 The one thing that all ray tracers have is a ray class and a computation of what color is seen along
 a ray. Let’s think of a ray as a function $\mathbf{P}(t) = \mathbf{A} + t \mathbf{b}$. Here
 $\mathbf{P}$ is a 3D position along a line in 3D. $\mathbf{A}$ is the ray origin and $\mathbf{b}$ is
@@ -461,8 +452,6 @@ can go anywhere on the 3D line. For positive $t$, you get only the parts in fron
 and this is what is often called a half-line or ray.
 
   ![Figure [lerp]: Linear interpolation](../images/fig-1.02-lerp.jpg)
-
-</div>
 
 <div class='together'>
 We can represent the idea of a ray as a class, and represent the function $\mathbf{P}(t)$ as a
@@ -497,6 +486,7 @@ function that I call `ray::at(t)`:
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-initial]: <kbd>[ray.h]</kbd> The ray class]
+
 </div>
 
 
@@ -612,9 +602,9 @@ Below in code, the ray `r` goes to the current image pixel:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-blue-white-blend]: <kbd>[main.cc]</kbd> Rendering a blue-to-white gradient]
+
 </div>
 
-<div class='together'>
 The `ray_color(ray)` function linearly blends white and blue depending on the height of the $y$
 coordinate _after_ scaling the ray direction to unit length (so $-1.0 < y < 1.0$).
 Because we're looking at the $y$ height after normalizing the vector, you'll notice a horizontal
@@ -631,6 +621,8 @@ A lerp is always of the form
   $$ \text{blendedValue} = (1-a)\cdot\text{startValue} + a\cdot\text{endValue}, $$
 
 with $a$ going from zero to one.
+
+<div class='together'>
 In our case this produces:
 
   ![Image 2: A blue-to-white gradient depending on ray Y coordinate
@@ -648,7 +640,6 @@ calculating whether a ray hits a sphere is pretty straightforward.
 
 Ray-Sphere Intersection
 ------------------------
-<div class='together'>
 Recall that the equation for a sphere of radius $r$ that is centered at the origin is:
 
     $$ x^2 + y^2 + z^2 = r^2 $$
@@ -660,9 +651,7 @@ $x^2 + y^2 + z^2 > r^2$. If we want to allow the sphere center to be at an arbit
 $(C_x, C_y, C_z)$, then the equation becomes a lot less nice:
 
   $$ (x - C_x)^2 + (y - C_y)^2 + (z - C_z)^2 = r^2 $$
-</div>
 
-<div class='together'>
 In graphics, you almost always want your formulas to be in terms of vectors so that all the
 $x$/$y$/$z$ stuff can be simply represented using a `vec3` class. You might note that the vector
 from center $\mathbf{C} = (C_x, C_y, C_z)$ to point $\mathbf{P} = (x,y,z)$ is
@@ -675,9 +664,7 @@ $(\mathbf{P} - \mathbf{C})$. If we use the definition of the dot product:
 Then we can rewrite the equation of the sphere in vector form as:
 
   $$ (\mathbf{P} - \mathbf{C}) \cdot (\mathbf{P} - \mathbf{C}) = r^2 $$
-</div>
 
-<div class='together'>
 We can read this as “any point $\mathbf{P}$ that satisfies this equation is on the sphere”. We want
 to know if our ray $\mathbf{P}(t) = \mathbf{A} + t\mathbf{b}$ ever hits the sphere anywhere. If it
 does hit the sphere, there is some $t$ for which $\mathbf{P}(t)$ satisfies the sphere equation. So
@@ -689,9 +676,7 @@ which can be found by replacing $\mathbf{P}(t)$ with its expanded form:
 
   $$ ((\mathbf{A} + t \mathbf{b}) - \mathbf{C})
       \cdot ((\mathbf{A} + t \mathbf{b}) - \mathbf{C}) = r^2 $$
-</div>
 
-<div class='together'>
 We have three vectors on the left dotted by three vectors on the right. If we solved for the full
 dot product we would get nine vectors. You can definitely go through and write everything out, but
 we don't need to work that hard. If you remember, we want to solve for $t$, so we'll separate the
@@ -713,9 +698,7 @@ Move the square of the radius over to the left hand side:
      + 2t \mathbf{b} \cdot (\mathbf{A}-\mathbf{C})
      + (\mathbf{A}-\mathbf{C}) \cdot (\mathbf{A}-\mathbf{C}) - r^2 = 0
   $$
-</div>
 
-<div class='together'>
 It's hard to make out what exactly this equation is, but the vectors and $r$ in that equation are
 all constant and known. Furthermore, the only vectors that we have are reduced to scalars by dot
 product. The only unknown is $t$, and we have a $t^2$, which means that this equation is quadratic.
@@ -736,12 +719,9 @@ we have is:
 
   ![Figure [ray-sphere]: Ray-sphere intersection results](../images/fig-1.04-ray-sphere.jpg)
 
-</div>
-
 
 Creating Our First Raytraced Image
 -----------------------------------
-<div class='together'>
 If we take that math and hard-code it into our program, we can test it by coloring red any pixel
 that hits a small sphere we place at -1 on the z-axis:
 
@@ -769,7 +749,6 @@ that hits a small sphere we place at -1 on the z-axis:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-red-sphere]: <kbd>[main.cc]</kbd> Rendering a red sphere]
-</div>
 
 <div class='together'>
 What we get is this:
@@ -802,7 +781,6 @@ the direction of the hit point minus the center:
 
   ![Figure [sphere-normal]: Sphere surface-normal geometry](../images/fig-1.05-sphere-normal.jpg)
 
-<div class='together'>
 On the earth, this implies that the vector from the earth’s center to you points straight up. Let’s
 throw that into the code now, and shade it. We don’t have any lights or anything yet, so let’s just
 visualize the normals with a color map. A common trick used for visualizing normals (because it’s
@@ -846,7 +824,6 @@ won't worry about negative values of $t$ yet. We'll just assume the closest hit 
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [render-surface-normal]: <kbd>[main.cc]</kbd> Rendering surface normals on a sphere]
-</div>
 
 <div class='together'>
 And that yields this picture:
@@ -891,6 +868,7 @@ quadratic equation if $b = 2h$:
 
   $$ = \frac{-h \pm \sqrt{h^2 - ac}}{a} $$
 
+<div class='together'>
 Using these observations, we can now simplify the sphere-intersection code to this:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -914,6 +892,8 @@ Using these observations, we can now simplify the sphere-intersection code to th
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-sphere-after]: <kbd>[main.cc]</kbd> Ray-sphere intersection code (after)]
 
+</div>
+
 
 An Abstraction for Hittable Objects
 ------------------------------------
@@ -924,7 +904,6 @@ quandary -- calling it an “object” would be good if not for “object orient
 is often used, with the weakness being maybe we will want volumes. “hittable” emphasizes the member
 function that unites them. I don’t love any of these, but I will go with “hittable”.
 
-<div class='together'>
 This `hittable` abstract class will have a hit function that takes in a ray. Most ray tracers have
 found it convenient to add a valid interval for hits $t_{\mathit{min}}$ to $t_{\mathit{max}}$, so
 the hit only “counts” if $t_{\mathit{min}} < t < t_{\mathit{max}}$. For the initial rays this is
@@ -957,7 +936,6 @@ bundle of stuff I will store in some structure. Here’s the abstract class:
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [hittable-initial]: <kbd>[hittable.h]</kbd> The hittable class]
-</div>
 
 <div class='together'>
 And here’s the sphere:
@@ -1012,7 +990,6 @@ And here’s the sphere:
 
 Front Faces Versus Back Faces
 ------------------------------
-<div class='together'>
 The second design decision for normals is whether they should always point out. At present, the
 normal found will always be in the direction of the center to the intersection point (the normal
 points out). If the ray intersects the sphere from the outside, the normal points against the ray.
@@ -1023,8 +1000,6 @@ point inward.
 
   ![Figure [normal-sides]: Possible directions for sphere surface-normal geometry
   ](../images/fig-1.06-normal-sides.jpg)
-
-</div>
 
 We need to choose one of these possibilities because we will eventually want to determine which
 side of the surface that the ray is coming from. This is important for objects that are rendered
@@ -1049,7 +1024,7 @@ sphere.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-normal-comparison]: Comparing the ray and the normal]
 
-
+<div class='together'>
 If we decide to have the normals always point against the ray, we won't be able to use the dot
 product to determine which side of the surface the ray is on. Instead, we would need to store that
 information:
@@ -1067,6 +1042,8 @@ information:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [normals-point-against]: Remembering the side of the surface]
+
+</div>
 
 We can set things up so that normals always point “outward” from the surface, or always point
 against the incident ray. This decision is determined by whether you want to determine the side of
@@ -1133,7 +1110,6 @@ And then we add the surface side determination to the class:
 
 A List of Hittable Objects
 ---------------------------
-<div class='together'>
 We have a generic object called a `hittable` that the ray can intersect with. We now add a class
 that stores a list of `hittable`s:
 
@@ -1182,7 +1158,6 @@ that stores a list of `hittable`s:
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [hittable-list-initial]: <kbd>[hittable_list.h]</kbd> The hittable_list class]
-</div>
 
 
 Some New C++ Features
@@ -1205,9 +1180,12 @@ Typically, a shared pointer is first initialized with a newly-allocated object, 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [shared-ptr]: An example allocation using shared_ptr]
 
+</div>
+
 `make_shared<thing>(thing_constructor_params ...)` allocates a new instance of type `thing`, using
 the constructor parameters. It returns a `shared_ptr<thing>`.
 
+<div class='together'>
 Since the type can be automatically deduced by the return type of `make_shared<type>(...)`, the
 above lines can be more simply expressed using C++'s `auto` type specifier:
 
@@ -1240,7 +1218,6 @@ getting `shared_ptr` and `make_shared` from the `std` library, so we don't need 
 
 Common Constants and Utility Functions
 ---------------------------------------
-<div class='together'>
 We need some math constants that we conveniently define in their own header file. For now we only
 need infinity, but we will also throw our own definition of pi in there, which we will need later.
 There is no standard portable definition of pi, so we just define our own constant for it. We'll
@@ -1281,7 +1258,6 @@ file.
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [rtweekend-initial]: <kbd>[rtweekend.h]</kbd> The rtweekend.h common header]
-</div>
 
 <div class='together'>
 And the new main:
@@ -1369,16 +1345,15 @@ And the new main:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-with-rtweekend-h]: <kbd>[main.cc]</kbd> The new main with hittables]
+
 </div>
 
-<div class='together'>
 This yields a picture that is really just a visualization of where the spheres are along with their
 surface normal. This is often a great way to look at your model for flaws and characteristics.
 
   ![Image 5: Resulting render of normals-colored sphere with ground
   ](../images/img-1.05-normals-sphere-ground.png class=pixel)
 
-</div>
 
 An Interval Class
 ------------------
@@ -1529,6 +1504,7 @@ When everything's been set, it will call the `render()` method.
 The `render()` method will set up the camera by calling the `initialize()` function, and then
   running the render loop.
 
+<div class='together'>
 Here's the skeleton of the new `camera` class:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1564,6 +1540,9 @@ Here's the skeleton of the new `camera` class:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [camera-skeleton]: <kbd>[camera.h]</kbd> The camera class skeleton]
 
+</div>
+
+<div class='together'>
 To begin with, let's fill in the `ray_color()` function from `main.cc`:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1592,6 +1571,9 @@ To begin with, let's fill in the `ray_color()` function from `main.cc`:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [camera-ray-color]: <kbd>[camera.h]</kbd> The camera::ray_color function]
 
+</div>
+
+<div class='together'>
 Now we move almost everything from the `main()` function into our new camera class.
 The only thing remaining in the `main()` function is the world construction.
 Here's the camera class with newly migrated code:
@@ -1665,6 +1647,9 @@ Here's the camera class with newly migrated code:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [camera-working]: <kbd>[camera.h]</kbd> The working camera class]
 
+</div>
+
+<div class='together'>
 And here's the much reduced main:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -1689,6 +1674,8 @@ And here's the much reduced main:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-with-new-camera]: <kbd>[main.cc]</kbd> The new main, using the new camera]
 
+</div>
+
 
 
 Antialiasing
@@ -1706,7 +1693,6 @@ One thing we need is a random number generator that returns real random numbers.
 that returns a canonical random number which by convention returns a random real in the range
 $0 ≤ r < 1$. The “less than” before the 1 is important as we will sometimes take advantage of that.
 
-<div class='together'>
 A simple approach to this is to use the `rand()` function that can be found in `<cstdlib>`. This
 function returns a random integer in the range 0 and `RAND_MAX`. Hence we can get a real random
 number as desired with the following code snippet, added to `rtweekend.h`:
@@ -1726,9 +1712,7 @@ number as desired with the following code snippet, added to `rtweekend.h`:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [random-double]: <kbd>[rtweekend.h]</kbd> random_double() functions]
-</div>
 
-<div class='together'>
 C++ did not traditionally have a standard random number generator, but newer versions of C++ have
 addressed this issue with the `<random>` header (if imperfectly according to some experts).
 If you want to use this, you can obtain a random number with the conditions we need as follows:
@@ -1743,18 +1727,14 @@ If you want to use this, you can obtain a random number with the conditions we n
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [random-double-alt]: <kbd>[rtweekend.h]</kbd> random_double(), alternate implemenation]
-</div>
 
 
 Generating Pixels with Multiple Samples
 ----------------------------------------
-<div class='together'>
 For a given pixel we have several samples within that pixel and send rays through each of the
 samples. The colors of these rays are then averaged:
 
   ![Figure [pixel-samples]: Pixel samples](../images/fig-1.07-pixel-samples.jpg)
-
-</div>
 
 To handle the multi-sampled color computation, we'll update the `write_color()` function. Rather
 than adding in a fractional contribution each time we accumulate more light to the color, just add
@@ -1799,6 +1779,7 @@ samples) when writing out the color. In addition, we'll add a handy utility func
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [write-color-clamped]: <kbd>[color.h]</kbd> The multi-sample write_color() function]
 
+<div class='together'>
 Update the camera class to incorporate multiple samples per pixel:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1855,6 +1836,9 @@ Update the camera class to incorporate multiple samples per pixel:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [camera-spp]: <kbd>[camera.h]</kbd> Camera with samples-per-pixel parameter]
 
+</div>
+
+<div class='together'>
 Main is updated to set the new camera parameter.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1872,10 +1856,15 @@ Main is updated to set the new camera parameter.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-spp]: <kbd>[main.cc]</kbd> Setting the new samples-per-pixel parameter]
 
+</div>
+
+<div class='together'>
 Zooming into the image that is produced, we can see the difference in edge pixels.
 
   ![Image 6: Before and after antialiasing
   ](../images/img-1.06-antialias-before-after.png class=pixel)
+
+</div>
 
 
 
@@ -1890,7 +1879,6 @@ do be aware that there are alternative approaches.
 
 A Simple Diffuse Material
 --------------------------
-<div class='together'>
 Diffuse objects that don’t emit light merely take on the color of their surroundings, but they
 modulate that with their own intrinsic color. Light that reflects off a diffuse surface has its
 direction randomized. So, if we send three rays into a crack between two diffuse surfaces they will
@@ -1898,19 +1886,14 @@ each have different random behavior:
 
   ![Figure [light-bounce]: Light ray bounces](../images/fig-1.08-light-bounce.jpg)
 
-</div>
-
-<div class='together'>
 They might also be absorbed rather than reflected. The darker the surface, the more likely
 the ray is absorbed (that’s why it's dark!). Really any algorithm that randomizes direction will
 produce surfaces that look matte. Let's start with the most intuitive: a surface that randomly
 bounces a ray equally in all directions. For this material, a ray that hits the surface has an
 equal probability of bouncing in any direction away from the surface.
 
-
   ![Figure [random-vec-hor]: Equal reflection above the horizon
   ](../images/fig-1.09-random-vec-horizon.jpg)
-
 
 This very intuitive material is the simplest kind of diffuse and -- indeed -- many of the first
 raytracing papers used this diffuse method (before adopting a more accurate method that we'll be
@@ -1932,9 +1915,6 @@ generate arbitrary random vectors:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [vec-rand-util]: <kbd>[vec3.h]</kbd> vec3 random utility functions]
 
-</div>
-
-<div class='together'>
 Then we need to figure out how to manipulate a random vector so that we only get results that are on
 the surface of a hemisphere. There are analytical methods of doing this, but they are actually
 surprisingly complicated to understand, and quite a bit complicated to implement. Instead, we'll use
@@ -1949,6 +1929,7 @@ method, but for our purposes we will go with the simplest, which is:
 2. Normalize this vector
 3. Invert the normalized vector if it falls onto the wrong hemisphere
 
+<div class='together'>
 First, we will use a rejection method to generate the random vector inside of the unit sphere. Pick
 a random point in the unit cube, where $x$, $y$, and $z$ all range from -1 to +1, and reject this
 point if it is outside the unit sphere.
@@ -1967,6 +1948,7 @@ point if it is outside the unit sphere.
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [random-in-unit-sphere]: <kbd>[vec3.h]</kbd> The random_in_unit_sphere() function]
+
 </div>
 
 <div class='together'>
@@ -1983,12 +1965,18 @@ unit sphere.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [random-unit-vec]: <kbd>[vec3.h]</kbd> Random vector on the unit sphere]
 
+</div>
+
+<div class='together'>
 And now that we have a random vector on the surface of the unit sphere, we can determine if it is on
 the correct hemisphere by comparing against the surface normal:
 
   ![Figure [normal-hor]: The normal vector tells us which hemisphere we need
   ](../images/fig-1.12-surface-normal.jpg)
 
+</div>
+
+<div class='together'>
 We can take the dot product of the surface normal and our random vector to determine if it's in the
 correct hemisphere. If the dot product is positive, then the vector is in the correct hemisphere. If
 the dot product is negative, then we need to invert the vector.
@@ -2003,9 +1991,9 @@ the dot product is negative, then we need to invert the vector.
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [random-in-hemisphere]: <kbd>[vec3.h]</kbd> The random_in_hemisphere() function]
+
 </div>
 
-<div class='together'>
 If a ray bounces off of a material and keeps 100% of its color, then we say that the material is
 _white_. If a ray bounces off of a material and keeps 0% of its color, then we say that the
 material is black. As a first demonstration of our new diffuse material we'll set the `ray_color`
@@ -2034,6 +2022,7 @@ function to return 50% of the color from a bounce. We should expect to get a nic
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-random-unit]: <kbd>[main.cc]</kbd> ray_color() using a random ray direction]
 
+<div class='together'>
 ... Indeed we do get rather nice gray spheres:
 
   ![Image 7: Rendering of diffuse spheres with hemispherical scattering
@@ -2044,7 +2033,6 @@ function to return 50% of the color from a bounce. We should expect to get a nic
 
 Limiting the Number of Child Rays
 ----------------------------------
-<div class='together'>
 There's one potential problem lurking here. Notice that the `ray_color` function is recursive. When
 will it stop recursing? When it fails to hit anything. In some cases, however, that may be a long
 time — long enough to blow the stack. To guard against that, let's limit the maximum recursion
@@ -2110,7 +2098,6 @@ depth, returning no light contribution at the maximum depth:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-depth]: <kbd>[camera.h]</kbd> camera::ray_color() with depth limiting]
-</div>
 
 <div class='together'>
 Update the main() function to use this new depth limit:
@@ -2129,6 +2116,7 @@ Update the main() function to use this new depth limit:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-ray-depth]: <kbd>[main.cc]</kbd> Using the new ray depth limiting]
+
 </div>
 
 <div class='together'>
@@ -2141,7 +2129,6 @@ For this very simple scene we should get basically the same result:
 
 Using Gamma Correction for Accurate Color Intensity
 ----------------------------------------------------
-<div class='together'>
 Note the shadowing under the sphere. The picture is very dark, but our spheres only absorb half the
 energy of each bounce, so they are 50% reflectors. The spheres should look pretty bright (in real
 life, a light grey) but they appear to be rather dark. The reason for this is that almost all
@@ -2194,8 +2181,6 @@ $1/\mathit{gamma}$, which is just the square-root:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [write-color-gamma]: <kbd>[color.h]</kbd> write_color(), with gamma correction]
 
-</div>
-
 <div class='together'>
 This yields light grey, which is more accurate:
 
@@ -2207,7 +2192,6 @@ This yields light grey, which is more accurate:
 
 Fixing Shadow Acne
 -------------------
-<div class='together'>
 There’s also a subtle bug that we need to address. A ray will attempt to accurately calculate the
 intersection point when it intersects with a surface. Unfortunately for us, this calculation is
 susceptible to floating point rounding errors which can cause the intersection point to be ever so
@@ -2248,12 +2232,10 @@ to address this is just to ignore hits that are very close to the calculated int
     Calculating reflected ray origins with tolerance]
 
 This gets rid of the shadow acne problem. Yes it is really called that.
-</div>
 
 
 True Lambertian Reflection
 ---------------------------
-<div class='together'>
 Using a diffuse model that scatters vectors evenly about the hemisphere produces a nice and soft
 diffuse model, but we can definitely do better. A more accurate representation of real diffuse
 objects is the _Lambertian_ distribution, which has a scattering distribution that is propertional
@@ -2285,8 +2267,6 @@ point $\mathbf{P}$ to the random point $\mathbf{S}$ (this is the vector $(\mathb
   ![Figure [rand-unitvec]: Randomly generating a vector according to Lambertian distribution
   ](../images/fig-1.13-rand-unitvec.jpg)
 
-</div>
-
 <div class='together'>
 The change is actually fairly minimal:
 
@@ -2314,6 +2294,7 @@ The change is actually fairly minimal:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-unit-sphere]: <kbd>[camera.h]</kbd> ray_color() with replacement diffuse]
+
 </div>
 
 <div class='together'>
@@ -2321,6 +2302,8 @@ After rendering we get a similar image:
 
   ![Image 10: Correct rendering of Lambertian spheres
   ](../images/img-1.09-correct-lambertian.png class=pixel)
+
+</div>
 
 It's hard to tell the difference between these two diffuse methods, given that our scene of two
 spheres is so simple, but you should be able to notice two important visual differences:
@@ -2338,7 +2321,7 @@ objects behave under light can be poorly formed. As scenes become more complicat
 of the book, you are encouraged to switch between the different diffuse renderers presented here.
 Most scenes of interest will contain a large amount of diffuse materials. You can gain valuable
 insight by understanding the effect of different diffuse methods on the lighting of the scene.
-</div>
+
 
 
 Metal
@@ -2377,12 +2360,12 @@ This suggests the abstract class:
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [material-initial]: <kbd>[material.h]</kbd> The material class]
+
 </div>
 
 
 A Data Structure to Describe Ray-Object Intersections
 ------------------------------------------------------
-<div class='together'>
 The `hit_record` is to avoid a bunch of arguments so we can stuff whatever info we want in there.
 You can use arguments instead; it’s a matter of taste. Hittables and materials need to know each
 other so there is some circularity of the references. In C++ you just need to alert the compiler
@@ -2413,7 +2396,6 @@ that the pointer is to a class, which the “class material” in the hittable c
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [hit-with-material]: <kbd>[hittable.h]</kbd> Hit record with added material pointer]
-</div>
 
 What we have set up here is that material will tell us how rays interact with the surface.
 `hit_record` is just a way to stuff a bunch of arguments into a class so we can send them as a
@@ -2458,12 +2440,12 @@ within `hit_record`. See the highlighted lines below:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [sphere-material]: <kbd>[sphere.h]</kbd>
     Ray-sphere intersection with added material information]
+
 </div>
 
 
 Modeling Light Scatter and Reflectance
 ---------------------------------------
-<div class='together'>
 For the Lambertian (diffuse) case we already have, it can either scatter always and attenuate by its
 reflectance $R$, or it can scatter with no attenuation but absorb the fraction $1-R$ of the rays, or
 it could be a mixture of those strategies. For Lambertian materials we get this simple class:
@@ -2486,7 +2468,6 @@ it could be a mixture of those strategies. For Lambertian materials we get this 
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [lambertian-initial]: <kbd>[material.h]</kbd> The lambertian material class]
-</div>
 
 Note we could just as well only scatter with some probability $p$ and have attenuation be
 $\mathit{albedo}/p$. Your choice.
@@ -2496,7 +2477,6 @@ vector we generate is exactly opposite the normal vector, the two will sum to ze
 result in a zero scatter direction vector. This leads to bad scenarios later on (infinities and
 NaNs), so we need to intercept the condition before we pass it on.
 
-<div class='together'>
 In service of this, we'll create a new vector method -- `vec3::near_zero()` -- that returns true if
 the vector is very close to zero in all dimensions.
 
@@ -2539,20 +2519,15 @@ the vector is very close to zero in all dimensions.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [lambertian-catch-zero]: <kbd>[material.h]</kbd> Lambertian scatter, bullet-proof]
-</div>
 
 
 Mirrored Light Reflection
 --------------------------
-<div class='together'>
 For smooth metals the ray won’t be randomly scattered. The key math is: how does a ray get
 reflected from a metal mirror? Vector math is our friend here:
 
   ![Figure [reflection]: Ray reflection](../images/fig-1.11-reflection.jpg)
 
-</div>
-
-<div class='together'>
 The reflected ray direction in red is just $\mathbf{v} + 2\mathbf{b}$. In our design, $\mathbf{n}$
 is a unit vector, but $\mathbf{v}$ may not be. The length of $\mathbf{b}$ should be $\mathbf{v}
 \cdot \mathbf{n}$. Because $\mathbf{v}$ points in, we will need a minus sign, yielding:
@@ -2563,7 +2538,6 @@ is a unit vector, but $\mathbf{v}$ may not be. The length of $\mathbf{b}$ should
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [vec3-reflect]: <kbd>[vec3.h]</kbd> vec3 reflection function]
-</div>
 
 <div class='together'>
 The metal material just reflects rays using that formula:
@@ -2586,6 +2560,7 @@ The metal material just reflects rays using that formula:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [metal-material]: <kbd>[material.h]</kbd> Metal material with reflectance function]
+
 </div>
 
 <div class='together'>
@@ -2624,12 +2599,12 @@ We need to modify the `ray_color()` function to use this:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-scatter]: <kbd>[camera.h]</kbd> Ray color with scattered reflectance]
+
 </div>
 
 
 A Scene with Metal Spheres
 ---------------------------
-<div class='together'>
 Now let’s add some metal spheres to our scene:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2671,7 +2646,6 @@ Now let’s add some metal spheres to our scene:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-with-metal]: <kbd>[main.cc]</kbd> Scene with metal spheres]
-</div>
 
 <div class='together'>
 Which gives:
@@ -2683,15 +2657,11 @@ Which gives:
 
 Fuzzy Reflection
 -----------------
-<div class='together'>
 We can also randomize the reflected direction by using a small sphere and choosing a new endpoint
 for the ray:
 
   ![Figure [reflect-fuzzy]: Generating fuzzed reflection rays](../images/fig-1.12-reflect-fuzzy.jpg)
 
-</div>
-
-<div class='together'>
 The bigger the sphere, the fuzzier the reflections will be. This suggests adding a fuzziness
 parameter that is just the radius of the sphere (so zero is no perturbation). The catch is that for
 big spheres or grazing rays, we may scatter below the surface. We can just have the surface
@@ -2723,8 +2693,7 @@ absorb those.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [metal-fuzz]: <kbd>[material.h]</kbd> Metal material fuzziness]
 
-</div>
-
+<div class='together'>
 We can try that out by adding fuzziness 0.3 and 1.0 to the metals:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2743,6 +2712,7 @@ We can try that out by adding fuzziness 0.3 and 1.0 to the metals:
 
   ![Image 12: Fuzzed metal](../images/img-1.12-metal-fuzz.png class=pixel)
 
+</div>
 
 
 
@@ -2755,14 +2725,11 @@ choosing between reflection or refraction, and only generating one scattered ray
 
 Refraction
 -----------
-<div class='together'>
 The hardest part to debug is the refracted ray. I usually first just have all the light refract if
 there is a refraction ray at all. For this project, I tried to put two glass balls in our scene, and
 I got this (I have not told you how to do this right or wrong yet, but soon!):
 
   ![Image 13: Glass first](../images/img-1.13-glass-first.png class=pixel)
-
-</div>
 
 Is that right? Glass balls look odd in real life. But no, it isn’t right. The world should be
 flipped upside down and no weird black stuff. I just printed out the ray straight through the middle
@@ -2771,7 +2738,6 @@ of the image and it was clearly wrong. That often does the job.
 
 Snell's Law
 ------------
-<div class='together'>
 The refraction is described by Snell’s law:
 
   $$ \eta \cdot \sin\theta = \eta' \cdot \sin\theta' $$
@@ -2782,9 +2748,6 @@ Where $\theta$ and $\theta'$ are the angles from the normal, and $\eta$ and $\et
 
   ![Figure [refraction]: Ray refraction](../images/fig-1.13-refraction.jpg)
 
-</div>
-
-<div class='together'>
 In order to determine the direction of the refracted ray, we have to solve for $\sin\theta'$:
 
   $$ \sin\theta' = \frac{\eta}{\eta'} \cdot \sin\theta $$
@@ -2817,6 +2780,7 @@ We can now rewrite $\mathbf{R'}_{\bot}$ in terms of known quantities:
   $$ \mathbf{R'}_{\bot} =
      \frac{\eta}{\eta'} (\mathbf{R} + (\mathbf{-R} \cdot \mathbf{n}) \mathbf{n}) $$
 
+<div class='together'>
 When we combine them back together, we can write a function to calculate $\mathbf{R'}$:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2828,6 +2792,7 @@ When we combine them back together, we can write a function to calculate $\mathb
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [refract]: <kbd>[vec3.h]</kbd> Refraction function]
+
 </div>
 
 <div class='together'>
@@ -2873,10 +2838,13 @@ Now we'll update the scene to change the left and center spheres to glass:
 
 </div>
 
+<div class='together'>
 This gives us the following result:
 
   ![Image 14: Glass sphere that always refracts
   ](../images/img-1.14-glass-always-refract.png class=pixel)
+
+</div>
 
 
 Total Internal Reflection
@@ -2891,11 +2859,11 @@ If the ray is inside glass and outside is air ($\eta = 1.5$ and $\eta' = 1.0$):
 
   $$ \sin\theta' = \frac{1.5}{1.0} \cdot \sin\theta $$
 
+<div class='together'>
 The value of $\sin\theta'$ cannot be greater than 1. So, if,
 
-  $$ \frac{1.5}{1.0} \cdot \sin\theta > 1.0 $$,
+  $$ \frac{1.5}{1.0} \cdot \sin\theta > 1.0 $$
 
-<div class="together">
 the equality between the two sides of the equation is broken, and a solution cannot exist. If a
 solution does not exist, the glass cannot refract, and therefore must reflect the ray:
 
@@ -2916,7 +2884,6 @@ Here all the light is reflected, and because in practice that is usually inside 
 is called “total internal reflection”. This is why sometimes the water-air boundary acts as a
 perfect mirror when you are submerged.
 
-<div class='together'>
 We can solve for `sin_theta` using the trigonometric qualities:
 
   $$ \sin\theta  = \sqrt{1 - \cos^2\theta} $$
@@ -2938,8 +2905,6 @@ and
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [dielectric]: <kbd>[material.h]</kbd> Determining if the ray can refract]
-
-</div>
 
 <div class='together'>
 And the dielectric material that always refracts (when possible) is:
@@ -2977,6 +2942,7 @@ And the dielectric material that always refracts (when possible) is:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [dielectric]: <kbd>[material.h]</kbd> Dielectric material class with reflection]
+
 </div>
 
 <div class='together'>
@@ -2991,6 +2957,9 @@ parameters:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-dielectric]: <kbd>[main.cc]</kbd> Scene with dielectric and shiny sphere]
 
+</div>
+
+<div class='together'>
 We get:
 
   ![Image 15: Glass sphere that sometimes refracts
@@ -3001,7 +2970,6 @@ We get:
 
 Schlick Approximation
 ----------------------
-<div class='together'>
 Now real glass has reflectivity that varies with angle -- look at a window at a steep angle and it
 becomes a mirror. There is a big ugly equation for that, but almost everybody uses a cheap and
 surprisingly accurate polynomial approximation by Christophe Schlick. This yields our full glass
@@ -3050,12 +3018,10 @@ material:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [glass]: <kbd>[material.h]</kbd> Full glass material]
-</div>
 
 
 Modeling a Hollow Glass Sphere
 -------------------------------
-<div class='together'>
 An interesting and easy trick with dielectric spheres is to note that if you use a negative radius,
 the geometry is unaffected, but the surface normal points inward. This can be used as a bubble to
 make a hollow glass sphere:
@@ -3072,7 +3038,6 @@ make a hollow glass sphere:
     ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-hollow-glass]: <kbd>[main.cc]</kbd> Scene with hollow glass sphere]
-</div>
 
 <div class='together'>
 This gives:
@@ -3094,13 +3059,10 @@ personal taste.
 
 Camera Viewing Geometry
 ------------------------
-<div class='together'>
 I first keep the rays coming from the origin and heading to the $z = -1$ plane. We could make it the
 $z = -2$ plane, or whatever, as long as we made $h$ a ratio to that distance. Here is our setup:
 
   ![Figure [cam-view-geom]: Camera viewing geometry](../images/fig-1.14-cam-view-geom.jpg)
-
-</div>
 
 <div class='together'>
 This implies $h = \tan(\frac{\theta}{2})$. Our camera now becomes:
@@ -3141,6 +3103,7 @@ This implies $h = \tan(\frac{\theta}{2})$. Our camera now becomes:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [camera-fov]: <kbd>[camera.h]</kbd> Camera with adjustable field-of-view (fov)]
+
 </div>
 
 <div class='together'>
@@ -3177,6 +3140,9 @@ Now update `main()` to use a 90° field of view, looking at the point where two 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-wide-angle]: <kbd>[main.cc]</kbd> Scene with wide-angle camera]
 
+</div>
+
+<div class='together'>
 This gives us the rendering:
 
   ![Image 17: A wide-angle view](../images/img-1.17-wide-view.png class=pixel)
@@ -3288,10 +3254,16 @@ We'll change back to the prior scene, and use the new viewpoint:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-free-view]: <kbd>[main.cc]</kbd> Scene with alternate viewpoint]
 
+</div>
+
+<div class='together'>
 to get:
 
   ![Image 18: A distant view](../images/img-1.18-view-distant.png class=pixel)
 
+</div>
+
+<div class='together'>
 And we can change field of view:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -3299,6 +3271,9 @@ And we can change field of view:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [change-field-view]: <kbd>[main.cc]</kbd> Change field of view]
 
+</div>
+
+<div class='together'>
 to get:
 
   ![Image 19: Zooming in](../images/img-1.19-view-zoom.png class=pixel)
@@ -3332,7 +3307,6 @@ sensor and never need more light, so we only have an aperture when we want defoc
 
 A Thin Lens Approximation
 --------------------------
-<div class="together">
 A real camera has a complicated compound lens. For our code we could simulate the order: sensor,
 then lens, then aperture. Then we could figure out where to send the rays, and flip the image after
 it's computed (the image is projected upside down on the film). Graphics people, however, usually
@@ -3340,17 +3314,12 @@ use a thin lens approximation:
 
   ![Figure [cam-lens]: Camera lens model](../images/fig-1.17-cam-lens.jpg)
 
-</div>
-
-<div class="together">
 We don’t need to simulate any of the inside of the camera. For the purposes of rendering an image
 outside the camera, that would be unnecessary complexity. Instead, I usually start rays from the
 lens, and send them toward the focus plane (`focus_dist` away from the lens), where everything on
 that plane is in perfect focus.
 
   ![Figure [cam-film-plane]: Camera focus plane](../images/fig-1.18-cam-film-plane.jpg)
-
-</div>
 
 
 Generating Sample Rays
@@ -3371,6 +3340,7 @@ defocus disk of radius zero (no blur at all), so all rays originated at the disk
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [rand-in-unit-disk]: <kbd>[vec3.h]</kbd> Generate random point inside unit disk]
+
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class camera {
@@ -3474,6 +3444,9 @@ Using a big aperture:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-camera-dof]: <kbd>[main.cc]</kbd> Scene camera with depth-of-field]
 
+</div>
+
+<div class='together'>
 We get:
 
   ![Image 20: Spheres with depth-of-field](../images/img-1.20-depth-of-field.png class=pixel)
@@ -3487,7 +3460,6 @@ Where Next?
 
 A Final Render
 ---------------
-<div class='together'>
 Let’s make the image on the cover of this book -- lots of random spheres.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -3553,7 +3525,6 @@ Let’s make the image on the cover of this book -- lots of random spheres.
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-final]: <kbd>[main.cc]</kbd> Final scene]
-</div>
 
 (Note that the code above differs slightly from the project sample code: the `samples_per_pixel` is
 set to 500 above for a high-quality image that will take quite a while to render.
@@ -3606,6 +3577,7 @@ Have fun, and please send me your cool images!
 
 
                                (insert acknowledgments.md.html here)
+
 
 
 Citing This Book

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -37,7 +37,6 @@ at the end of this book.
 
 
 
-
 Motion Blur
 ====================================================================================================
 When you decided to ray trace, you decided that visual quality was worth more than run-time. When
@@ -97,6 +96,7 @@ time for each ray:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [time-ray]: <kbd>[ray.h]</kbd> Ray with time information]
+
 </div>
 
 
@@ -212,11 +212,11 @@ at time=1.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [moving-sphere]: <kbd>[sphere.h]</kbd> A moving sphere]
 
-<div class='together'>
 An alternative to making special stationary spheres is to just make them all move, but stationary
 spheres have the same begin and end position. I’m on the fence about that trade-off between simpler
 code and more efficient stationary spheres, so let your design taste guide you.
 
+<div class='together'>
 The updated `sphere::hit()` function is almost identical to the old `sphere::hit()` function:
 `center` just needs to query a function `sphere_center(time)`:
 
@@ -238,8 +238,10 @@ The updated `sphere::hit()` function is almost identical to the old `sphere::hit
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [moving-sphere-hit]: <kbd>[sphere.h]</kbd> Moving sphere hit function]
+
 </div>
 
+<div class='together'>
 We need to implement the new `interval::contains()` method mentioned above:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -254,10 +256,11 @@ We need to implement the new `interval::contains()` method mentioned above:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [interval-contains]: <kbd>interval.h</kbd> interval::contains() method]
 
+</div>
+
 
 Tracking the Time of Ray Intersection
 --------------------------------------
-<div class='together'>
 Now that rays have a time property, we need to update the `material::scatter()` methods to account
 for the time of intersection:
 
@@ -312,12 +315,10 @@ for the time of intersection:
     [Listing [material-time]: <kbd>[material.h]</kbd>
         Handle ray time in the material::scatter() methods
     ]
-</div>
 
 
 Putting Everything Together
 ----------------------------
-<div class='together'>
 The code below takes the example diffuse spheres from the scene at the end of the last book, and
 makes them move during the image render. Each sphere moves from its center $\mathbf{C}$ at time
 $t=0$ to $\mathbf{C} + (0, r/2, 0)$ at time $t=1$:
@@ -372,7 +373,6 @@ $t=0$ to $\mathbf{C} + (0, r/2, 0)$ at time $t=1$:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-spheres-moving]:
     <kbd>[main.cc]</kbd> Last book's final scene, but with moving spheres]
-</div>
 
 <div class='together'>
 This gives the following result:
@@ -400,7 +400,6 @@ models.
 
 The Key Idea
 -------------
-<div class='together'>
 The key idea of a bounding volume over a set of primitives is to find a volume that fully encloses
 (bounds) all the objects. For example, suppose you computed a sphere that bounds 10 objects. Any ray
 that misses the bounding sphere definitely misses all ten objects inside. If the ray hits the
@@ -413,7 +412,6 @@ form:
     else
         return false
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-</div>
 
 A key thing is we are dividing objects into subsets. We are not dividing the screen or the volume.
 Any object is in just one bounding volume, but bounding volumes can overlap.
@@ -421,14 +419,11 @@ Any object is in just one bounding volume, but bounding volumes can overlap.
 
 Hierarchies of Bounding Volumes
 --------------------------------
-<div class='together'>
 To make things sub-linear we need to make the bounding volumes hierarchical. For example, if we
 divided a set of objects into two groups, red and blue, and used rectangular bounding volumes, we’d
 have:
 
   ![Figure [bvol-hierarchy]: Bounding volume hierarchy](../images/fig-2.01-bvol-hierarchy.jpg)
-
-</div>
 
 <div class='together'>
 Note that the blue and red bounding volumes are contained in the purple one, but they might overlap,
@@ -443,6 +438,7 @@ of ordering in the left and right children; they are simply inside. The code wou
             return true and info of closer hit
     return false
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 </div>
 
 
@@ -469,41 +465,30 @@ In 2D, two intervals overlapping makes a 2D AABB (a rectangle):
 
 </div>
 
-<div class='together'>
 For a ray to hit one interval we first need to figure out whether the ray hits the boundaries. For
 example, again in 2D, this is the ray parameters $t_0$ and $t_1$. (If the ray is parallel to the
 plane, its intersection with the plane will be undefined.)
 
   ![Figure [ray-slab]: Ray-slab intersection](../images/fig-2.03-ray-slab.jpg)
 
-</div>
-
-<div class='together'>
 In 3D, those boundaries are planes. The equations for the planes are $x = x_0$ and $x = x_1$. Where
 does the ray hit that plane? Recall that the ray can be thought of as just a function that given a
 $t$ returns a location $\mathbf{P}(t)$:
 
   $$ \mathbf{P}(t) = \mathbf{A} + t \mathbf{b} $$
-</div>
 
-<div class='together'>
 This equation applies to all three of the x/y/z coordinates. For example, $x(t) = A_x + t b_x$. This
 ray hits the plane $x = x_0$ at the parameter $t$ that satisfies this equation:
 
   $$ x_0 = A_x + t_0 b_x $$
-</div>
 
-<div class='together'>
 Thus $t$ at that hitpoint is:
 
   $$ t_0 = \frac{x_0 - A_x}{b_x} $$
-</div>
 
-<div class='together'>
 We get the similar expression for $x_1$:
 
   $$ t_1 = \frac{x_1 - A_x}{b_x} $$
-</div>
 
 <div class='together'>
 The key observation to turn that 1D math into a hit test is that for a hit, the $t$-intervals need
@@ -517,7 +502,6 @@ to overlap. For example, in 2D the green and blue overlapping only happens if th
 
 Ray Intersection with an AABB
 ------------------------------
-<div class='together'>
 The following pseudocode determines whether the $t$ intervals in the slab overlap:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -526,6 +510,7 @@ The following pseudocode determines whether the $t$ intervals in the slab overla
     return overlap?( (tx0, tx1), (ty0, ty1))
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+<div class='together'>
 That is awesomely simple, and the fact that the 3D version also works is why people love the
 slab method:
 
@@ -535,9 +520,9 @@ slab method:
     compute (tz0, tz1)
     return overlap ? ((tx0, tx1), (ty0, ty1), (tz0, tz1))
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 </div>
 
-<div class='together'>
 There are some caveats that make this less pretty than it first appears. First, suppose the ray is
 travelling in the negative $\mathbf{x}$ direction. The interval $(t_{x0}, t_{x1})$ as computed above
 might be reversed, _e.g._ something like $(7, 3)$. Second, the divide in there could give us
@@ -550,9 +535,7 @@ fastest anyway! First let’s look at computing the intervals:
 
   $$ t_{x0} = \frac{x_0 - A_x}{b_x} $$
   $$ t_{x1} = \frac{x_1 - A_x}{b_x} $$
-</div>
 
-<div class='together'>
 One troublesome thing is that perfectly valid rays will have $b_x = 0$, causing division by zero.
 Some of those rays are inside the slab, and some are not. Also, the zero will have a ± sign when
 using IEEE floating point. The good news for $b_x = 0$ is that $t_{x0}$ and $t_{x1}$ will both be +∞
@@ -567,13 +550,11 @@ or both be -∞ if not between $x_0$ and $x_1$. So, using min and max should get
      \frac{x_0 - A_x}{b_x},
      \frac{x_1 - A_x}{b_x})
   $$
-</div>
 
 The remaining troublesome case if we do that is if $b_x = 0$ and either $x_0 - A_x = 0$ or $x_1 -
 A_x = 0$ so we get a `NaN`. In that case we can probably accept either hit or no hit answer, but
 we’ll revisit that later.
 
-<div class='together'>
 Now, let’s look at that overlap function. Suppose we can assume the intervals are not reversed (so
 the first value is less than the second value in the interval) and we want to return true in that
 case. The boolean overlap that also computes the overlap interval $(f, F)$ of intervals $(d, D)$ and
@@ -585,9 +566,7 @@ $(e, E)$ would be:
         F = min(D, E)
         return (f < F)
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-</div>
 
-<div class='together'>
 If there are any `NaN`s running around there, the compare will return false so we need to be sure
 our bounding boxes have a little padding if we care about grazing cases (and we probably should
 because in a ray tracer all cases come up eventually). Here's the implementation:
@@ -657,12 +636,10 @@ because in a ray tracer all cases come up eventually). Here's the implementation
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [aabb]: <kbd>[aabb.h]</kbd> Axis-aligned bounding box class]
-</div>
 
 
 An Optimized AABB Hit Method
 -----------------------------
-<div class='together'>
 In reviewing this intersection method, Andrew Kensler at Pixar tried some experiments and proposed
 the following version of the code. It works extremely well on many compilers, and I have adopted it
 as my go-to method:
@@ -694,12 +671,10 @@ as my go-to method:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [aabb-hit]: <kbd>[aabb.h]</kbd> Axis-aligned bounding box hit function]
-</div>
 
 
 Constructing Bounding Boxes for Hittables
 ------------------------------------------
-<div class='together'>
 We now need to add a function to compute the bounding boxes of all the hittables. Then we will make
 a hierarchy of boxes over all the primitives, and the individual primitives--like spheres--will live
 at the leaves.
@@ -731,9 +706,7 @@ entire range of motion, from time=0 to time=1.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [hittable-bbox]: <kbd>[hittable.h]</kbd> Hittable class with bounding-box]
-</div>
 
-<div class='together'>
 For a stationary sphere, the `bounding_box` function is easy:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -766,7 +739,6 @@ For a stationary sphere, the `bounding_box` function is easy:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [sphere-bbox]: <kbd>[sphere.h]</kbd> Sphere with bounding box]
-</div>
 
 For a moving sphere, we want the bounds of its entire range of motion. To do this, we can take the
 box of the sphere at time=0, and the box of the sphere at time=1, and compute the box around those
@@ -794,6 +766,7 @@ two boxes.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [moving-sphere-bbox]: <kbd>[sphere.h]</kbd> Moving sphere with bounding box]
 
+<div class='together'>
 Now we need a new `aabb` constructor that takes two boxes as input.
 First, we'll add a new interval constructor that takes two intervals as input:
 
@@ -809,7 +782,9 @@ First, we'll add a new interval constructor that takes two intervals as input:
         Interval constructor from two intervals
     ]
 
+</div>
 
+<div class='together'>
 Now we can use this to construct an axis-aligned bounding box from two input boxes.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -828,10 +803,11 @@ Now we can use this to construct an axis-aligned bounding box from two input box
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [aabb-from-two-aabb]: <kbd>[aabb.h]</kbd> AABB constructor from two AABB inputs]
 
+</div>
+
 
 Creating Bounding Boxes of Lists of Objects
 --------------------------------------------
-<div class='together'>
 Now we'll update the `hittable_list` object, computing the bounds of its children. We'll update the
 bounding box incrementally as each new child is added.
 
@@ -868,18 +844,17 @@ bounding box incrementally as each new child is added.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [hit-list-bbox]: <kbd>[hittable_list.h]</kbd> Hittable list with bounding box]
-</div>
 
 
 The BVH Node Class
 -------------------
-<div class='together'>
 A BVH is also going to be a `hittable` -- just like lists of `hittable`s. It’s really a container,
 but it can respond to the query “does this ray hit you?”. One design question is whether we have two
 classes, one for the tree, and one for the nodes in the tree; or do we have just one class and have
 the root just be a node we point to. The `hit` function is pretty straightforward: check whether the
 box for the node is hit, and if so, check the children and sort out any details.
 
+<div class='together'>
 I am a fan of the one class design when feasible. Here is such a class:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -921,12 +896,12 @@ I am a fan of the one class design when feasible. Here is such a class:
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [bvh]: <kbd>[bvh.h]</kbd> Bounding volume hierarchy]
+
 </div>
 
 
 Splitting BVH Volumes
 ----------------------
-<div class='together'>
 The most complicated part of any efficiency structure, including the BVH, is building it. We do this
 in the constructor. A cool thing about BVHs is that as long as the list of objects in a `bvh_node`
 gets divided into two sub-lists, the hit function will work. It will work best if the division is
@@ -938,9 +913,7 @@ list along one axis. I’ll go for simplicity:
   2. sort the primitives (`using std::sort`)
   3. put half in each subtree
 
-</div>
 
-<div class='together'>
 When the list coming in is two elements, I put one in each subtree and end the recursion. The
 traversal algorithm should be smooth and not have to check for null pointers, so if I just have one
 element I duplicate it in each subtree. Checking explicitly for three elements and just following
@@ -988,10 +961,9 @@ we haven't yet defined.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [bvh-node]: <kbd>[bvh.h]</kbd> Bounding volume hierarchy node]
-</div>
 
 <div class='together'>
-    This uses a new function: `random_int()`:
+This uses a new function: `random_int()`:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     inline int random_int(int min, int max) {
@@ -1000,6 +972,7 @@ we haven't yet defined.
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [random-int]: <kbd>[rtweekend.h]</kbd> A function to return random integers in a range]
+
 </div>
 
 The check for whether there is a bounding box at all is in case you sent in something like an
@@ -1009,7 +982,6 @@ shouldn’t happen until you add such a thing.
 
 The Box Comparison Functions
 -----------------------------
-<div class='together'>
 Now we need to implement the box comparison functions, used by `std::sort()`. To do this, create a
 generic comparator returns true if the first argument is less than the second, given an additional
 axis index argument. Then define axis-specific comparison functions that use the generic comparison
@@ -1041,7 +1013,6 @@ function.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [bvh-x-comp]: <kbd>[bvh.h]</kbd> BVH comparison function, X-axis]
-</div>
 
 At this point, we're ready to use our new BVH code. Let's use it on our random spheres scene.
 
@@ -1241,6 +1212,9 @@ If we add this to our `random_scene()` function’s base sphere:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [checker-example]: <kbd>[main.cc]</kbd> Checkered texture in use]
 
+</div>
+
+<div class='together'>
 We get:
 
   ![Image 2: Spheres on checkered ground](../images/img-2.02-checker-ground.png class=pixel)
@@ -1286,8 +1260,10 @@ Here's what our main.cc looks like after refactoring for our single random spher
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-scenes]: <kbd>[main.cc]</kbd> Main dispatching to selected scene]
+
 </div>
 
+<div class='together'>
 Now add a scene with two checkered spheres, one atop the other.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1343,6 +1319,8 @@ Now add a scene with two checkered spheres, one atop the other.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-two-spheres]: <kbd>[main.cc]</kbd> Two textured spheres]
 
+</div>
+
 <div class='together'>
 We get this result:
 
@@ -1366,7 +1344,6 @@ completely arbitrary, but generally you'd like to cover the entire surface, and 
 orient and stretch the 2D image in a way that makes some sense. We'll start with deriving a scheme
 to get the $u,v$ coordinates of a sphere.
 
-<div class='together'>
 For spheres, texture coordinates are usually based on some form of longitude and latitude, _i.e._,
 spherical coordinates. So we compute $(\theta,\phi)$ in spherical coordinates, where $\theta$ is the
 angle up from the bottom pole (that is, up from -Y), and $\phi$ is the angle around the Y-axis (from
@@ -1378,9 +1355,7 @@ $(\theta,\phi)$ to $(u,v)$ would be:
 
   $$ u = \frac{\phi}{2\pi} $$
   $$ v = \frac{\theta}{\pi} $$
-</div>
 
-<div class='together'>
 To compute $\theta$ and $\phi$ for a given point on the unit sphere centered at the origin, we start
 with the equations for the corresponding Cartesian coordinates:
 
@@ -1390,17 +1365,13 @@ with the equations for the corresponding Cartesian coordinates:
       z &= \quad\sin(\phi) \sin(\theta)
      \end{align*}
   $$
-</div>
 
-<div class='together'>
 We need to invert these equations to solve for $\theta$ and $\phi$. Because of the lovely `<cmath>`
 function `atan2()`, which takes any pair of numbers proportional to sine and cosine and returns the
 angle, we can pass in $x$ and $z$ (the $\sin(\theta)$ cancel) to solve for $\phi$:
 
   $$ \phi = \text{atan2}(z, -x) $$
-</div>
 
-<div class='together'>
 `atan2()` returns values in the range $-\pi$ to $\pi$, but they go from 0 to $\pi$, then flip to
 $-\pi$ and proceed back to zero. While this is mathematically correct, we want $u$ to range from $0$
 to $1$, not from $0$ to $1/2$ and then from $-1/2$ to $0$. Fortunately,
@@ -1411,13 +1382,10 @@ and the second formulation yields values from $0$ continuously to $2\pi$. Thus, 
 $\phi$ as
 
   $$ \phi = \text{atan2}(-z, x) + \pi $$
-</div>
 
-<div>
 The derivation for $\theta$ is more straightforward:
 
   $$ \theta = \text{acos}(-y) $$
-</div>
 
 <div class='together'>
 So for a sphere, the $(u,v)$ coord computation is accomplished by a utility function that takes
@@ -1447,6 +1415,7 @@ points on the unit sphere centered at the origin, and computes $u$ and $v$:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [get-sphere-uv]: <kbd>[sphere.h]</kbd> get_sphere_uv function]
+
 </div>
 
 <div class='together'>
@@ -1474,6 +1443,7 @@ Update the `sphere::hit()` function to use this function to update the hit recor
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [get-sphere-uv-call]: <kbd>[sphere.h]</kbd> Sphere UV coordinates from hit]
+
 </div>
 
 <div class='together'>
@@ -1513,13 +1483,13 @@ Now we can make textured materials by replacing the `const color& a` with a text
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [lambertian-textured]: <kbd>[material.h]</kbd> Lambertian material with texture]
+
 </div>
 
 From the hitpoint $\mathbf{P}$, we compute the surface coordinates $(u,v)$. We then use these to
 index into our procedural solid texture (like marble). We can also read in an image and use the
 2D $(u,v)$ texture coordinate to index into the image.
 
-<div class='together'>
 A direct way to use scaled $(u,v)$ in an image is to round the $u$ and $v$ to integers, and use that
 as $(i,j)$ pixels. This is awkward, because we don’t want to have to change the code when we change
 image resolution. So instead, one of the the most universal unofficial standards in graphics is to
@@ -1529,7 +1499,6 @@ position is:
 
   $$ u = \frac{i}{N_x-1} $$
   $$ v = \frac{j}{N_y-1} $$
-</div>
 
 This is just a fractional position.
 
@@ -1676,17 +1645,15 @@ The `image_texture` class uses the `rtw_image` class:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [img-texture]: <kbd>[texture.h]</kbd> Image texture class]
+
 </div>
 
 
 Rendering The Image Texture
 ----------------------------
-<div class='together'>
 I just grabbed a random earth map from the web -- any standard projection will do for our purposes.
 
   ![Image 4: earthmap.jpg](../images/earthmap.jpg class=pixel)
-
-</div>
 
 <div class='together'>
 Here's the code to read an image from a file and then assign it to a diffuse material:
@@ -1729,6 +1696,7 @@ Here's the code to read an image from a file and then assign it to a diffuse mat
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [stbi-load-use]: <kbd>[main.cc]</kbd> Using stbi_load() to load an image]
+
 </div>
 
 We start to see some of the power of all colors being textures -- we can assign any kind of texture
@@ -1744,12 +1712,12 @@ sure to copy the Earth into your build directory, or rewrite `earth()` to point 
 
 Perlin Noise
 ====================================================================================================
-<div class='together'>
 To get cool looking solid textures most people use some form of Perlin noise. These are named after
 their inventor Ken Perlin. Perlin texture doesn’t return white noise like this:
 
   ![Image 6: White noise](../images/img-2.06-white-noise.jpg class=pixel)
 
+<div class='together'>
 Instead it returns something similar to blurred white noise:
 
   ![Image 7: White noise, blurred](../images/img-2.07-white-noise-blurred.jpg class=pixel)
@@ -1764,13 +1732,10 @@ incrementally based on Andrew Kensler’s description.
 
 Using Blocks of Random Numbers
 -------------------------------
-<div class='together'>
 We could just tile all of space with a 3D array of random numbers and use them in blocks. You get
 something blocky where the repeating is clear:
 
   ![Image 8: Tiled random patterns](../images/img-2.08-tile-random.jpg class=pixel)
-
-</div>
 
 <div class='together'>
 Let’s just use some sort of hashing to scramble this, instead of tiling. This has a bit of support
@@ -1841,6 +1806,7 @@ code to make it all happen:
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [perlin]: <kbd>[perlin.h]</kbd> A Perlin texture class and functions]
+
 </div>
 
 <div class='together'>
@@ -1862,6 +1828,7 @@ Now if we create an actual texture that takes these floats between 0 and 1 and c
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [noise-texture]: <kbd>[texture.h]</kbd> Noise texture]
+
 </div>
 
 <div class='together'>
@@ -1908,6 +1875,7 @@ We can use that texture on some spheres:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-perlin]: <kbd>[main.cc]</kbd> Scene with two Perlin-textured spheres]
+
 </div>
 
 <div class='together'>
@@ -1920,7 +1888,6 @@ Add the hashing does scramble as hoped:
 
 Smoothing out the Result
 -------------------------
-<div class='together'>
 To make it smooth, we can linearly interpolate:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -1971,7 +1938,6 @@ To make it smooth, we can linearly interpolate:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [perlin-trilinear]: <kbd>[perlin.h]</kbd> Perlin with trilinear interpolation]
-</div>
 
 <div class='together'>
 And we get:
@@ -1984,7 +1950,6 @@ And we get:
 
 Improvement with Hermitian Smoothing
 -------------------------------------
-<div class='together'>
 Smoothing yields an improved result, but there are obvious grid features in there. Some of it is
 Mach bands, a known perceptual artifact of linear interpolation of color. A standard trick is to use
 a Hermite cubic to round off the interpolation:
@@ -2010,7 +1975,6 @@ a Hermite cubic to round off the interpolation:
             ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [perlin-smoothed]: <kbd>[perlin.h]</kbd> Perlin smoothed]
-</div>
 
 <div class='together'>
 This gives a smoother looking image:
@@ -2023,7 +1987,6 @@ This gives a smoother looking image:
 
 Tweaking The Frequency
 -----------------------
-<div class='together'>
 It is also a bit low frequency. We can scale the input point to make it vary more quickly:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2050,7 +2013,6 @@ It is also a bit low frequency. We can scale the input point to make it vary mor
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [perlin-smoothed-2]: <kbd>[texture.h]</kbd> Perlin smoothed, higher frequency]
-</div>
 
 <div class='together'>
 We then add that scale to the `two_perlin_spheres()` scene description:
@@ -2069,8 +2031,8 @@ We then add that scale to the `two_perlin_spheres()` scene description:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scale-perlin]: <kbd>[main.cc]</kbd> Perlin-textured spheres with a scale to the noise]
-</div>
 
+</div>
 
 <div class='together'>
 This yields the following result:
@@ -2082,7 +2044,6 @@ This yields the following result:
 
 Using Random Vectors on the Lattice Points
 -------------------------------------------
-<div class='together'>
 This is still a bit blocky looking, probably because the min and max of the pattern always lands
 exactly on the integer x/y/z. Ken Perlin’s very clever trick was to instead put random unit vectors
 (instead of just floats) on the lattice points, and use a dot product to move the min and max off
@@ -2129,7 +2090,6 @@ reasonable set of irregular directions, and I won't bother to make them exactly 
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [perlin-randunit]: <kbd>[perlin.h]</kbd> Perlin with random unit translations]
-</div>
 
 <div class='together'>
 The Perlin class `noise()` method is now:
@@ -2171,6 +2131,7 @@ The Perlin class `noise()` method is now:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [perlin-2]: <kbd>[perlin.h]</kbd> Perlin class with new noise() method]
+
 </div>
 
 <div class='together'>
@@ -2205,9 +2166,9 @@ And the interpolation becomes a bit more complicated:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [perlin-interp]: <kbd>[perlin.h]</kbd> Perlin interpolation function so far]
+
 </div>
 
-<div class='together'>
 The output of the perlin interpretation can return negative values. These negative values will be
 passed to the `sqrt()` function of our gamma function and get turned into `NaN`s. We will cast the
 perlin output back to between 0 and 1.
@@ -2231,7 +2192,6 @@ perlin output back to between 0 and 1.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [perlin-smoothed-2]: <kbd>[texture.h]</kbd> Perlin smoothed, higher frequency]
-</div>
 
 <div class='together'>
 This finally gives something more reasonable looking:
@@ -2244,7 +2204,6 @@ This finally gives something more reasonable looking:
 
 Introducing Turbulence
 -----------------------
-<div class='together'>
 Very often, a composite noise that has multiple summed frequencies is used. This is usually called
 turbulence, and is a sum of repeated calls to noise:
 
@@ -2269,11 +2228,9 @@ turbulence, and is a sum of repeated calls to noise:
         ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [perlin-turb]: <kbd>[perlin.h]</kbd> Turbulence function]
-</div>
 
 Here `fabs()` is the absolute value function defined in `<cmath>`.
 
-<div class='together'>
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class noise_texture : public texture {
       public:
@@ -2294,7 +2251,6 @@ Here `fabs()` is the absolute value function defined in `<cmath>`.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [noise-tex-2]: <kbd>[texture.h]</kbd> Noise texture with turbulence]
-</div>
 
 <div class='together'>
 Used directly, turbulence gives a sort of camouflage netting appearance:
@@ -2306,7 +2262,6 @@ Used directly, turbulence gives a sort of camouflage netting appearance:
 
 Adjusting the Phase
 --------------------
-<div class='together'>
 However, usually turbulence is used indirectly. For example, the “hello world” of procedural solid
 textures is a simple marble-like texture. The basic idea is to make color proportional to something
 like a sine function, and use turbulence to adjust the phase (so it shifts $x$ in $\sin(x)$) which
@@ -2334,6 +2289,7 @@ effect is:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [noise-tex-3]: <kbd>[texture.h]</kbd> Noise texture with marbled texture]
 
+<div class='together'>
 Which yields:
 
   ![Image 15: Perlin noise, marbled texture](../images/img-2.15-perlin-marble.png class=pixel)
@@ -2366,9 +2322,12 @@ example, a quad with corner at the origin and extending two units in the Z direc
 the Y direction would have values $\mathbf{Q} = (0,0,0), \mathbf{u} = (0,0,2), \text{and }
 \mathbf{v} = (0,1,0)$.
 
+<div class='together'>
 The following figure illustrates the quadrilateral components.
 
   ![Figure [quad-def]: Quadrilateral Components](../images/fig-2.05-quad-def.jpg)
+
+</div>
 
 <div class='together'>
 Quads are flat, so their axis-aligned bounding box will have zero thickness in one dimension if the
@@ -2402,6 +2361,7 @@ actual shape anyway. To this end, we add a new `aabb::pad()` method that remedie
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [aabb]: <kbd>[aabb.h]</kbd> New aabb::pad() method]
+
 </div>
 
 <div class='together'>
@@ -2443,6 +2403,7 @@ Now we're ready for the first sketch of the new `quad` class:
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [quad]: <kbd>[quad.h]</kbd> 2D quadrilateral (parallelogram) class]
+
 </div>
 
 
@@ -2532,6 +2493,7 @@ know that $\mathbf{Q}$ lies on the plane, so that's enough to solve for $D$:
      \end{align*}
   $$
 
+<div class='together'>
 Add the planar values to the `quad` class:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2563,6 +2525,8 @@ Add the planar values to the `quad` class:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [quad-plane1]:
         <kbd>[quad.h]</kbd> Caching thel planar values]
+
+</div>
 
 We will use the two values `normal` and `D` to find the point of intersection between a given ray
 and the plane containing the quadrilateral.
@@ -2743,10 +2707,12 @@ Now that we have the intersection point's planar coordinates $\alpha$ and $\beta
 use these to determine if the intersection point is inside the quadrilateral -- that is, if the ray
 actually hit the quadrilateral.
 
+<div class='together'>
 The plane is divided into coordinate regions like so:
 
   ![Figure [quad-coords]: Quadrilateral coordinates](../images/fig-2.07-quad-coords.jpg)
 
+</div>
 
 Thus, to see if a point with planar coordinates $(\alpha,\beta)$ lies inside the quadrilateral, it
 just needs to meet the following criteria:
@@ -2831,6 +2797,7 @@ test method from the hit method.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [quad-final]: <kbd>[quad.h]</kbd> Final quad class]
 
+<div class='together'>
 And now we add a new scene to demonstrate our new `quad` primitive:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -2892,7 +2859,10 @@ And now we add a new scene to demonstrate our new `quad` primitive:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [quad-scene]: <kbd>[main.cc]</kbd> A new scene with quads]
 
+</div>
+
   ![Image 16: Quads](../images/img-2.16-quads.png class=pixel)
+
 
 
 Lights
@@ -2905,7 +2875,6 @@ turn it into something that emits light into our scene.
 
 Emissive Materials
 -------------------
-<div class='together'>
 First, let’s make a light emitting material. We need to add an emitted function (we could also add
 it to `hit_record` instead -- that’s a matter of design taste). Like the background, it just tells
 the ray what color it is and performs no reflection. It’s very simple:
@@ -2930,7 +2899,6 @@ the ray what color it is and performs no reflection. It’s very simple:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [diffuse-light]: <kbd>[material.h]</kbd> A diffuse light class]
-</div>
 
 <div class='together'>
 So that I don’t have to make all the non-emitting materials implement `emitted()`, I have the base
@@ -2954,6 +2922,7 @@ class return black:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [matl-emit]: <kbd>[material.h]</kbd> New emitted function in class material]
+
 </div>
 
 
@@ -3009,6 +2978,7 @@ the new `color_from_emission` value.
     [Listing [ray-color-emitted]: <kbd>[camera.h]</kbd>
     ray_color function with background and emitting materials]
 
+<div class='together'>
 `main()` is updated to set the background color for the prior scenes:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -3084,6 +3054,8 @@ the new `color_from_emission` value.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [use-bg-color]: <kbd>[main.cc]</kbd> Specifying new background color]
 
+</div>
+
 Since we're removing the code that we used to determine the color of the sky when a ray hit it, we
 need to pass in a new color value for our old scene renders. We've elected to stick with a flat
 bluish-white for the whole sky. You could always pass in a boolean to switch between the previous
@@ -3092,7 +3064,6 @@ skybox code versus the new solid color background. We're keeping it simple here.
 
 Turning Objects into Lights
 ----------------------------
-<div class='together'>
 If we set up a rectangle as a light:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -3141,7 +3112,6 @@ If we set up a rectangle as a light:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [rect-light]: <kbd>[main.cc]</kbd> A simple rectangle light]
-</div>
 
 <div class='together'>
 We get:
@@ -3173,7 +3143,6 @@ Fool around with making some spheres lights too.
 
 Creating an Empty “Cornell Box”
 --------------------------------
-<div class='together'>
 The “Cornell Box” was introduced in 1984 to model the interaction of light between diffuse surfaces.
 Let’s make the 5 walls and the light of the box:
 
@@ -3229,7 +3198,6 @@ Let’s make the 5 walls and the light of the box:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [cornell-box-empty]: <kbd>[main.cc]</kbd> Cornell box scene, empty]
-</div>
 
 <div class='together'>
 We get:
@@ -3237,6 +3205,7 @@ We get:
   ![Image 19: Empty Cornell box](../images/img-2.19-cornell-empty.png class=pixel)
 
 This image is very noisy because the light is small.
+
 </div>
 
 
@@ -3277,7 +3246,7 @@ create a function that returns a box, by creating a `hittable_list` of six recta
     [Listing [box-class]: <kbd>[quad.h]</kbd> A box object]
 
 <div class='together'>
-Now we can add two blocks (but not rotated)
+Now we can add two blocks (but not rotated).
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     void cornell_box() {
@@ -3310,7 +3279,6 @@ This gives:
 
 </div>
 
-<div class='together'>
 Now that we have boxes, we need to rotate them a bit to have them match the _real_ Cornell box. In
 ray tracing, this is usually done with an _instance_. An instance is a copy of a geometric
 primitive that has been placed into the scene. This instance is entirely independent of the other
@@ -3323,12 +3291,9 @@ the box where it is, but in its hit routine subtract two off the x-component of 
 
   ![Figure [ray-box]: Ray-box intersection with moved ray vs box](../images/fig-2.08-ray-box.jpg)
 
-</div>
-
 
 Instance Translation
 ---------------------
-<div class='together'>
 Whether you think of this as a move or a change of coordinates is up to you. The way to reason about
 this is to think of moving the incident ray backwards the offset amount, determining if an
 intersection occurs, and then moving that intersection point forward the offset amount.
@@ -3362,6 +3327,7 @@ make this happen.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [translate-hit]: <kbd>[hittable.h]</kbd> Hittable translation hit function]
 
+<div class='together'>
 ... and then flesh out the rest of the `translate` class:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -3403,11 +3369,12 @@ make this happen.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [translate-class]: <kbd>[hittable.h]</kbd> Hittable translation class]
+
 </div>
 
 We also need to remember to offset the bounding box, otherwise the incident ray might be looking in
-the wrong place and trivially reject the intersection. The expression
-`object->bounding_box() + offset` above requires some additional support.
+  the wrong place and trivially reject the intersection.
+The expression `object->bounding_box() + offset` above requires some additional support.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class aabb {
@@ -3425,7 +3392,6 @@ the wrong place and trivially reject the intersection. The expression
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [aabb-plus-offset]: <kbd>[aabb.h]</kbd> The aabb + offset operator]
-
 
 Since each dimension of an `aabb` is represented as an interval, we'll need to extend `interval`
 with an addition operator as well.
@@ -3454,7 +3420,6 @@ with an addition operator as well.
 
 Instance Rotation
 ------------------
-<div class='together'>
 Rotation isn’t quite as easy to understand or generate the formulas for. A common graphics tactic is
 to apply all rotations about the x, y, and z axes. These rotations are in some sense axis-aligned.
 First, let’s rotate by theta about the z-axis. That will be changing only x and y, and in ways that
@@ -3462,23 +3427,18 @@ don’t depend on z.
 
   ![Figure [rot-z]: Rotation about the Z axis](../images/fig-2.09-rot-z.jpg)
 
-</div>
-
-<div class='together'>
 This involves some basic trigonometry that uses formulas that I will not cover here. That gives you
 the correct impression it’s a little involved, but it is straightforward, and you can find it in any
 graphics text and in many lecture notes. The result for rotating counter-clockwise about z is:
 
   $$ x' = \cos(\theta) \cdot x - \sin(\theta) \cdot y $$
   $$ y' = \sin(\theta) \cdot x + \cos(\theta) \cdot y $$
-</div>
 
 The great thing is that it works for any $\theta$ and doesn’t need any cases for quadrants or
 anything like that. The inverse transform is the opposite geometric operation: rotate by $-\theta$.
 Here, recall that $\cos(\theta) = \cos(-\theta)$ and $\sin(-\theta) = -\sin(\theta)$, so the
 formulas are very simple.
 
-<div class='together'>
 Similarly, for rotating about y (as we want to do for the blocks in the box) the formulas are:
 
   $$ x' =  \cos(\theta) \cdot x + \sin(\theta) \cdot z $$
@@ -3488,7 +3448,6 @@ And if we want to rotate about the x-axis:
 
   $$ y' = \cos(\theta) \cdot y - \sin(\theta) \cdot z $$
   $$ z' = \sin(\theta) \cdot y + \cos(\theta) \cdot z $$
-</div>
 
 Thinking of translation as a simple movement of the initial ray is a fine way to reason about what's
 going on. But, for a more complex operation like a rotation, it can be easy to accidentally get your
@@ -3507,7 +3466,6 @@ But this can also be thought of in terms of a _changing of coordinates_:
 2. Determine whether an intersection exists in object space (and if so, where)
 3. Change the intersection point from object space to world space
 
-
 Rotating an object will not only change the point of intersection, but will also change the surface
 normal vector, which will change the direction of reflections and refractions. So we need to change
 the normal as well. Fortunately, the normal will rotate similarly to a vector, so we can use the
@@ -3522,6 +3480,7 @@ rotating by $-\theta$.
   $$ x' = \cos(\theta) \cdot x - \sin(\theta) \cdot z $$
   $$ z' = \sin(\theta) \cdot x + \cos(\theta) \cdot z $$
 
+<div class='together'>
 We can now create a class for y-rotation:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -3564,6 +3523,9 @@ We can now create a class for y-rotation:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [rot-y-hit]: <kbd>[hittable.h]</kbd> Hittable rotate-Y hit function]
 
+</div>
+
+<div class='together'>
 ... and now for the rest of the class:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -3621,6 +3583,8 @@ We can now create a class for y-rotation:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [rot-y]: <kbd>[hittable.h]</kbd> Hittable rotate-Y class]
 
+</div>
+
 <div class='together'>
 And the changes to Cornell are:
 
@@ -3647,6 +3611,7 @@ And the changes to Cornell are:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-rot-y]: <kbd>[main.cc]</kbd> Cornell scene with Y-rotated boxes]
+
 </div>
 
 <div class='together'>
@@ -3678,17 +3643,18 @@ through.
 
   ![Figure [ray-vol]: Ray-volume interaction](../images/fig-2.10-ray-vol.jpg)
 
-<div class='together'>
 As the ray passes through the volume, it may scatter at any point. The denser the volume, the more
 likely that is. The probability that the ray scatters in any small distance $\Delta L$ is:
 
   $$ \text{probability} = C \cdot \Delta L $$
-</div>
 
 where $C$ is proportional to the optical density of the volume. If you go through all the
 differential equations, for a random number you get a distance where the scattering occurs. If that
 distance is outside the volume, then there is no “hit”. For a constant volume we just need the
-density $C$ and the boundary. I’ll use another hittable for the boundary. The resulting class is:
+density $C$ and the boundary. I’ll use another hittable for the boundary.
+
+<div class='together'>
+The resulting class is:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #ifndef CONSTANT_MEDIUM_H
@@ -3769,6 +3735,8 @@ density $C$ and the boundary. I’ll use another hittable for the boundary. The 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [const-med-class]: <kbd>[constant_medium.h]</kbd> Constant medium class]
 
+</div>
+
 <div class='together'>
 The scattering function of isotropic picks a uniform random direction:
 
@@ -3790,6 +3758,7 @@ The scattering function of isotropic picks a uniform random direction:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [isotropic-class]: <kbd>[material.h]</kbd> The isotropic class]
+
 </div>
 
 The reason we have to be so careful about the logic around the boundary is we need to make sure this
@@ -3888,7 +3857,6 @@ We get:
 
 A Scene Testing All New Features
 ====================================================================================================
-
 Let’s put it all together, with a big thin mist covering everything, and a blue subsurface
 reflection sphere (we didn’t implement that explicitly, but a volume inside a dielectric is what a
 subsurface material is). The biggest limitation left in the renderer is no shadow rays, but that is
@@ -4016,11 +3984,11 @@ Running it with 10,000 rays per pixel (sweet dreams) yields:
 
   ![Image 23: Final scene](../images/img-2.23-book2-final.jpg)
 
-</div>
-
 Now go off and make a really cool image of your own! See https://in1weekend.blogspot.com/ for
 pointers to further reading and features, and feel free to email questions, comments, and cool
 images to me at ptrshrl@gmail.com.
+
+</div>
 
 
 

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -49,7 +49,6 @@ at the end of this book.
 
 A Simple Monte Carlo Program
 ====================================================================================================
-<div class='together'>
 Let’s start with one of the simplest Monte Carlo programs. If you're not familiar with Monte Carlo
 programs, then it'll be good to pause and catch you up. There are two kinds of randomized
 algorithms: Monte Carlo and Las Vegas. Randomized algorithms can be found everywhere in computer
@@ -83,12 +82,9 @@ decide that the answer is accurate _enough_ and call it quits. This basic charac
 programs producing noisy but ever-better answers is what MC is all about, and is especially good for
 applications like graphics where great accuracy is not needed.
 
-</div>
-
 
 Estimating Pi
 --------------
-<div class='together'>
 The canonical example of a Monte Carlo algorithm is estimating $\pi$, so let's do that. There are
 many ways to estimate $\pi$, with the Buffon Needle problem being a classic case study. We’ll do a
 variation inspired by this method. Suppose you have a circle inscribed inside a square:
@@ -96,15 +92,11 @@ variation inspired by this method. Suppose you have a circle inscribed inside a 
   ![Figure [circ-square]: Estimating π with a circle inside a square
   ](../images/fig-3.01-circ-square.jpg)
 
-</div>
-
-<div class='together'>
 Now, suppose you pick random points inside the square. The fraction of those random points that end
 up inside the circle should be proportional to the area of the circle. The exact fraction should in
 fact be the ratio of the circle area to the square area:
 
   $$ \frac{\pi r^2}{(2r)^2} = \frac{\pi}{4} $$
-</div>
 
 <div class='together'>
 Since the $r$ cancels out, we can pick whatever is computationally convenient. Let’s go with $r=1$,
@@ -132,15 +124,15 @@ centered at the origin:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [estpi-1]: <kbd>[pi.cc]</kbd> Estimating π]
-</div>
 
 The answer of $\pi$ found will vary from computer to computer based on the initial random seed.
 On my computer, this gives me the answer `Estimate of Pi = 3.143760000000`.
 
+</div>
+
 
 Showing Convergence
 --------------------
-<div class='together'>
 If we change the program to run forever and just print out a running estimate:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -170,12 +162,10 @@ If we change the program to run forever and just print out a running estimate:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [estpi-2]: <kbd>[pi.cc]</kbd> Estimating π, v2]
-</div>
 
 
 Stratified Samples (Jittering)
 -------------------------------
-<div class='together'>
 We get very quickly near $\pi$, and then more slowly zero in on it. This is an example of the _Law
 of Diminishing Returns_, where each sample helps less than the last. This is the worst part of Monte
 Carlo. We can mitigate this diminishing return by _stratifying_ the samples (often called
@@ -183,8 +173,6 @@ _jittering_), where instead of taking random samples, we take a grid and take on
 each:
 
   ![Figure [jitter]: Sampling areas with jittered points](../images/fig-3.02-jitter.jpg)
-
-</div>
 
 <div class='together'>
 This changes the sample generation, but we need to know how many samples we are taking in advance
@@ -223,6 +211,9 @@ because we need to know the grid. Let’s take a million and try it both ways:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [estpi-3]: <kbd>[pi.cc]</kbd> Estimating π, v3]
 
+</div>
+
+<div class='together'>
 On my computer, I get:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -246,7 +237,6 @@ $\phi_o$ and $\theta_o$. We won't be stratifying the output reflection angle in 
 because it is a little bit too complicated to cover, but there is a lot of interesting research
 currently happening in this space.
 
-<div class='together'>
 As an intermediary, we'll be stratifying the locations of the sampling positions around each pixel
 location.
 
@@ -363,15 +353,17 @@ location.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [render-estpi-3]: <kbd>[camera.h]</kbd> Stratifying the samples inside pixels (render)]
 
+<div class='together'>
 If we compare the results from without stratification:
 
   ![Image 1: Cornell box, no stratification](../images/img-3.01-cornell-no-strat.png class=pixel)
 
+</div>
+
+<div class='together'>
 To after, with stratification:
 
   ![Image 2: Cornell box, with stratification](../images/img-3.02-cornell-strat.png class=pixel)
-
-</div>
 
 You should, if you squint, be able to see sharper contrast at the edges of planes and at the edges
 of boxes. The effect will be more pronounced at locations that have a higher frequency of change.
@@ -382,6 +374,9 @@ reflective materials.
 
 If you are ever doing single-reflection or shadowing or some strictly 2D problem, you definitely
 want to stratify.
+
+</div>
+
 
 
 One Dimensional Monte Carlo Integration
@@ -407,35 +402,38 @@ We choose a circle with radius $r = 1$ and get:
 
     $$ \text{area}(\mathit{circle}) = \pi $$
 
+<div class='together'>
 Our work above is equally valid as a means to solve for $pi$ as it is a means to solve for the area
 of a circle:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-#include "rtweekend.h"
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    #include "rtweekend.h"
 
-#include <iostream>
-#include <iomanip>
-#include <math.h>
-#include <stdlib.h>
+    #include <iostream>
+    #include <iomanip>
+    #include <math.h>
+    #include <stdlib.h>
 
-int main() {
-    int N = 100000;
-    int inside_circle = 0;
-    for (int i = 0; i < N; i++) {
-        auto x = random_double(-1,1);
-        auto y = random_double(-1,1);
-        if (x*x + y*y < 1)
-            inside_circle++;
+    int main() {
+        int N = 100000;
+        int inside_circle = 0;
+        for (int i = 0; i < N; i++) {
+            auto x = random_double(-1,1);
+            auto y = random_double(-1,1);
+            if (x*x + y*y < 1)
+                inside_circle++;
+        }
+        std::cout << std::fixed << std::setprecision(12);
+        std::cout << "Estimated area of unit circle = " << (4.0 * inside_circle) / N << '\n';
     }
-    std::cout << std::fixed << std::setprecision(12);
-    std::cout << "Estimated area of unit circle = " << (4.0 * inside_circle) / N << '\n';
-}
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[Listing [estunitcircle]: <kbd>[pi.cc]</kbd> Estimating area of unit circle]
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    [Listing [estunitcircle]: <kbd>[pi.cc]</kbd> Estimating area of unit circle]
+
+</div>
+
 
 Expected Value
 --------------
-
 Let's take a step back and think about our Monte Carlo algorithm a little bit more generally.
 
 If we assume that we have all of the following:
@@ -519,7 +517,6 @@ that interval.
 
     $$  E[f(x) | a \leq x \leq b] = \frac{1}{b - a} \cdot \text{area}(f(x), a, b) $$
 
-
 Both the integral of a function and a Monte Carlo sampling of that function can be used to solve for
 the average over a specific interval. While integration solves for the average with the sum of
 infinitely many infinitesimally small slices of the interval, a Monte Carlo algorithm will
@@ -531,10 +528,9 @@ things.
 
 I think a couple of examples will help.
 
+
 Integrating x²
 ---------------
-
-<div class='together'>
 Let’s look at a classic integral:
 
     $$ I = \int_{0}^{2} x^2 dx $$
@@ -556,8 +552,6 @@ We could also write it as:
     $$ \text{average}(x^2, 0, 2) = \frac{1}{2 - 0} \cdot \text{area}( x^2, 0, 2 ) $$
     $$ \text{average}(x^2, 0, 2) = \frac{1}{2 - 0} \cdot I $$
     $$ I = 2 \cdot \text{average}(x^2, 0, 2) $$
-
-</div>
 
 <div class='together'>
 The Monte Carlo approach:
@@ -584,8 +578,10 @@ The Monte Carlo approach:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [integ-xsq-1]: <kbd>[integrate_x_sq.cc]</kbd> Integrating x^2]
+
 </div>
 
+<div class='together'>
 This, as expected, produces approximately the exact answer we get with integration, _i.e._
 $I = 8/3$. You could rightly point to this example and say that the integration is actually a lot
 less work than the Monte Carlo. That might be true in the case where the function is $f(x) = x^2$,
@@ -600,6 +596,9 @@ integration, like $f(x) = sin^5(x)$.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [integ-sin5]: Integrating sin^5]
 
+</div>
+
+<div class='together'>
 We could also use the Monte Carlo algorithm for functions where an analytical integration does not
 exist, like $f(x) = \ln(\sin(x))$.
 
@@ -610,6 +609,8 @@ exist, like $f(x) = \ln(\sin(x))$.
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [integ-ln-sin]: Integrating ln(sin)]
+
+</div>
 
 In graphics, we often have functions that we can write down explicitly but that have a complicated
 analytic integration, or, just as often, we have functions that _can_ be evaluated but that _can't_
@@ -622,7 +623,6 @@ one particular place, for a single particular direction.
 
 Density Functions
 ------------------
-<div class='together'>
 The `ray_color` function that we wrote in the first two books, while elegant in its simplicity, has
 a fairly _major_ problem. Small light sources create too much noise. This is because our uniform
 sampling doesn’t sample these light sources often enough. Light sources are only sampled if a ray
@@ -655,9 +655,6 @@ from the histogram Wikipedia page:
 
   ![Figure [histogram]: Histogram example](../images/fig-3.03-histogram.jpg)
 
-</div>
-
-<div class='together'>
 If we had more items in our data source, the number of bins would stay the same, but each bin would
 have a higher frequency of each item. If we divided the data into more bins, we'd have more bins,
 but each bin would have a lower frequency of each item. If we took the number of bins and raised it
@@ -669,7 +666,6 @@ Converting from a _discrete function_ to a _discrete density function_ is trivia
 
     $$ \text{Density of Bin i} = \frac{\text{Number of items in Bin i}}
                                       {\text{Number of items total}} $$
-
 
 Once we have a _discrete density function_, we can then convert it into a _density function_ by
 changing our discrete values into continuous values.
@@ -690,12 +686,12 @@ interpret that as a statistical predictor of a tree’s height:
 
     $$ \text{Probability a random tree is between } H \text{ and } H’ =
         \text{Bin Density}\cdot(H-H’)$$
-</div>
 
 Indeed, with this continuous probability function, we can now say the likelihood that any given tree
 has a height that places it within any arbitrary span of multiple bins. This is a
 _probability density function_ (henceforth _PDF_). In short, a PDF is a continuous function that
 can be  integrated over to determine how likely a result is over an integral.
+
 
 Constructing a PDF
 -------------------
@@ -709,8 +705,6 @@ and linearly increases along that interval. So, if we used this function as a PD
 random number then the _probability_ of getting a number near zero would be less than the
 probability of getting a number near two.
 
-
-<div class='together'>
 The PDF $p(r)$ is a linear function that starts with $0$ at $r=0$ and monotonically increases to its
 highest point at $p(2)$ for $r=2$. What is the value of $p(2)$? What is the value of $p(r)$? Maybe
 $p(2)$ is 2? The PDF increases linearly from 0 to 2, so guessing that the value of $p(2)$ is 2
@@ -744,10 +738,7 @@ region to figure out the probability that $r$ is in some interval $[x_0,x_1]$:
 
 To confirm your understanding, you should integrate over the region $r=0$ to $r=2$, you should get a
 probability of 1.
-</div>
 
-
-<div class='together'>
 After spending enough time with PDFs you might start referring to a PDF as the probability that a
 variable $r$ is value $x$, _i.e._ $p(r=x)$. Don't do this. For a continuous function, the
 probability that a variable is a specific value is always zero. A PDF can only tell you the
@@ -766,7 +757,6 @@ Finding the probability of a region surrounding x may not be zero:
          \text{area}(p(r), x - \Delta x, x + \Delta x) $$
     $$ = P(x + \Delta x) - P(x - \Delta x) $$
 
-</div>
 
 Choosing our Samples
 --------------------
@@ -790,6 +780,8 @@ uniform PDF with
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     10.0 * random_double()
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+</div>
 
 That's an easy case, but the vast majority of cases that we're going to care about are nonuniform.
 We need to figure out a way to convert a uniform random number generator into a nonuniform random
@@ -829,13 +821,19 @@ in $[0,\sqrt{2}]$, if `d` is greater than 0.5, it produces a uniform number in $
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [crude-approx]: A crude, first-order approximation to nonuniform PDF]
 
+<div class='together'>
 While our initial random number generator was uniform from 0 to 1:
 
    ![Figure [uniform-dist]: A uniform distribution](../images/fig-3.05-uniform-dist.jpg)
 
+</div>
+
+<div class='together'>
 Our, new, crude approximation for $\frac{r}{2}$ is nonuniform (but only just):
 
     ![Figure [approx-f]: A nonuniform distribution for r/2](../images/fig-3.06-nonuniform-dist.jpg)
+
+</div>
 
 We had the analytical solution to the integration above, so we could very easily solve for the 50%
 value. But we could also solve for this 50% value experimentally. There will be functions that we
@@ -844,11 +842,15 @@ result close to the real value. Let's take the function:
 
     $$ p(x) = e^{\frac{-x}{2 \pi}} sin^2(x) $$
 
+<div class='together'>
 Which looks a little something like this:
 
     ![Figure [exp-sin2]: A function that we don't want to solve analytically
     ](../images/fig-3.07-exp-sin2.jpg)
 
+</div>
+
+<div class='together'>
 At this point you should be familiar with how to experimentally solve for the area under a curve.
 We'll take our existing code and modify it slightly to get an estimate for the 50% value. We want to
 solve for the $x$ value that gives us half of the total area under the curve. As we go along and
@@ -916,6 +918,9 @@ have an area that is half of the total. From $0$ to $2\pi$ for example:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [est-halfway]: <kbd>[estimate_halfway.cc]</kbd> Estimating the 50% point of a function]
 
+</div>
+
+<div class='together'>
 This code snippet isn't too different from what we had before. We're still solving for the sum
 over an interval (0 to $2\pi$). Only this time, we're also storing and sorting all of our samples by
 their input and output. We use this to determine the point at which they subtotal half of the sum
@@ -928,17 +933,17 @@ we know that the $j\text{th}$ $x$ roughly corresponds to our halfway point:
     Halfway = 2.016002314977
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+</div>
+
 If you solve for the integral from $0$ to $2.016$ and from $2.016$ to $2\pi$ you should get almost
 exactly the same result for both.
 
 We have a method of solving for the halfway point that splits a PDF in half. If we wanted to, we
 could use this to create a nested binary partition of the PDF:
 
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    1. Solve for halfway point of a PDF
-    2. Recurse into lower half, repeat step 1
-    3. Recurse into upper half, repeat step 1
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  1. Solve for halfway point of a PDF
+  2. Recurse into lower half, repeat step 1
+  3. Recurse into upper half, repeat step 1
 
 Stopping at a reasonable depth, say 6–10. As you can imagine, this could be quite computationally
 expensive. The computational bottleneck for the code above is probably sorting the samples. A naive
@@ -950,6 +955,7 @@ distributions of nonuniform numbers. This divide and conquer method of producing
 distributions is used somewhat commonly in practice, although there are much more efficient means of
 doing so than a simple binary partition. If you have an arbitrary function that you wish to use as
 the PDF for a distribution, you'll want to research the _Metropolis-Hastings Algorithm_.
+
 
 Approximating Distributions
 ---------------------------
@@ -999,9 +1005,7 @@ To go from the PDF to the CDF, you need to integrate from $-\infty$ to $x$, but 
 to the PDF, all you need to do is take the derivative:
 
     $$ p(x) = \frac{d}{dx}P(x) $$
-</div>
 
-<div class='together'>
 If we evaluate the CDF, $P(r)$, at $r = 1.0$, we get:
 
     $$ P(1.0) = \frac{1}{4} $$
@@ -1016,10 +1020,7 @@ increases, then we would expect $f(0.25) = 1.0$ and $f(0.5) = \sqrt{2}$. This ca
 figure out $f(d)$ for every possible input:
 
     $$ f(P(x)) = x $$
-</div>
 
-
-<div class='together'>
 Let's take some more samples:
 
     $$ P(0.0) = 0 $$
@@ -1045,9 +1046,7 @@ all, the CDF is just the integral of the PDF. However, you can still create a di
 approximates the PDF. If you take a bunch of samples from the random function you want the PDF from,
 you can approximate the PDF by getting a histogram of the samples and then converting to a PDF.
 Alternatively, you can do as we did above and sort all of your samples.
-</div>
 
-<div class='together'>
 Looking closer at the equality:
 
     $$ f(P(x)) = x $$
@@ -1060,9 +1059,7 @@ For our purposes, if we have PDF $p()$ and cumulative distribution function $P()
 "inverse function" with a random number to get what we want:
 
     $$ f(d) = P^{-1} (\text{random_double}()) $$
-</div>
 
-<div class='together'>
 For our PDF $p(r) = r/2$, and corresponding $P(r)$, we need to compute the inverse of $P(r)$. If we
 have
 
@@ -1083,18 +1080,17 @@ Thus our random number generator with density $p(r)$ can be created with:
 Note that this ranges from 0 to 2 as we hoped, and if we check our work, we replace
 `random_double()` with $1/4$ to get 1, and also replace with $1/2$ to get $\sqrt{2}$, just as
 expected.
-</div>
 
 
 Importance Sampling
 --------------------
-<div class='together'>
 You should now have a decent understanding of how to take an analytical PDF and generate a function
 that produces random numbers with that distribution. We return to our original integral and try it
 with a few different PDFs to get a better understanding:
 
     $$ I = \int_{0}^{2} x^2 dx $$
 
+<div class='together'>
 The last time that we tried to solve for the integral we used a Monte Carlo approach, uniformly
 sampling from the interval $[0, 2]$. We didn't know it at the time, but we were implicitly using a
 uniform PDF between 0 and 2. This means that we're using a PDF = $1/2$ over the range $[0,2]$, which
@@ -1136,6 +1132,7 @@ means the CDF is $P(x) = x/2$, so $f(d) = 2d$. Knowing this, we can make this un
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [integ-xsq-2]: <kbd>[integrate_x_sq.cc]</kbd> Explicit uniform PDF for $x^2$]
 
+</div>
 
 There are a couple of important things to emphasize. Every value of $x$ represents one sample of the
 function $x^2$ within the distribution $[0, 2]$. We use a function $f$ to randomly select samples
@@ -1143,7 +1140,6 @@ from within this distribution. We were previously multiplying the average over t
 (`sum / N`) times the length of the interval (`b - a`) to arrive at the final answer. Here, we
 don't need to multiply by the interval length--that is, we no longer need to multiply the average
 by $2$.
-
 
 We need to account for the nonuniformity of the PDF of $x$. Failing to account for this
 nonuniformity will introduce bias in our scene. Indeed, this bias is the source of our inaccurately
@@ -1154,9 +1150,7 @@ frequently, and to up-weight where we sample less frequently. For our new nonuni
 generator, the PDF defines how much or how little we sample a specific portion. So the weighting
 function should be proportional to $1/\text{pdf}$. In fact it is _exactly_ $1/\text{pdf}$. This is
 why we divide `x*x` by `pdf(x)`.
-</div>
 
-<div class='together'>
 We can try to solve for the integral using the linear PDF $p(r) = \frac{r}{2}$, for which we were
 able to solve for the CDF and its inverse. To do that, all we need to do is replace the functions
 $f = \sqrt{4d}$ and $pdf = x/2$.
@@ -1183,10 +1177,7 @@ $f = \sqrt{4d}$ and $pdf = x/2$.
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [integ-xsq-3]: <kbd>[integrate_x_sq.cc]</kbd> Integrating $x^2$ with linear PDF]
-</div>
 
-
-<div class='together'>
 If you compared the runs from the uniform PDF and the linear PDF, you would have probably found that
 the linear PDF converged faster. If you think about it, a linear PDF is probably a better
 approximation for a quadratic function than a uniform PDF, so you would expect it to converge
@@ -1224,7 +1215,6 @@ And we get the corresponding CDF:
 and
 
     $$ P^{-1}(x) = f(d) = 8d^\frac{1}{3} $$
-</div>
 
 <div class='together'>
 For just one sample we get:
@@ -1253,20 +1243,19 @@ For just one sample we get:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [integ-xsq-5]: <kbd>[integrate_x_sq.cc]</kbd> Integrating $x^2$, final version]
-</div>
 
 This always returns the exact answer. Which, honestly, feels a bit like magic.
 
+</div>
 
 A nonuniform PDF "steers" more samples to where the PDF is big, and fewer samples to where the PDF
-is small.
-By this sampling, we would expect less noise in the places where the PDF is big and more noise where
-the PDF is small. If we choose a PDF that is higher in the parts of the scene that have higher
-noise, and is smaller in the parts of the scene that have lower noise, we'll be able to reduce the
-total noise of the scene with fewer samples. This means that we will be able to converge to the
-correct scene _faster_ than with a uniform PDF. In effect, we are steering our samples toward the
-parts of the distribution that are more _important_. This is why using a carefully chosen nonuniform
-PDF is usually called _importance sampling_.
+is small. By this sampling, we would expect less noise in the places where the PDF is big and more
+noise where the PDF is small. If we choose a PDF that is higher in the parts of the scene that have
+higher noise, and is smaller in the parts of the scene that have lower noise, we'll be able to
+reduce the total noise of the scene with fewer samples. This means that we will be able to converge
+to the correct scene _faster_ than with a uniform PDF. In effect, we are steering our samples toward
+the parts of the distribution that are more _important_. This is why using a carefully chosen
+nonuniform PDF is usually called _importance sampling_.
 
 In all of the examples given, we always converged to the correct answer of $8/3$. We got the same
 answer when we used both a uniform PDF and the "correct" PDF ($i.e. f(d)=8d^{\frac{1}{3}}$). While
@@ -1284,7 +1273,6 @@ than a pure uniform PDF, but slower than the linear PDF ($i.e. f(d) = \sqrt{4d}$
 The perfect importance sampling is only possible when we already know the answer (we got $P$ by
 integrating $p$ analytically), but it’s a good exercise to make sure our code works.
 
-<div class='together'>
 Let's review the main concepts that underlie Monte Carlo ray tracers:
 
   1. You have an integral of $f(x)$ over some domain $[a,b]$
@@ -1293,7 +1281,6 @@ Let's review the main concepts that underlie Monte Carlo ray tracers:
 
 Any choice of PDF $p$ will always converge to the right answer, but the closer that $p$
 approximates $f$, the faster that it will converge.
-</div>
 
 
 
@@ -1359,7 +1346,6 @@ axis:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-sphereimp]: <kbd>[sphere_importance.cc]</kbd>
     Generating importance-sampled points on the unit sphere]
-</div>
 
 The analytic answer is $\frac{4}{3} \pi$ -- if you remember enough advanced calc, check me! And the
 code above produces that. The key point here is that all of the integrals and the probability and
@@ -1441,7 +1427,6 @@ on the scattering position: $\mathit{pScatter}(\mathbf{x}, \omega_i, \omega_o, \
 $\mathbf{x}$ is just math notation for the scattering position: $\mathbf{x} = (x, y, z)$. The albedo
 of an object can also depend on these quantities: $A(\mathbf{x}, \omega_i, \omega_o, \lambda)$.
 
-<div class='together'>
 The color of a surface is found by integrating these terms over the unit hemisphere by the incident
 direction:
 
@@ -1454,12 +1439,10 @@ We've added a $\text{Color}_i$ term. The scattering PDF and the albedo at the su
 are acting as filters to the light that is shining on that point. So we need to solve for the light
 that is shining on that point. This is a recursive algorithm, and is the reason our `ray_color`
 function returns the color of the current object multiplied by the color of the next ray.
-</div>
 
 
 The Scattering PDF
 -------------------
-<div class='together'>
 If we apply the Monte Carlo basic formula we get the following statistical estimate:
 
     $$ \text{Color}_o(\mathbf{x}, \omega_o, \lambda) \approx \sum
@@ -1470,7 +1453,6 @@ If we apply the Monte Carlo basic formula we get the following statistical estim
 
 where $p(\mathbf{x}, \omega_i, \omega_o, \lambda)$ is the PDF of whatever outgoing direction we
 randomly generate.
-</div>
 
 For a Lambertian surface we already implicitly implemented this formula for the special case where
 $pScatter(\, \ldots \,)$ is a cosine density. The $\mathit{pScatter}(\, \ldots \,)$ of a Lambertian
@@ -1483,7 +1465,6 @@ All two dimensional PDFs need to integrate to one over the whole surface (rememb
 $\mathit{pScatter}$ is a PDF). We set $\mathit{pScatter}(\theta_o < 0) = 0$ so that we don't
 scatter below the horizon.
 
-<div class='together'>
     $$ 1 = \int_{0}^{2 \pi} \int_{0}^{\pi / 2} C \cdot cos(\theta) dA $$
 
 To integrate over the hemisphere, remember that in spherical coordinates:
@@ -1503,9 +1484,7 @@ so we'll simplify its representation to just $\mathit{pScatter}(\omega_o)$. Put 
 and you get the scattering PDF for a Lambertian surface:
 
     $$ \mathit{pScatter}(\omega_o) = \frac{\cos(\theta_o)}{\pi} $$
-</div>
 
-<div class='together'>
 We'll assume that the $p(\mathbf{x}, \omega_i, \omega_o, \lambda)$ is equal to the scattering PDF:
 
     $$ p(\omega_o) = \mathit{pScatter}(\omega_o) = \frac{\cos(\theta_o)}{\pi} $$
@@ -1516,11 +1495,14 @@ The numerator and denominator cancel out, and we get:
         A(\, \ldots \,) \cdot
         \text{Color}_i(\, \ldots \,) $$
 
+<div class='together'>
 This is exactly what we had in our original `ray_color()` function!
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         return attenuation * ray_color(scattered, depth-1, world);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+</div>
 
 The treatment above is slightly non-standard because I want the same math to work for surfaces and
 volumes. If you read the literature, you’ll see reflection defined by the
@@ -1536,13 +1518,11 @@ our scattering PDF is usually called the _phase function_.
 All that we've done here is outline the PDF for the Lambertian scattering of a material. However,
 we'll need to generalize so that we can send extra rays in important directions, such as toward the
 lights.
-</div>
 
 
 
 Playing with Importance Sampling
 ====================================================================================================
-<div class='together'>
 Our goal over the next several chapters is to instrument our program to send a bunch of extra rays
 toward light sources so that our picture is less noisy. Let’s assume we can send a bunch of rays
 toward the light source using a PDF $\mathit{pLight}(\omega_o)$. Let’s also assume we have a PDF
@@ -1552,7 +1532,6 @@ PDFs. For example, the simplest would be:
 
   $$ p(\omega_o) = \frac{1}{2} \mathit{pSurface}(\omega_o) +  \frac{1}{2}
       \mathit{pLight}(\omega_o)$$
-</div>
 
 As long as the weights are positive and add up to one, any such mixture of PDFs is a PDF. Remember,
 we can use any PDF: _all PDFs eventually converge to the correct answer_. So, the game is to figure
@@ -1590,9 +1569,10 @@ At 600×600 my code produces this image in 15min on 1 core of my Macbook:
 
   ![Image 3: Cornell box, refactored](../images/img-3.03-cornell-refactor1.jpg class=pixel)
 
+</div>
+
 Reducing that noise is our goal. We’ll do that by constructing a PDF that sends more rays to the
 light.
-</div>
 
 First, let’s instrument the code so that it explicitly samples some PDF and then normalizes for
 that. Remember Monte Carlo basics: $\int f(x) \approx \sum f(r)/p(r)$. For the Lambertian material,
@@ -1617,6 +1597,7 @@ We modify the base-class `material` to enable this importance sampling:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-material]: <kbd>[material.h]</kbd>
     The material class, adding importance sampling]
+
 </div>
 
 <div class='together'>
@@ -1655,6 +1636,7 @@ And the `lambertian` material becomes:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-lambertian-impsample]: <kbd>[material.h]</kbd>
     Lambertian material, modified for importance sampling]
+
 </div>
 
 <div class='together'>
@@ -1698,6 +1680,7 @@ And the `camera::ray_color` function gets a minor modification:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-impsample]: <kbd>[camera.h]</kbd>
     The ray_color function, modified for importance sampling]
+
 </div>
 
 You should get exactly the same picture. Which _should make sense_, as the scattered part of
@@ -1707,7 +1690,6 @@ You should get exactly the same picture. Which _should make sense_, as the scatt
 
 Using a Uniform PDF Instead of a Perfect Match
 ----------------------------------------------
-<div class='together'>
 Now, just for the experience, let's try using a different sampling PDF. We'll continue to have our
 reflected rays weighted by Lambertian, so $\cos(\theta_o)$, and we'll keep the scattering PDF as is,
 but we'll use a different PDF in the denominator. We will sample using a uniform PDF about the
@@ -1752,15 +1734,12 @@ a noisier image:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-uniform]: <kbd>[camera.h]</kbd>
     The ray_color function, now with a uniform PDF in the denominator]
-</div>
 
-<div class='together'>
 You should get a very similar result to before, only with slightly more noise, it may be hard to
 see.
 
   ![Image 4: Cornell box, with imperfect PDF
   ](../images/img-3.04-cornell-refactor2.jpg class=pixel)
-
 
 Make sure to return the PDF to the scattering PDF.
 
@@ -1776,12 +1755,9 @@ Make sure to return the PDF to the scattering PDF.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-return]: <kbd>[camera.h]</kbd> Return the PDF to the same as scattering PDF]
 
-</div>
-
 
 Random Hemispherical Sampling
 ---------------------------
-<div class='together'>
 To confirm our understanding, let's try a different scattering distribution. For this one, we'll
 attempt to repeat the uniform hemispherical scattering from the first book. There's nothing wrong
 with this technique, but we are no longer treating our objects as Lambertian. Lambertian is a
@@ -1825,17 +1801,13 @@ PDF:
         ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scatter-mod]: <kbd>[material.h]</kbd> Modified PDF and scatter function]
-</div>
 
-<div class='together'>
 This new diffuse material is actually just $p(\omega_o) = \frac{1}{2\pi}$ for the scattering PDF. So
 our uniform PDF that was an imperfect match for Lambertian diffuse is actually a perfect match for
 our uniform hemispherical diffuse. When rendering, we should get a slightly different image.
 
   ![Image 5: Cornell box, with uniform hemispherical sampling
   ](../images/img-3.04-cornell-refactor2.jpg class=pixel)
-
-</div>
 
 It’s pretty close to our old picture, but there are differences that are not just noise. The front
 of the tall box is much more uniform in color. If you aren't sure what the best sampling pattern for
@@ -1848,6 +1820,7 @@ to find in a Monte Carlo program -- a bug that produces a reasonable looking ima
 if the bug is in the first version of the program, or the second, or both!
 
 Let’s build some infrastructure to address this.
+
 
 
 Generating Random Directions
@@ -1864,15 +1837,12 @@ normal. We'll set everything up in terms of the $z$ axis this chapter. Next chap
 oriented to the surface normal vector. We will only deal with distributions that are rotationally
 symmetric about $z$. So $p(\omega) = f(\theta)$.
 
-<div class='together'>
 Given a directional PDF on the sphere (where $p(\omega) = f(\theta)$), the one dimensional PDFs on
 $\theta$ and $\phi$ are:
 
     $$ a(\phi) = \frac{1}{2\pi} $$
     $$ b(\theta) = 2\pi f(\theta)\sin(\theta) $$
-</div>
 
-<div class='together'>
 For uniform random numbers $r_1$ and $r_2$, we solve for the CDF of $\theta$ and $\phi$ so that we
 can invert the CDF to derive the random number generator.
 
@@ -1893,9 +1863,6 @@ as $\phi'$ and $\theta$ as $\theta'$ just like before, as a formality. For $\the
     $$ r_2 = \int_{0}^{\theta} b(\theta') d\theta' $$
     $$ = \int_{0}^{\theta} 2 \pi f(\theta') \sin(\theta') d\theta' $$
 
-</div>
-
-<div class='together'>
 Let’s try some different functions for $f()$. Let’s first try a uniform density on the sphere. The
 area of the unit sphere is $4\pi$, so a uniform $p(\omega) = \frac{1}{4\pi}$ on the unit sphere.
 
@@ -1910,9 +1877,7 @@ Solving for $\cos(\theta)$ gives:
 
 We don’t solve for theta because we probably only need to know $\cos(\theta)$ anyway, and don’t want
 needless $\arccos()$ calls running around.
-</div>
 
-<div class='together'>
 To generate a unit vector direction toward $(\theta,\phi)$ we convert to Cartesian coordinates:
 
     $$ x = \cos(\phi) \cdot \sin(\theta) $$
@@ -1930,7 +1895,6 @@ Simplifying a little, $(1 - 2 r_2)^2 = 1 - 4r_2 + 4r_2^2$, so:
     $$ x = \cos(2 \pi r_1) \cdot 2 \sqrt{r_2(1 - r_2)} $$
     $$ y = \sin(2 \pi r_1) \cdot 2 \sqrt{r_2(1 - r_2)} $$
     $$ z = 1 - 2 r_2 $$
-</div>
 
 <div class='together'>
 We can output some of these:
@@ -1953,6 +1917,7 @@ We can output some of these:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [rand-unit-sphere-plot]: <kbd>[sphere_plot.cc]</kbd> Random points on the unit sphere]
+
 </div>
 
 <div class='together'>
@@ -1961,14 +1926,13 @@ And plot them for free on plot.ly (a great site with 3D scatterplot support):
   ![Figure [rand-pts-sphere]: Random points on the unit sphere
   ](../images/fig-3.10-rand-pts-sphere.jpg)
 
-</div>
-
 On the plot.ly website you can rotate that around and see that it appears uniform.
+
+</div>
 
 
 Uniform Sampling a Hemisphere
 ------------------------------
-<div class='together'>
 Now let’s derive uniform on the hemisphere. The density being uniform on the hemisphere means
 $p(\omega) = f(\theta) = \frac{1}{2\pi}$. Just changing the constant in the theta equations yields:
 
@@ -1977,9 +1941,7 @@ $p(\omega) = f(\theta) = \frac{1}{2\pi}$. Just changing the constant in the thet
     $$ = \int_{0}^{\theta} 2 \pi \frac{1}{2\pi} \sin(\theta') d\theta' $$
     $$ \ldots $$
     $$ \cos(\theta) = 1 - r_2 $$
-</div>
 
-<div class='together'>
 This means that $\cos(\theta)$ will vary from 1 to 0, so $\theta$ will vary from 0 to $\pi/2$, which
 means that nothing will go below the horizon. Rather than plot it, we'll solve for a 2D integral
 with a known solution. Let’s integrate cosine cubed over the hemisphere (just picking something
@@ -1988,7 +1950,6 @@ arbitrary with a known solution). First we'll solve the integral by hand:
     $$ \int_\omega \cos^3(\theta) dA $$
     $$ = \int_{0}^{2 \pi} \int_{0}^{\pi /2} \cos^3(\theta) \sin(\theta) d\theta d\phi $$
     $$ = 2 \pi \int_{0}^{\pi/2} \cos^3(\theta) \sin(\theta) d\theta = \frac{\pi}{2} $$
-</div>
 
 <div class='together'>
 Now for integration with importance sampling. $p(\omega) = \frac{1}{2\pi}$, so we average
@@ -2029,12 +1990,12 @@ $f()/p() = \cos^3(\theta) / \frac{1}{2\pi}$, and we can test this:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [cos-cubed]: <kbd>[cos_cubed.cc]</kbd> Integration using $cos^3(x)$]
+
 </div>
 
 
 Cosine Sampling a Hemisphere
 ------------------------------
-<div class='together'>
 We'll now continue trying to solve for cosine cubed over the horizon, but we'll change our PDF to
 generate directions with $p(\omega) =  f(\theta) = \cos(\theta) / \pi$.
 
@@ -2052,7 +2013,6 @@ We can save a little algebra on specific cases by noting
     $$ z = \cos(\theta) = \sqrt{1 - r_2} $$
     $$ x = \cos(\phi) \sin(\theta) = \cos(2 \pi r_1) \sqrt{1 - z^2} = \cos(2 \pi r_1) \sqrt{r_2} $$
     $$ y = \sin(\phi) \sin(\theta) = \sin(2 \pi r_1) \sqrt{1 - z^2} = \sin(2 \pi r_1) \sqrt{r_2} $$
-</div>
 
 <div class='together'>
 Here's a function that generates random vectors weighted by this PDF:
@@ -2073,6 +2033,7 @@ Here's a function that generates random vectors weighted by this PDF:
     [Listing [random-cosine-direction]: <kbd>[vec3.h]</kbd>
     Random cosine direction utility function]
 
+</div>
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #include "rtweekend.h"
@@ -2105,7 +2066,6 @@ Here's a function that generates random vectors weighted by this PDF:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [cos-density]: <kbd>[cos_density.cc]</kbd> Integration with cosine density function]
-</div>
 
 We can generate other densities later as we need them. This `random_cosine_direction()` function
 produces a random direction weighted by $\cos(\theta)$ where $\theta$ is the angle from the $z$
@@ -2137,20 +2097,16 @@ the space, but an orthonormal basis alone is not enough. The objects and the cam
 described by their displacement from a mutually defined location. This is just the origin
 $\mathbf{O}$ of the scene; it represents the center of the universe for everything to displace from.
 
-<div class='together'>
 Suppose we have an origin $\mathbf{O}$ and Cartesian unit vectors $\mathbf{x}$, $\mathbf{y}$, and
 $\mathbf{z}$. When we say a location is (3,-2,7), we really are saying:
 
     $$ \text{Location is } \mathbf{O} + 3\mathbf{x} - 2\mathbf{y} + 7\mathbf{z} $$
-</div>
 
-<div class='together'>
 If we want to measure coordinates in another coordinate system with origin $\mathbf{O}'$ and basis
 vectors $\mathbf{u}$, $\mathbf{v}$, and $\mathbf{w}$, we can just find the numbers $(u,v,w)$ such
 that:
 
     $$ \text{Location is } \mathbf{O}' + u\mathbf{u} + v\mathbf{v} + w\mathbf{w} $$
-</div>
 
 
 Generating an Orthonormal Basis
@@ -2163,7 +2119,6 @@ needing an origin for this because a direction is relative and has no specific o
 with, we need two cotangent vectors that are each perpendicular to $\mathbf{n}$ and that are also
 perpendicular to each other.
 
-<div class='together'>
 Some 3D object models will come with one or more cotangent vectors for each vertex. If our model has
 only one cotangent vector, then the process of making an ONB is a nontrivial one. Suppose we have
 any vector $\mathbf{a}$ that is of nonzero length and nonparallel with $\mathbf{n}$. We can get
@@ -2174,7 +2129,6 @@ $\mathbf{a}$:
     $$ \mathbf{s} = \text{unit_vector}(\mathbf{n} \times \mathbf{a}) $$
 
     $$ \mathbf{t} = \mathbf{n} \times \mathbf{s} $$
-</div>
 
 <div class='together'>
 This is all well and good, but the catch is that we may not be given an $\mathbf{a}$ when we load a
@@ -2189,6 +2143,7 @@ $\mathbf{n}$ (which we assume to be of unit length), if it is, just use another 
     else
         a = vec3(1, 0, 0)
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 </div>
 
 <div class='together'>
@@ -2199,13 +2154,14 @@ We then take the cross product to get $\mathbf{s}$ and $\mathbf{t}$
     vec3 t = cross(n, s);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+</div>
+
 Note that we don't need to take the unit vector for $\mathbf{t}$. Since $\mathbf{n}$ and
 $\mathbf{s}$ are both unit vectors, their cross product $\mathbf{t}$ will be also. Once we have an
 ONB of $\mathbf{s}$, $\mathbf{t}$, and $\mathbf{n}$, and we have a random $(x,y,z)$ relative to the
 $z$ axis, we can get the vector relative to $\mathbf{n}$ with:
 
     $$ \text{Random vector} = x \mathbf{s} + y \mathbf{t} + z \mathbf{n} $$
-</div>
 
 If you remember, we used similar math to produce rays from a camera. You can think of that as a
 change to the camera’s natural coordinate system.
@@ -2288,6 +2244,7 @@ We can rewrite our Lambertian material using this to get:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scatter-onb]: <kbd>[material.h]</kbd> Scatter function, with orthonormal basis]
+
 </div>
 
 <div class='together'>
@@ -2296,10 +2253,11 @@ Which produces:
   ![Image 6: Cornell box, with orthonormal basis scatter function
   ](../images/img-3.06-cornell-ortho.jpg class=pixel)
 
-Let’s get rid of some of that noise.
 </div>
 
 <div class='together'>
+Let’s get rid of some of that noise.
+
 But first, let's quickly update the `isotropic` material:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2336,7 +2294,9 @@ But first, let's quickly update the `isotropic` material:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-isotropic-impsample]: <kbd>[material.h]</kbd>
     Isotropic material, modified for importance sampling]
+
 </div>
+
 
 
 Sampling Lights Directly
@@ -2346,7 +2306,6 @@ sampled than any arbirary or unimportant direction. We could use shadow rays to 
 lighting at any given point. Instead, I’ll just use a PDF that sends more rays to the light. We can
 then turn around and change that PDF to send more rays in whatever direction we want.
 
-<div class='together'>
 It’s really easy to pick a random direction toward the light; just pick a random point on the light
 and send a ray in that direction. But we'll need to know the PDF, $p(\omega)$, so that we're not
 biasing our render. But what is that?
@@ -2362,9 +2321,6 @@ diagram:
   ![Figure [shape-onto-pdf]: Projection of light shape onto PDF
   ](../images/fig-3.11-shape-onto-pdf.jpg)
 
-</div>
-
-<div class='together'>
 If we look at a small area $dA$ on the light, the probability of sampling it is
 $p_{\text{q}}(\text{q}) \cdot dA$. On the sphere, the probability of sampling the small area
 $d\omega$ on the sphere is $p(\omega) \cdot d\omega$. There is a geometric relationship between
@@ -2383,15 +2339,14 @@ We know that if we sample uniformly on the light the PDF on the surface is $\fra
     $$ p_{\text{q}}(\text{q}) = \frac{1}{A} $$
     $$ p(\omega) \cdot \frac{dA \cdot \cos(\theta)}{distance^2(\text{p},\text{q})}
        =  \frac{dA}{A} $$
+
 So
 
   $$ p(\omega) = \frac{distance^2(\text{p},\text{q})}{\cos(\theta) \cdot A} $$
-</div>
 
 
 Light Sampling
 ---------------
-<div class='together'>
 We can hack our `ray_color()` function to sample the light in a very hard-coded fashion just to
 check that we got the math and concept right:
 
@@ -2452,7 +2407,6 @@ check that we got the math and concept right:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-lights]: <kbd>[camera.h]</kbd> Ray color with light sampling]
-</div>
 
 <div class='together'>
 With 10 samples per pixel this yields:
@@ -2460,11 +2414,10 @@ With 10 samples per pixel this yields:
   ![Image 7: Cornell box, sampling only the light, 10 samples per pixel
   ](../images/img-3.07-cornell-sample-light.jpg class=pixel)
 
-</div>
-
-<div class='together'>
 This is about what we would expect from something that samples only the light sources, so this
 appears to work.
+
+</div>
 
 
 Switching to Unidirectional Light
@@ -2507,8 +2460,8 @@ down. We can do that by letting the emitted member function of hittable take ext
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [emitted-directional]: <kbd>[material.h]</kbd> Material emission, directional]
-</div>
 
+<div class='together'>
 This gives us:
 
   ![Image 8: Cornell box, light emitted only in the downward direction
@@ -2526,7 +2479,6 @@ a PDF that combines these.
 
 The PDF Class
 -------------
-<div class='together'>
 We've worked with PDFs in quite a lot of code already. I think that now is a good time to figure out
 how we want to standardize our usage of PDFs. We already know that we are going to have a PDF for
 the surface and a PDF for the light, so let's create a `pdf` base class. So far, we've had a `pdf()`
@@ -2537,11 +2489,12 @@ distribution of the PDF. We covered this quite a lot in the chapter Playing with
 Sampling. In general, if we know the distribution of our random directions, we should use a PDF with
 the same distribution. This will lead to the fastest convergence. With that in mind, we'll create a
 `pdf` class that is responsible for generating random directions and determining the value of the
-PDF. From all of this, any `pdf` class should be responsible for,
+PDF.
 
-1. Return a random direction weighted by the internal PDF distribution, and
-2. Return the corresponding PDF distribution value in that direction
-</div>
+From all of this, any `pdf` class should be responsible for
+
+  1. returning a random direction weighted by the internal PDF distribution, and
+  2. returning the corresponding PDF distribution value in that direction.
 
 <div class='together'>
 The details of how this is done under the hood varies for $\mathit{pSurface}$ and $\mathit{pLight}$,
@@ -2569,6 +2522,7 @@ this implies:
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-pdf]: <kbd>[pdf.h]</kbd> The abstract pdf class]
+
 </div>
 
 <div class='together'>
@@ -2591,6 +2545,9 @@ create a uniform density over the unit sphere:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-uni-pdf]: <kbd>[pdf.h]</kbd> The uniform_pdf class]
 
+</div>
+
+<div class='together'>
 Next, let’s try a cosine density:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2612,6 +2569,7 @@ Next, let’s try a cosine density:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-cos-pdf]: <kbd>[pdf.h]</kbd> The cosine_pdf class]
+
 </div>
 
 <div class='together'>
@@ -2662,6 +2620,7 @@ We can try this cosine PDF in the `ray_color()` function:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-cos-pdf]: <kbd>[camera.h]</kbd> The ray_color function, using cosine pdf]
+
 </div>
 
 <div class='together'>
@@ -2676,7 +2635,6 @@ This yields an exactly matching result so all we’ve done so far is move some c
 
 Sampling Directions towards a Hittable
 ---------------------------------------
-<div class='together'>
 Now we can try sampling directions toward a `hittable`, like the light.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2703,9 +2661,7 @@ Now we can try sampling directions toward a `hittable`, like the light.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-hittable-pdf]: <kbd>[pdf.h]</kbd> The hittable_pdf class]
-</div>
 
-<div class='together'>
 If we want to sample the light, we will need `hittable` to answer some queries that it doesn’t yet
 have an interface for. The above code assumes the existence of two as-of-yet unimplemented functions
 in the `hittable` class: `pdf_value()` and `random()`. We need to add these functions for the
@@ -2732,7 +2688,6 @@ functions through to subclasses if you want a purely abstract `hittable` interfa
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [hittable-plus2]: <kbd>[hittable.h]</kbd> The hittable class, with two new methods]
-</div>
 
 <div class='together'>
 And then we change `quad` to implement those functions:
@@ -2791,11 +2746,12 @@ And then we change `quad` to implement those functions:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [quad-pdf]: <kbd>[quad.h]</kbd> quad with pdf]
 
+</div>
+
 We only need to add `pdf_value()` and `random()` to `quad` because we're using this to importance
 sample the light, and the only light we have in our scene is a `quad`. if you want other light
 geometries, or want to use a PDF with other objects, you'll need to implement the above functions
 for the corresponding classes.
-</div>
 
 <div class='together'>
 Add a `lights` parameter to the camera `render()` function:
@@ -2867,6 +2823,9 @@ Add a `lights` parameter to the camera `render()` function:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-lights]: <kbd>[camera.h]</kbd> ray_color function with light PDF]
 
+</div>
+
+<div class='together'>
 Create a light in the middle of the ceiling:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2897,6 +2856,7 @@ Create a light in the middle of the ceiling:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-hittable-pdf]: <kbd>[main.cc]</kbd> Adding a light to the Cornell box]
+
 </div>
 
 <div class='together'>
@@ -2910,7 +2870,6 @@ At 10 samples per pixel we get:
 
 The Mixture PDF Class
 ----------------------
-<div class='together'>
 As was briefly mentioned in the chapter Playing with Importance Sampling, we can create linear
 mixtures of any PDFs to form mixture densities that are also PDFs. Any weighted average of PDFs is
 also a PDF. As long as the weights are positive and add up to any one, we have a new PDF.
@@ -2935,6 +2894,9 @@ quite as easy as one might expect. Generating the random direction for a mixture
         pick direction according to pLight
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+</div>
+
+<div class='together'>
 But solving for the PDF value of $\mathit{pMixture}$ is slightly more subtle. We can't just
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2944,6 +2906,9 @@ But solving for the PDF value of $\mathit{pMixture}$ is slightly more subtle. We
         get PDF value of pLight
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+</div>
+
+<div class='together'>
 For one, figuring out which PDF the random direction came from is probably not trivial. We don't
 have any plumbing for `generate()` to tell `value()` what the original `random_double()` was, so we
 can't trivially say which PDF the random direction comes from. If we thought that the above was
@@ -2979,6 +2944,7 @@ density class is actually pretty straightforward:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-mixturep-df]: <kbd>[pdf.h]</kbd> The mixture_pdf class]
+
 </div>
 
 <div class='together'>
@@ -3016,6 +2982,7 @@ plug it into `ray_color()`:
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-mixture]: <kbd>[camera.h]</kbd> The ray_color function, using mixture PDF]
+
 </div>
 
 <div class='together'>
@@ -3082,17 +3049,15 @@ of the book.
 
 Cleaning Up PDF Management
 ====================================================================================================
-<div class='together'>
 So far I have the `ray_color()` function create two hard-coded PDFs:
 
-1. `p0()` related to the shape of the light
-2. `p1()` related to the normal vector and type of surface
+  1. `p0()` related to the shape of the light
+  2. `p1()` related to the normal vector and type of surface
 
 We can pass information about the light (or whatever `hittable` we want to sample) into the
 `ray_color()` function, and we can ask the `material` function for a PDF (we would have to add
 instrumentation to do that). We also need to know if the scattered ray is specular, and we can do
 this either by asking the `hit()` function or the `material` class.
-</div>
 
 
 Diffuse Versus Specular
@@ -3133,6 +3098,7 @@ We can redesign `material` and stuff all the new arguments into a class like we 
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [material-refactor]: <kbd>[material.h]</kbd> Refactoring the material class]
+
 </div>
 
 <div class='together'>
@@ -3164,6 +3130,7 @@ The `lambertian` material becomes simpler:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [lambertian-scatter]: <kbd>[material.h]</kbd> New lambertian scatter() method]
+
 </div>
 
 <div class='together'>
@@ -3196,6 +3163,7 @@ As does the `isotropic` material:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [isotropic-scatter]: <kbd>[material.h]</kbd> New isotropic scatter() method]
+
 </div>
 
 <div class='together'>
@@ -3251,12 +3219,12 @@ And `ray_color()` changes are small:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-mixture]: <kbd>[camera.h]</kbd> The ray_color function, using mixture PDF]
+
 </div>
 
 
 Handling Specular
 ------------------
-<div class='together'>
 We have not yet dealt with specular surfaces, nor instances that mess with the surface normal. But
 this design is clean overall, and those are all fixable. For now, I will just fix `specular`. Metal
 and dielectric materials are easy to fix.
@@ -3322,7 +3290,6 @@ and dielectric materials are easy to fix.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [material-scatter]: <kbd>[material.h]</kbd> The metal and dielectric scatter methods]
-</div>
 
 Note that if the fuzziness is nonzero, this surface isn’t really ideally specular, but the implicit
 sampling works just like it did before. We're effectively skipping all of our PDF work for the
@@ -3359,9 +3326,9 @@ materials that we're treating specularly.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-implicit]: <kbd>[camera.h]</kbd>
     Ray color function with implicitly-sampled rays]
+
 </div>
 
-<div class='together'>
 We'll check our work by changing a block to metal. We'd also like to swap out one of the blocks for
 a glass object, but we'll push that off for the next section. Glass objects are difficult to render
 well, so we'd like to make a PDF for them, but we have some more work to do before we're able to do
@@ -3397,7 +3364,6 @@ that.
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-cornell-al]: <kbd>[main.cc]</kbd> Cornell box scene with aluminum material]
-</div>
 
 <div class='together'>
 The resulting image has a noisy reflection on the ceiling because the directions toward the box are
@@ -3409,10 +3375,8 @@ not sampled with more density.
 </div>
 
 
-
 Sampling a Sphere Object
 -------------------------
-<div class='together'>
 The noisiness on the ceiling could be reduced by making a PDF of the metal block. We would also want
 a PDF for the block if we made it glass. But making a PDF for a block is quite a bit of work and
 isn't terribly interesting, so let’s create a PDF for a glass sphere instead. It's quicker and makes
@@ -3439,9 +3403,7 @@ If we solve through the calculus:
 So
 
   $$ cos(\theta) = 1 - \frac{r_2}{2 \pi \cdot C} $$
-</div>
 
-<div class='together'>
 We are constraining our distribution so that the random direction must be less than $\theta_{max}$.
 This means that the integral from 0 to $\theta_{max}$ must be one, and therefore $r_2 = 1$. We can
 use this to solve for $C$:
@@ -3453,38 +3415,28 @@ use this to solve for $C$:
 Which gives us an equality between $\theta$, $\theta_{max}$, and $r_2$:
 
   $$ \cos(\theta) = 1 + r_2 \cdot (\cos(\theta_{max})-1) $$
-</div>
 
-<div class='together'>
 We sample $\phi$ like before, so:
 
   $$ z = \cos(\theta) = 1 + r_2 \cdot (\cos(\theta_{max}) - 1) $$
   $$ x = \cos(\phi) \cdot \sin(\theta) = \cos(2\pi \cdot r_1) \cdot \sqrt{1-z^2} $$
   $$ y = \sin(\phi) \cdot \sin(\theta) = \sin(2\pi \cdot r_1) \cdot \sqrt{1-z^2} $$
-</div>
 
-<div class='together'>
 Now what is $\theta_{max}$?
 
   ![Figure [sphere-enclosing-cone]: A sphere-enclosing cone
   ](../images/fig-3.12-sphere-enclosing-cone.jpg)
 
-</div>
-
-<div class='together'>
 We can see from the figure that $\sin(\theta_{max}) = R / length(\mathbf{c} - \mathbf{p})$. So:
 
   $$ \cos(\theta_{max}) = \sqrt{1 - \frac{R^2}{length^2(\mathbf{c} - \mathbf{p})}} $$
-</div>
 
-<div class='together'>
 We also need to evaluate the PDF of directions. For a uniform distribution toward the sphere the PDF
 is $1/\text{solid_angle}$. What is the solid angle of the sphere? It has something to do with the
 $C$ above. It is -- by definition -- the area on the unit sphere, so the integral is
 
   $$ \text{solid angle} = \int_{0}^{2\pi} \int_{0}^{\theta_{max}} \sin(\theta)
        = 2 \pi \cdot (1-\cos(\theta_{max})) $$
-</div>
 
 It’s good to check the math on all such calculations. I usually plug in the extreme cases (thank you
 for that concept, Mr. Horton -- my high school physics teacher). For a zero radius sphere
@@ -3494,7 +3446,6 @@ $\cos(\theta_{max}) = 0$, and $2\pi$ is the area of a hemisphere, so that works 
 
 Updating the Sphere Code
 -------------------------
-<div class='together'>
 The sphere class needs the two PDF-related functions:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -3545,7 +3496,6 @@ The sphere class needs the two PDF-related functions:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [sphere-pdf]: <kbd>[sphere.h]</kbd> Sphere with PDF]
-</div>
 
 <div class='together'>
 We can first try just sampling the sphere rather than the light:
@@ -3577,6 +3527,7 @@ We can first try just sampling the sphere rather than the light:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [sampling-sphere]: <kbd>[main.cc]</kbd> Sampling just the sphere]
+
 </div>
 
 <div class='together'>
@@ -3592,7 +3543,6 @@ expensive!
 
 Adding PDF Functions to Hittable Lists
 ---------------------------------------
-<div class='together'>
 We should probably just sample both the sphere and the light. We can do that by creating a mixture
 density of their two distributions. We could do that in the `ray_color()` function by passing a list
 of hittables in and building a mixture PDF, or we could add PDF functions to `hittable_list`. I
@@ -3625,8 +3575,8 @@ think both tactics would work fine, but I will go with instrumenting `hittable_l
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [density-mixture]: <kbd>[hittable_list.h]</kbd> Creating a mixture of densities]
-</div>
 
+<div class='together'>
 We assemble a list to pass to `render()` from `main()`:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -3645,6 +3595,7 @@ We assemble a list to pass to `render()` from `main()`:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [scene-density-mixture]: <kbd>[main.cc]</kbd> Updating the scene]
+
 </div>
 
 <div class='together'>
@@ -3658,14 +3609,12 @@ And we get a decent image with 1000 samples as before:
 
 Handling Surface Acne
 ----------------------
-<div class='together'>
 An astute reader pointed out there are some black specks in the image above. All Monte Carlo Ray
 Tracers have this as a main loop:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     pixel_color = average(many many samples)
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-</div>
 
 If you find yourself getting some form of acne in your renders, and this acne is white or black --
 where one "bad" sample seems to kill the whole pixel -- then that sample is probably a huge number
@@ -3708,6 +3657,7 @@ always remember for `NaN`s is that a `NaN` does not equal itself. Using this tri
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [write-color-nan]: <kbd>[color.h]</kbd> NaN-tolerant write_color function]
+
 </div>
 
 <div class='together'>


### PR DESCRIPTION
- Avoid splitting headers from their introductory paragraphs.
- All closing div tags need a blank line before (lacking this, images display as inline instead of block, so text flows around them).
- Let text and equations split across pages (treat equations as text).
- Fixed existing cases with extra or no closing div tags.

Changes reviewed in print for all three books.

Resolves #944