### PR TITLE
perlin::turb() now requires both parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ then.
   - Fix - Fix references from `random_in_hemisphere()` to `random_on_hemisphere()` (#1198)
 
 ### In One Weekend
-  - Update reference to "Fundamentals of Interactive Computer Graphics" to "Computer Graphics:
-    Principles and Practice". This is the name used by newer editions of the book.
+  - Change - Update reference to "Fundamentals of Interactive Computer Graphics" to "Computer
+    Graphics: Principles and Practice". This is the name used by newer editions of the book.
 
 ### The Next Week
+  - Change - `perlin::turb()` no longer defaults the value for the depth parameter.
 
 ### The Rest of Your Life
 

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -2306,7 +2306,7 @@ turbulence, and is a sum of repeated calls to noise:
       ...
       public:
         ...
-        double turb(const point3& p, int depth=7) const {
+        double turb(const point3& p, int depth) const {
             auto accum = 0.0;
             auto temp_p = p;
             auto weight = 1.0;
@@ -2335,7 +2335,7 @@ Here `fabs()` is the absolute value function defined in `<cmath>`.
         color value(double u, double v, const point3& p) const override {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             auto s = scale * p;
-            return color(1,1,1) * noise.turb(s);
+            return color(1,1,1) * noise.turb(s, 7);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
 
@@ -2373,7 +2373,7 @@ effect is:
         color value(double u, double v, const point3& p) const override {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             auto s = scale * p;
-            return color(1,1,1) * 0.5 * (1 + sin(s.z() + 10*noise.turb(s)));
+            return color(1,1,1) * 0.5 * (1 + sin(s.z() + 10*noise.turb(s, 7)));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
 

--- a/src/TheNextWeek/perlin.h
+++ b/src/TheNextWeek/perlin.h
@@ -55,7 +55,7 @@ class perlin {
         return perlin_interp(c, u, v, w);
     }
 
-    double turb(const point3& p, int depth=7) const {
+    double turb(const point3& p, int depth) const {
         auto accum = 0.0;
         auto temp_p = p;
         auto weight = 1.0;

--- a/src/TheNextWeek/texture.h
+++ b/src/TheNextWeek/texture.h
@@ -77,7 +77,7 @@ class noise_texture : public texture {
 
     color value(double u, double v, const point3& p) const override {
         auto s = scale * p;
-        return color(1,1,1)*0.5*(1 + sin(s.z() + 10*noise.turb(s)));
+        return color(1,1,1)*0.5*(1 + sin(s.z() + 10*noise.turb(s, 7)));
     }
 
   private:

--- a/src/TheRestOfYourLife/perlin.h
+++ b/src/TheRestOfYourLife/perlin.h
@@ -55,7 +55,7 @@ class perlin {
         return perlin_interp(c, u, v, w);
     }
 
-    double turb(const point3& p, int depth=7) const {
+    double turb(const point3& p, int depth) const {
         auto accum = 0.0;
         auto temp_p = p;
         auto weight = 1.0;

--- a/src/TheRestOfYourLife/texture.h
+++ b/src/TheRestOfYourLife/texture.h
@@ -77,7 +77,7 @@ class noise_texture : public texture {
 
     color value(double u, double v, const point3& p) const override {
         auto s = scale * p;
-        return color(1,1,1)*0.5*(1 + sin(s.z() + 10*noise.turb(s)));
+        return color(1,1,1)*0.5*(1 + sin(s.z() + 10*noise.turb(s, 7)));
     }
 
   private:


### PR DESCRIPTION
The original version defaulted the `depth` parameter to 7.

This was the second instance of default parameters in the book source. The first was for the time value in the `ray` constructor, which we addressed by implementing two constructors.

Generally, we're leaning away from using default parameter values in the interest of simplicity and clarity.