### PR TITLE
Make linear_to_gamma robust for negative inputs

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -2595,12 +2595,16 @@ just need to be aware of it. We are going to transform our data into gamma space
 viewer can more accurately display our image. As a simple approximation, we can use “gamma 2” as our
 transform, which is the power that you use when going from gamma space to linear space. We need to
 go from linear space to gamma space, which means taking the inverse of "gamma 2", which means an
-exponent of $1/\mathit{gamma}$, which is just the square-root.
+exponent of $1/\mathit{gamma}$, which is just the square-root. We'll also want to ensure that we
+robustly handle negative inputs.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
     inline double linear_to_gamma(double linear_component)
     {
-        return sqrt(linear_component);
+        if (linear_component > 0)
+            return sqrt(linear_component);
+
+        return 0;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
@@ -3169,6 +3173,9 @@ When we combine them back together, we can write a function to calculate $\mathb
     [Listing [refract]: <kbd>[vec3.h]</kbd> Refraction function]
 
 </div>
+
+(Note here that we use the C++ standard function `fmin()`, which returns the minimum of the two
+arguments. Similarly, we will later use `fmax()`, which returns the maximum of the two arguments.)
 
 <div class='together'>
 And the dielectric material that always refracts is:

--- a/src/InOneWeekend/color.h
+++ b/src/InOneWeekend/color.h
@@ -19,7 +19,10 @@ using color = vec3;
 
 inline double linear_to_gamma(double linear_component)
 {
-    return sqrt(linear_component);
+    if (linear_component > 0)
+        return sqrt(linear_component);
+
+    return 0;
 }
 
 void write_color(std::ostream &out, color pixel_color, int samples_per_pixel) {

--- a/src/TheNextWeek/color.h
+++ b/src/TheNextWeek/color.h
@@ -19,7 +19,10 @@ using color = vec3;
 
 inline double linear_to_gamma(double linear_component)
 {
-    return sqrt(linear_component);
+    if (linear_component > 0)
+        return sqrt(linear_component);
+
+    return 0;
 }
 
 void write_color(std::ostream &out, color pixel_color, int samples_per_pixel) {

--- a/src/TheRestOfYourLife/color.h
+++ b/src/TheRestOfYourLife/color.h
@@ -19,7 +19,10 @@ using color = vec3;
 
 inline double linear_to_gamma(double linear_component)
 {
-    return sqrt(linear_component);
+    if (linear_component > 0)
+        return sqrt(linear_component);
+
+    return 0;
 }
 
 void write_color(std::ostream &out, color pixel_color, int samples_per_pixel) {


### PR DESCRIPTION
Without this hardening, we will return NaNs for negative inputs, which can happen from time to time.

I also ran across fmin/fmax in one implementation, which we never commented on in the books. Added an explanation for these two functions for readers unfamiliar with C++.

Resolves #1202