### PR TITLE
Update code style

### DIFF
--- a/style/book-highlight-test.css
+++ b/style/book-highlight-test.css
@@ -1,5 +1,14 @@
 /* -------------------------------------------------------------------------------------------------
-** Code Highlighting Test
+** Code Highlighting Style Test
+**
+** To use these test styles, go to the bottom of the Markdeep document and find the line containing
+**
+**     <link rel='stylesheet' href='../style/book.css'>
+**
+** Add this line following:
+**
+**     <link rel='stylesheet' href='../style/book-highlight-test.css'>
+**
 ** -----------------------------------------------------------------------------------------------*/
 
 .md pre.listing.tilde {
@@ -23,7 +32,6 @@
     letter-spacing: -0.20;
     background: #eee;
 }
-
 
 /* Hilight.js Syntax Coloring */
 

--- a/style/book-highlight-test.css
+++ b/style/book-highlight-test.css
@@ -1,0 +1,61 @@
+/* -------------------------------------------------------------------------------------------------
+** Code Highlighting Test
+** -----------------------------------------------------------------------------------------------*/
+
+.md pre.listing.tilde {
+    border: solid 3px #d4d4d4;
+    padding: 1.5ex;
+    min-width: 96%;
+    width: fit-content;
+    background: #eee;
+}
+
+.md code {
+    /* All code, both in fenced blocks and inline. */
+    font-family: Consolas, Menlo, monospace;
+    font-size: 86%;
+    color: #000;
+    background: #eee;
+}
+
+.md pre.listing.tilde code {
+    /* Only code in fenced blocks. */
+    letter-spacing: -0.20;
+    background: #eee;
+}
+
+
+/* Hilight.js Syntax Coloring */
+
+.hljs-attr                 { color: #0ff; } /* Cyan Bright */
+.hljs-built_in             { color: #0cc; } /* Cyan */
+.hljs-comment              { color: #00f; } /* Blue */
+.hljs-doctag               { color: #fff; } /* White */
+.hljs-function .hljs-title { color: #f00; } /* Red */
+.hljs-keyword              { color: #0a0; } /* Green Dark */
+.hljs-literal              { color: #00a; } /* Blue Dark */
+.hljs-meta                 { color: #ff0; } /* Yellow Bright */
+.hljs-keyword              { color: #f0f; } /* Purple Bright */
+.hljs-meta .hljs-keyword   { color: #fa0; } /* Orange */
+.hljs-name                 { color: #0ff; font-weight: 900; } /* Cyan Bright Extra Bold */
+.hljs-number               { color: #f00; text-decoration: underline; } /* Red Underline */
+.hljs-operator             { color: #fff; } /* White */
+.hljs-params               { color: #f00; font-style: italic; } /* Red Italic */
+.hljs-string               { color: #aaa; } /* Gray */
+.hljs-tag                  { font-weight: 900; } /* Extra Bold */
+.hljs-title                { color: #b0b; } /* Purple Dark */
+.hljs-class_               { color: #0f0; } /* Green Bright */
+.hljs-type                 { color: #f00; font-weight: 900; } /* Red extra bold */
+
+/* Code Line Types */
+
+.md code > .highlight {
+    background-color: #ccdbc8;
+}
+
+.md code > .delete {
+    text-decoration: line-through;
+    background-color: #;
+    color: #a0a0a0;
+    background: #e0cfcc;
+}

--- a/style/book.css
+++ b/style/book.css
@@ -101,8 +101,16 @@ div.indented {
 
 /* Hilight.js Syntax Coloring */
 
+.hljs-built_in, .hljs-params, .hljs-type, .hljs-literal {
+    color: #222;
+}
+
 .hljs-comment {
     color: #40f;
+}
+
+.hljs-meta .hljs-keyword {
+    color: #f40;
 }
 
 .hljs-keyword {
@@ -131,7 +139,7 @@ div.indented {
     text-decoration: line-through;
     background-color: #;
     color: #a0a0a0;
-    background: #f4dcd8;
+    background: #e0cfcc;
 }
 
 .md div.listingcaption {


### PR DESCRIPTION
There were some changes to code styling with Markdeep 1.15, plus we wanted to just revisit our code styling, both in fenced blocks and inline.

Ultimately, I didn't find any improvement to our inline style.

For the general code style, I made preprocessor '#' characters and the preprocessor keywords get the same styling. I also suppressed styling for built-ins, parameters, types, and literals. I also tweaked the background for deleted lines as well, to make it a bit more desaturated.

Resolves #868
Resolves #1166