### PR TITLE
From C++ static_cast to ctor-like conversion

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -122,9 +122,9 @@ Let’s make some C++ code to output such a thing:
                 auto g = double(j) / (image_height-1);
                 auto b = 0;
 
-                int ir = static_cast<int>(255.999 * r);
-                int ig = static_cast<int>(255.999 * g);
-                int ib = static_cast<int>(255.999 * b);
+                int ir = int(255.999 * r);
+                int ig = int(255.999 * g);
+                int ib = int(255.999 * b);
 
                 std::cout << ir << ' ' << ig << ' ' << ib << '\n';
             }
@@ -240,9 +240,9 @@ instead write to the logging output stream (`std::clog`):
                 auto g = double(j) / (image_height-1);
                 auto b = 0;
 
-                int ir = static_cast<int>(255.999 * r);
-                int ig = static_cast<int>(255.999 * g);
-                int ib = static_cast<int>(255.999 * b);
+                int ir = int(255.999 * r);
+                int ig = int(255.999 * g);
+                int ib = int(255.999 * b);
 
                 std::cout << ir << ' ' << ig << ' ' << ib << '\n';
             }
@@ -405,9 +405,9 @@ that writes a single pixel's color out to the standard output stream.
 
     void write_color(std::ostream &out, color pixel_color) {
         // Write the translated [0,255] value of each color component.
-        out << static_cast<int>(255.999 * pixel_color.x()) << ' '
-            << static_cast<int>(255.999 * pixel_color.y()) << ' '
-            << static_cast<int>(255.999 * pixel_color.z()) << '\n';
+        out << int(255.999 * pixel_color.x()) << ' '
+            << int(255.999 * pixel_color.y()) << ' '
+            << int(255.999 * pixel_color.z()) << '\n';
     }
 
     #endif
@@ -548,12 +548,12 @@ to give us the desired aspect ratio. Here's a snippet of what this code will loo
     int image_width = 400;
 
     // Calculate the image height, and ensure that it's at least 1.
-    int image_height = static_cast<int>(image_width / aspect_ratio);
+    int image_height = int(image_width / aspect_ratio);
     image_height = (image_height < 1) ? 1 : image_height;
 
     // Viewport widths less than one are ok since they are real valued.
     auto viewport_height = 2.0;
-    auto viewport_width = viewport_height * (static_cast<double>(image_width)/image_height);
+    auto viewport_width = viewport_height * (double(image_width)/image_height);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [image-setup]: Rendered image setup]
 
@@ -634,14 +634,14 @@ return black for now.
         int image_width = 400;
 
         // Calculate the image height, and ensure that it's at least 1.
-        int image_height = static_cast<int>(image_width / aspect_ratio);
+        int image_height = int(image_width / aspect_ratio);
         image_height = (image_height < 1) ? 1 : image_height;
 
         // Camera
 
         auto focal_length = 1.0;
         auto viewport_height = 2.0;
-        auto viewport_width = viewport_height * (static_cast<double>(image_width)/image_height);
+        auto viewport_width = viewport_height * (double(image_width)/image_height);
         auto camera_center = point3(0, 0, 0);
 
         // Calculate the vectors across the horizontal and down the vertical viewport edges.
@@ -1426,7 +1426,7 @@ And the new main:
         int image_width = 400;
 
         // Calculate the image height, and ensure that it's at least 1.
-        int image_height = static_cast<int>(image_width / aspect_ratio);
+        int image_height = int(image_width / aspect_ratio);
         image_height = (image_height < 1) ? 1 : image_height;
 
 
@@ -1443,7 +1443,7 @@ And the new main:
 
         auto focal_length = 1.0;
         auto viewport_height = 2.0;
-        auto viewport_width = viewport_height * (static_cast<double>(image_width)/image_height);
+        auto viewport_width = viewport_height * (double(image_width)/image_height);
         auto camera_center = point3(0, 0, 0);
 
         // Calculate the vectors across the horizontal and down the vertical viewport edges.
@@ -1781,7 +1781,7 @@ migrated code:
         vec3   pixel_delta_v;  // Offset to pixel below
 
         void initialize() {
-            image_height = static_cast<int>(image_width / aspect_ratio);
+            image_height = int(image_width / aspect_ratio);
             image_height = (image_height < 1) ? 1 : image_height;
 
             center = point3(0, 0, 0);
@@ -1789,7 +1789,7 @@ migrated code:
             // Determine viewport dimensions.
             auto focal_length = 1.0;
             auto viewport_height = 2.0;
-            auto viewport_width = viewport_height * (static_cast<double>(image_width)/image_height);
+            auto viewport_width = viewport_height * (double(image_width)/image_height);
 
             // Calculate the vectors across the horizontal and down the vertical viewport edges.
             auto viewport_u = vec3(viewport_width, 0, 0);
@@ -1986,9 +1986,9 @@ and the number of samples involved:
 
         // Write the translated [0,255] value of each color component.
         static const interval intensity(0.000, 0.999);
-        out << static_cast<int>(256 * intensity.clamp(r)) << ' '
-            << static_cast<int>(256 * intensity.clamp(g)) << ' '
-            << static_cast<int>(256 * intensity.clamp(b)) << '\n';
+        out << int(256 * intensity.clamp(r)) << ' '
+            << int(256 * intensity.clamp(g)) << ' '
+            << int(256 * intensity.clamp(b)) << '\n';
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [write-color-clamped]: <kbd>[color.h]</kbd> The multi-sample write_color() function]
@@ -2632,9 +2632,9 @@ robustly handle negative inputs.
 
         // Write the translated [0,255] value of each color component.
         static const interval intensity(0.000, 0.999);
-        out << static_cast<int>(256 * intensity.clamp(r)) << ' '
-            << static_cast<int>(256 * intensity.clamp(g)) << ' '
-            << static_cast<int>(256 * intensity.clamp(b)) << '\n';
+        out << int(256 * intensity.clamp(r)) << ' '
+            << int(256 * intensity.clamp(g)) << ' '
+            << int(256 * intensity.clamp(b)) << '\n';
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [write-color-gamma]: <kbd>[color.h]</kbd> write_color(), with gamma correction]
@@ -3484,7 +3484,7 @@ This implies $h = \tan(\frac{\theta}{2})$. Our camera now becomes:
         ...
 
         void initialize() {
-            image_height = static_cast<int>(image_width / aspect_ratio);
+            image_height = int(image_width / aspect_ratio);
             image_height = (image_height < 1) ? 1 : image_height;
 
             center = point3(0, 0, 0);
@@ -3496,7 +3496,7 @@ This implies $h = \tan(\frac{\theta}{2})$. Our camera now becomes:
             auto h = tan(theta/2);
             auto viewport_height = 2 * h * focal_length;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-            auto viewport_width = viewport_height * (static_cast<double>(image_width)/image_height);
+            auto viewport_width = viewport_height * (double(image_width)/image_height);
 
             // Calculate the vectors across the horizontal and down the vertical viewport edges.
             auto viewport_u = vec3(viewport_width, 0, 0);
@@ -3621,7 +3621,7 @@ angles.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         void initialize() {
-            image_height = static_cast<int>(image_width / aspect_ratio);
+            image_height = int(image_width / aspect_ratio);
             image_height = (image_height < 1) ? 1 : image_height;
 
 
@@ -3636,7 +3636,7 @@ angles.
             auto theta = degrees_to_radians(vfov);
             auto h = tan(theta/2);
             auto viewport_height = 2 * h * focal_length;
-            auto viewport_width = viewport_height * (static_cast<double>(image_width)/image_height);
+            auto viewport_width = viewport_height * (double(image_width)/image_height);
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -3866,7 +3866,7 @@ Now let's update the camera to originate rays from the defocus disk:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         void initialize() {
-            image_height = static_cast<int>(image_width / aspect_ratio);
+            image_height = int(image_width / aspect_ratio);
             image_height = (image_height < 1) ? 1 : image_height;
 
             center = lookfrom;
@@ -3880,7 +3880,7 @@ Now let's update the camera to originate rays from the defocus disk:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             auto viewport_height = 2 * h * focus_dist;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-            auto viewport_width = viewport_height * (static_cast<double>(image_width)/image_height);
+            auto viewport_width = viewport_height * (double(image_width)/image_height);
 
             // Calculate the u,v,w unit basis vectors for the camera coordinate frame.
             w = unit_vector(lookfrom - lookat);

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -969,7 +969,7 @@ This uses a new function: `random_int()`:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     inline int random_int(int min, int max) {
         // Returns a random integer in [min,max].
-        return static_cast<int>(random_double(min, max+1));
+        return int(random_double(min, max+1));
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [random-int]: <kbd>[rtweekend.h]</kbd> A function to return random integers in a range]
@@ -1271,9 +1271,9 @@ pattern in the scene.
         {}
 
         color value(double u, double v, const point3& p) const override {
-            auto xInteger = static_cast<int>(std::floor(inv_scale * p.x()));
-            auto yInteger = static_cast<int>(std::floor(inv_scale * p.y()));
-            auto zInteger = static_cast<int>(std::floor(inv_scale * p.z()));
+            auto xInteger = int(std::floor(inv_scale * p.x()));
+            auto yInteger = int(std::floor(inv_scale * p.y()));
+            auto zInteger = int(std::floor(inv_scale * p.z()));
 
             bool isEven = (xInteger + yInteger + zInteger) % 2 == 0;
 
@@ -1739,8 +1739,8 @@ The `image_texture` class uses the `rtw_image` class:
             u = interval(0,1).clamp(u);
             v = 1.0 - interval(0,1).clamp(v);  // Flip V to image coordinates
 
-            auto i = static_cast<int>(u * image.width());
-            auto j = static_cast<int>(v * image.height());
+            auto i = int(u * image.width());
+            auto j = int(v * image.height());
             auto pixel = image.pixel_data(i,j);
 
             auto color_scale = 1.0 / 255.0;
@@ -1877,9 +1877,9 @@ code to make it all happen:
         }
 
         double noise(const point3& p) const {
-            auto i = static_cast<int>(4*p.x()) & 255;
-            auto j = static_cast<int>(4*p.y()) & 255;
-            auto k = static_cast<int>(4*p.z()) & 255;
+            auto i = int(4*p.x()) & 255;
+            auto j = int(4*p.y()) & 255;
+            auto k = int(4*p.z()) & 255;
 
             return ranfloat[perm_x[i] ^ perm_y[j] ^ perm_z[k]];
         }
@@ -2010,9 +2010,9 @@ To make it smooth, we can linearly interpolate:
             auto v = p.y() - floor(p.y());
             auto w = p.z() - floor(p.z());
 
-            auto i = static_cast<int>(floor(p.x()));
-            auto j = static_cast<int>(floor(p.y()));
-            auto k = static_cast<int>(floor(p.z()));
+            auto i = int(floor(p.x()));
+            auto j = int(floor(p.y()));
+            auto k = int(floor(p.z()));
             double c[2][2][2];
 
             for (int di=0; di < 2; di++)
@@ -2078,9 +2078,9 @@ a Hermite cubic to round off the interpolation:
             w = w*w*(3-2*w);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-            auto i = static_cast<int>(floor(p.x()));
-            auto j = static_cast<int>(floor(p.y()));
-            auto k = static_cast<int>(floor(p.z()));
+            auto i = int(floor(p.x()));
+            auto j = int(floor(p.y()));
+            auto k = int(floor(p.z()));
             ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [perlin-smoothed]: <kbd>[perlin.h]</kbd> Perlin smoothed]
@@ -2214,9 +2214,9 @@ The Perlin class `noise()` method is now:
             auto v = p.y() - floor(p.y());
             auto w = p.z() - floor(p.z());
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-            auto i = static_cast<int>(floor(p.x()));
-            auto j = static_cast<int>(floor(p.y()));
-            auto k = static_cast<int>(floor(p.z()));
+            auto i = int(floor(p.x()));
+            auto j = int(floor(p.y()));
+            auto k = int(floor(p.z()));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             vec3 c[2][2][2];
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -3597,7 +3597,7 @@ think both tactics would work fine, but I will go with instrumenting `hittable_l
         }
 
         vec3 random(const vec3& o) const override {
-            auto int_size = static_cast<int>(objects.size());
+            auto int_size = int(objects.size());
             return objects[random_int(0, int_size-1)]->random(o);
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -3681,9 +3681,9 @@ always remember for `NaN`s is that a `NaN` does not equal itself. Using this tri
 
         // Write the translated [0,255] value of each color component.
         static const interval intensity(0.000, 0.999);
-        out << static_cast<int>(256 * intensity.clamp(r)) << ' '
-            << static_cast<int>(256 * intensity.clamp(g)) << ' '
-            << static_cast<int>(256 * intensity.clamp(b)) << '\n';
+        out << int(256 * intensity.clamp(r)) << ' '
+            << int(256 * intensity.clamp(g)) << ' '
+            << int(256 * intensity.clamp(b)) << '\n';
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [write-color-nan]: <kbd>[color.h]</kbd> NaN-tolerant write_color function]

--- a/src/InOneWeekend/camera.h
+++ b/src/InOneWeekend/camera.h
@@ -66,7 +66,7 @@ class camera {
     vec3   defocus_disk_v;  // Defocus disk vertical radius
 
     void initialize() {
-        image_height = static_cast<int>(image_width / aspect_ratio);
+        image_height = int(image_width / aspect_ratio);
         image_height = (image_height < 1) ? 1 : image_height;
 
         center = lookfrom;
@@ -75,7 +75,7 @@ class camera {
         auto theta = degrees_to_radians(vfov);
         auto h = tan(theta/2);
         auto viewport_height = 2 * h * focus_dist;
-        auto viewport_width = viewport_height * (static_cast<double>(image_width)/image_height);
+        auto viewport_width = viewport_height * (double(image_width)/image_height);
 
         // Calculate the u,v,w unit basis vectors for the camera coordinate frame.
         w = unit_vector(lookfrom - lookat);

--- a/src/InOneWeekend/color.h
+++ b/src/InOneWeekend/color.h
@@ -43,9 +43,9 @@ void write_color(std::ostream &out, color pixel_color, int samples_per_pixel) {
 
     // Write the translated [0,255] value of each color component.
     static const interval intensity(0.000, 0.999);
-    out << static_cast<int>(256 * intensity.clamp(r)) << ' '
-        << static_cast<int>(256 * intensity.clamp(g)) << ' '
-        << static_cast<int>(256 * intensity.clamp(b)) << '\n';
+    out << int(256 * intensity.clamp(r)) << ' '
+        << int(256 * intensity.clamp(g)) << ' '
+        << int(256 * intensity.clamp(b)) << '\n';
 }
 
 

--- a/src/TheNextWeek/camera.h
+++ b/src/TheNextWeek/camera.h
@@ -67,7 +67,7 @@ class camera {
     vec3   defocus_disk_v;  // Defocus disk vertical radius
 
     void initialize() {
-        image_height = static_cast<int>(image_width / aspect_ratio);
+        image_height = int(image_width / aspect_ratio);
         image_height = (image_height < 1) ? 1 : image_height;
 
         center = lookfrom;
@@ -76,7 +76,7 @@ class camera {
         auto theta = degrees_to_radians(vfov);
         auto h = tan(theta/2);
         auto viewport_height = 2 * h * focus_dist;
-        auto viewport_width = viewport_height * (static_cast<double>(image_width)/image_height);
+        auto viewport_width = viewport_height * (double(image_width)/image_height);
 
         // Calculate the u,v,w unit basis vectors for the camera coordinate frame.
         w = unit_vector(lookfrom - lookat);

--- a/src/TheNextWeek/color.h
+++ b/src/TheNextWeek/color.h
@@ -43,9 +43,9 @@ void write_color(std::ostream &out, color pixel_color, int samples_per_pixel) {
 
     // Write the translated [0,255] value of each color component.
     static const interval intensity(0.000, 0.999);
-    out << static_cast<int>(256 * intensity.clamp(r)) << ' '
-        << static_cast<int>(256 * intensity.clamp(g)) << ' '
-        << static_cast<int>(256 * intensity.clamp(b)) << '\n';
+    out << int(256 * intensity.clamp(r)) << ' '
+        << int(256 * intensity.clamp(g)) << ' '
+        << int(256 * intensity.clamp(b)) << '\n';
 }
 
 

--- a/src/TheNextWeek/perlin.h
+++ b/src/TheNextWeek/perlin.h
@@ -38,9 +38,9 @@ class perlin {
         auto u = p.x() - floor(p.x());
         auto v = p.y() - floor(p.y());
         auto w = p.z() - floor(p.z());
-        auto i = static_cast<int>(floor(p.x()));
-        auto j = static_cast<int>(floor(p.y()));
-        auto k = static_cast<int>(floor(p.z()));
+        auto i = int(floor(p.x()));
+        auto j = int(floor(p.y()));
+        auto k = int(floor(p.z()));
         vec3 c[2][2][2];
 
         for (int di=0; di < 2; di++)

--- a/src/TheNextWeek/rtweekend.h
+++ b/src/TheNextWeek/rtweekend.h
@@ -44,7 +44,7 @@ inline double random_double(double min, double max) {
 
 inline int random_int(int min, int max) {
     // Returns a random integer in [min,max].
-    return static_cast<int>(random_double(min, max+1));
+    return int(random_double(min, max+1));
 }
 
 // Common Headers

--- a/src/TheNextWeek/texture.h
+++ b/src/TheNextWeek/texture.h
@@ -53,9 +53,9 @@ class checker_texture : public texture {
     {}
 
     color value(double u, double v, const point3& p) const override {
-        auto xInteger = static_cast<int>(std::floor(inv_scale * p.x()));
-        auto yInteger = static_cast<int>(std::floor(inv_scale * p.y()));
-        auto zInteger = static_cast<int>(std::floor(inv_scale * p.z()));
+        auto xInteger = int(std::floor(inv_scale * p.x()));
+        auto yInteger = int(std::floor(inv_scale * p.y()));
+        auto zInteger = int(std::floor(inv_scale * p.z()));
 
         bool isEven = (xInteger + yInteger + zInteger) % 2 == 0;
 
@@ -98,8 +98,8 @@ class image_texture : public texture {
         u = interval(0,1).clamp(u);
         v = 1.0 - interval(0,1).clamp(v);  // Flip V to image coordinates
 
-        auto i = static_cast<int>(u * image.width());
-        auto j = static_cast<int>(v * image.height());
+        auto i = int(u * image.width());
+        auto j = int(v * image.height());
         auto pixel = image.pixel_data(i,j);
 
         auto color_scale = 1.0 / 255.0;

--- a/src/TheRestOfYourLife/camera.h
+++ b/src/TheRestOfYourLife/camera.h
@@ -71,7 +71,7 @@ class camera {
     vec3   defocus_disk_v;  // Defocus disk vertical radius
 
     void initialize() {
-        image_height = static_cast<int>(image_width / aspect_ratio);
+        image_height = int(image_width / aspect_ratio);
         image_height = (image_height < 1) ? 1 : image_height;
 
         center = lookfrom;
@@ -80,9 +80,9 @@ class camera {
         auto theta = degrees_to_radians(vfov);
         auto h = tan(theta/2);
         auto viewport_height = 2 * h * focus_dist;
-        auto viewport_width = viewport_height * (static_cast<double>(image_width)/image_height);
+        auto viewport_width = viewport_height * (double(image_width)/image_height);
 
-        sqrt_spp = static_cast<int>(sqrt(samples_per_pixel));
+        sqrt_spp = int(sqrt(samples_per_pixel));
         recip_sqrt_spp = 1.0 / sqrt_spp;
 
         // Calculate the u,v,w unit basis vectors for the camera coordinate frame.

--- a/src/TheRestOfYourLife/color.h
+++ b/src/TheRestOfYourLife/color.h
@@ -48,9 +48,9 @@ void write_color(std::ostream &out, color pixel_color, int samples_per_pixel) {
 
     // Write the translated [0,255] value of each color component.
     static const interval intensity(0.000, 0.999);
-    out << static_cast<int>(256 * intensity.clamp(r)) << ' '
-        << static_cast<int>(256 * intensity.clamp(g)) << ' '
-        << static_cast<int>(256 * intensity.clamp(b)) << '\n';
+    out << int(256 * intensity.clamp(r)) << ' '
+        << int(256 * intensity.clamp(g)) << ' '
+        << int(256 * intensity.clamp(b)) << '\n';
 }
 
 

--- a/src/TheRestOfYourLife/hittable_list.h
+++ b/src/TheRestOfYourLife/hittable_list.h
@@ -63,7 +63,7 @@ class hittable_list : public hittable {
     }
 
     vec3 random(const vec3 &o) const override {
-        auto int_size = static_cast<int>(objects.size());
+        auto int_size = int(objects.size());
         return objects[random_int(0, int_size-1)]->random(o);
     }
 

--- a/src/TheRestOfYourLife/perlin.h
+++ b/src/TheRestOfYourLife/perlin.h
@@ -38,9 +38,9 @@ class perlin {
         auto u = p.x() - floor(p.x());
         auto v = p.y() - floor(p.y());
         auto w = p.z() - floor(p.z());
-        auto i = static_cast<int>(floor(p.x()));
-        auto j = static_cast<int>(floor(p.y()));
-        auto k = static_cast<int>(floor(p.z()));
+        auto i = int(floor(p.x()));
+        auto j = int(floor(p.y()));
+        auto k = int(floor(p.z()));
         vec3 c[2][2][2];
 
         for (int di=0; di < 2; di++)

--- a/src/TheRestOfYourLife/rtweekend.h
+++ b/src/TheRestOfYourLife/rtweekend.h
@@ -44,7 +44,7 @@ inline double random_double(double min, double max) {
 
 inline int random_int(int min, int max) {
     // Returns a random integer in [min,max].
-    return static_cast<int>(random_double(min, max+1));
+    return int(random_double(min, max+1));
 }
 
 // Common Headers

--- a/src/TheRestOfYourLife/texture.h
+++ b/src/TheRestOfYourLife/texture.h
@@ -53,9 +53,9 @@ class checker_texture : public texture {
     {}
 
     color value(double u, double v, const point3& p) const override {
-        auto xInteger = static_cast<int>(std::floor(inv_scale * p.x()));
-        auto yInteger = static_cast<int>(std::floor(inv_scale * p.y()));
-        auto zInteger = static_cast<int>(std::floor(inv_scale * p.z()));
+        auto xInteger = int(std::floor(inv_scale * p.x()));
+        auto yInteger = int(std::floor(inv_scale * p.y()));
+        auto zInteger = int(std::floor(inv_scale * p.z()));
 
         bool isEven = (xInteger + yInteger + zInteger) % 2 == 0;
 
@@ -98,8 +98,8 @@ class image_texture : public texture {
         u = interval(0,1).clamp(u);
         v = 1.0 - interval(0,1).clamp(v);  // Flip V to image coordinates
 
-        auto i = static_cast<int>(u * image.width());
-        auto j = static_cast<int>(v * image.height());
+        auto i = int(u * image.width());
+        auto j = int(v * image.height());
         auto pixel = image.pixel_data(i,j);
 
         auto color_scale = 1.0 / 255.0;


### PR DESCRIPTION
Instead of `static_cast<double>(x)` switch to `double(x)` for easier readability for non-C++ readers and simple for C++ readers alike. In the end, these are the same thing.

Resolves #1222