### PR TITLE
Fix CMake deprecation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See README.md for guidance.
 #---------------------------------------------------------------------------------------------------
 
-cmake_minimum_required ( VERSION 3.1.0 )
+cmake_minimum_required ( VERSION 3.1.0...3.27.0 )
 
 project ( RTWeekend LANGUAGES CXX )
 


### PR DESCRIPTION
The original specified a hard minimum of 3.1.0, which now yields the following warning from CMake:

  CMake Deprecation Warning at CMakeLists.txt:7 (cmake_minimum_required):
    Compatibility with CMake < 3.5 will be removed from a future version of
    CMake.

    Update the VERSION argument <min> value or use a ...<max> suffix to tell
    CMake that the project does not need compatibility with older versions.

Searched online and it looks like one should test their latest version and add that as a maximum minimum. As is typically the case with CMake, I still have lingering confusion about what exactly is going on here, but adding the latest tested version seems to hush things up.

Of course, the nagging concern is that this will have to be continually updated as time passes, which is pretty stupid.