### PR TITLE
ray origin() and direction() getters return const&

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -508,8 +508,8 @@ function that we'll call `ray::at(t)`:
 
         ray(const point3& origin, const vec3& direction) : orig(origin), dir(direction) {}
 
-        point3 origin() const  { return orig; }
-        vec3 direction() const { return dir; }
+        const point3& origin() const  { return orig; }
+        const vec3& direction() const { return dir; }
 
         point3 at(double t) const {
             return orig + t*dir;
@@ -525,6 +525,10 @@ function that we'll call `ray::at(t)`:
     [Listing [ray-initial]: <kbd>[ray.h]</kbd> The ray class]
 
 </div>
+
+(For those unfamiliar with C++, the functions `ray::origin()` and `ray::direction()` both return an
+immutable reference to their members. Callers can either just use the reference directly, or make a
+mutable copy depending on their needs.)
 
 
 Sending Rays Into the Scene

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -78,10 +78,12 @@ time for each ray:
           : orig(origin), dir(direction), tm(time) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-        point3 origin() const  { return orig; }
-        vec3 direction() const { return dir; }
+        const point3& origin() const  { return orig; }
+        const vec3& direction() const { return dir; }
+
+
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        double time() const    { return tm; }
+        double time() const { return tm; }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         point3 at(double t) const {

--- a/src/InOneWeekend/ray.h
+++ b/src/InOneWeekend/ray.h
@@ -20,8 +20,8 @@ class ray {
 
     ray(const point3& origin, const vec3& direction) : orig(origin), dir(direction) {}
 
-    point3 origin() const  { return orig; }
-    vec3 direction() const { return dir; }
+    const point3& origin() const  { return orig; }
+    const vec3& direction() const { return dir; }
 
     point3 at(double t) const {
         return orig + t*dir;

--- a/src/TheNextWeek/ray.h
+++ b/src/TheNextWeek/ray.h
@@ -24,9 +24,10 @@ class ray {
     ray(const point3& origin, const vec3& direction, double time)
       : orig(origin), dir(direction), tm(time) {}
 
-    point3 origin() const  { return orig; }
-    vec3 direction() const { return dir; }
-    double time() const    { return tm; }
+    const point3& origin() const  { return orig; }
+    const vec3& direction() const { return dir; }
+
+    double time() const { return tm; }
 
     point3 at(double t) const {
         return orig + t*dir;

--- a/src/TheRestOfYourLife/ray.h
+++ b/src/TheRestOfYourLife/ray.h
@@ -24,9 +24,10 @@ class ray {
     ray(const point3& origin, const vec3& direction, double time)
       : orig(origin), dir(direction), tm(time) {}
 
-    point3 origin() const  { return orig; }
-    vec3 direction() const { return dir; }
-    double time() const    { return tm; }
+    const point3& origin() const  { return orig; }
+    const vec3& direction() const { return dir; }
+
+    double time() const { return tm; }
 
     point3 at(double t) const {
         return orig + t*dir;


### PR DESCRIPTION
Update the ray::origin() and ray::direction() functions to return a const reference to their members instead of always making a return value copy.