### PR TITLE
Update reference to Foley & van Dam book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ then.
   - Fix - Fix references from `random_in_hemisphere()` to `random_on_hemisphere()` (#1198)
 
 ### In One Weekend
+  - Update reference to "Fundamentals of Interactive Computer Graphics" to "Computer Graphics:
+    Principles and Practice". This is the name used by newer editions of the book.
 
 ### The Next Week
 

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -63,7 +63,7 @@ solution.
 We assume a little bit of familiarity with vectors (like dot product and vector addition). If you
 don’t know that, do a little review. If you need that review, or to learn it for the first time,
 check out the online [_Graphics Codex_][gfx-codex] by Morgan McGuire, _Fundamentals of Computer
-Graphics_ by Steve Marschner and Peter Shirley, or _Fundamentals of Interactive Computer Graphics_
+Graphics_ by Steve Marschner and Peter Shirley, or _Computer Graphics: Principles and Practice_
 by J.D. Foley and Andy Van Dam.
 
 Peter maintains a site related to this book series at https://in1weekend.blogspot.com/, which


### PR DESCRIPTION
The book currently refers to "Fundamentals of Interactive Computer Graphics". That was certainly one of the seminal books of the field but it has been rewritten by the same (and a few other) authors since it was first published in 1982 and renamed "Computer Graphics: Principles and Practice". I think it is a lot easier to find copies of the newer editions today, they cover more topics, are more up-to-date in general.

I think it makes sense to refer to the book by it's newer name (well, it was new in 1990). There is a brief history of the book at https://en.wikipedia.org/wiki/Computer_Graphics:_Principles_and_Practice if you're curious.

For your consideration.