### PR TITLE
Clean up ray constructors

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -71,11 +71,11 @@ time for each ray:
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        ray(const point3& origin, const vec3& direction) : orig(origin), dir(direction), tm(0) {}
+        ray(const point3& origin, const vec3& direction)
+          : orig(origin), dir(direction), tm(0) {}
 
         ray(const point3& origin, const vec3& direction, double time)
-          : orig(origin), dir(direction), tm(time)
-        {}
+          : orig(origin), dir(direction), tm(time) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         point3 origin() const  { return orig; }

--- a/src/TheNextWeek/ray.h
+++ b/src/TheNextWeek/ray.h
@@ -18,12 +18,11 @@ class ray {
   public:
     ray() {}
 
-    ray(const point3& origin, const vec3& direction) : orig(origin), dir(direction), tm(0)
-    {}
+    ray(const point3& origin, const vec3& direction)
+      : orig(origin), dir(direction), tm(0) {}
 
     ray(const point3& origin, const vec3& direction, double time)
-      : orig(origin), dir(direction), tm(time)
-    {}
+      : orig(origin), dir(direction), tm(time) {}
 
     point3 origin() const  { return orig; }
     vec3 direction() const { return dir; }

--- a/src/TheRestOfYourLife/ray.h
+++ b/src/TheRestOfYourLife/ray.h
@@ -18,12 +18,11 @@ class ray {
   public:
     ray() {}
 
-    ray(const point3& origin, const vec3& direction) : orig(origin), dir(direction), tm(0)
-    {}
+    ray(const point3& origin, const vec3& direction)
+      : orig(origin), dir(direction), tm(0) {}
 
     ray(const point3& origin, const vec3& direction, double time)
-      : orig(origin), dir(direction), tm(time)
-    {}
+      : orig(origin), dir(direction), tm(time) {}
 
     point3 origin() const  { return orig; }
     vec3 direction() const { return dir; }


### PR DESCRIPTION
Eliminate the defaulted time parameter originally present in the book (though not reflected in the source).