### PR TITLE
Aabb rewrite

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1231,7 +1231,8 @@ know more about the specific geometry.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [front-face-tracking]: <kbd>[hittable.h]</kbd>
-        Adding front-face tracking to hit_record]
+        Adding front-face tracking to hit_record
+    ]
 
 <div class='together'>
 And then we add the surface side determination to the class:
@@ -1618,7 +1619,8 @@ and a maximum. We'll end up using this class quite often as we proceed.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [hittable-list-with-interval]: <kbd>[hittable_list.h]</kbd>
-        hittable_list::hit() using interval]
+        hittable_list::hit() using interval
+    ]
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2328,7 +2330,8 @@ return 50% of the color from a bounce. We should expect to get a nice gray color
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-random-unit]: <kbd>[camera.h]</kbd>
-        ray_color() using a random ray direction]
+        ray_color() using a random ray direction
+    ]
 
 <div class='together'>
 ... Indeed we do get rather nice gray spheres:
@@ -2478,7 +2481,8 @@ to address this is just to ignore hits that are very close to the calculated int
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [reflect-tolerance]: <kbd>[camera.h]</kbd>
-        Calculating reflected ray origins with tolerance]
+        Calculating reflected ray origins with tolerance
+    ]
 
 <div class='together'>
 This gets rid of the shadow acne problem. Yes it is really called that. Here's the result:
@@ -2585,30 +2589,30 @@ life, a light grey) but they appear to be rather dark. We can see this more clea
 through the full brightness gamut for our diffuse material. We start by setting the reflectance of
 the `ray_color` function from `0.5` (50%) to `0.1` (10%):
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-class camera {
-    ...
-    color ray_color(const ray& r, int depth, const hittable& world) const {
-        hit_record rec;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    class camera {
+        ...
+        color ray_color(const ray& r, int depth, const hittable& world) const {
+            hit_record rec;
 
-        // If we've exceeded the ray bounce limit, no more light is gathered.
-        if (depth <= 0)
-            return color(0,0,0);
+            // If we've exceeded the ray bounce limit, no more light is gathered.
+            if (depth <= 0)
+                return color(0,0,0);
 
-        if (world.hit(r, interval(0.001, infinity), rec)) {
-            vec3 direction = rec.normal + random_unit_vector();
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-            return 0.1 * ray_color(ray(rec.p, direction), depth-1, world);
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    }
+            if (world.hit(r, interval(0.001, infinity), rec)) {
+                vec3 direction = rec.normal + random_unit_vector();
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+                return 0.1 * ray_color(ray(rec.p, direction), depth-1, world);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+        }
 
-        vec3 unit_direction = unit_vector(r.direction());
-        auto a = 0.5*(unit_direction.y() + 1.0);
-        return (1.0-a)*color(1.0, 1.0, 1.0) + a*color(0.5, 0.7, 1.0);
-    }
-};
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[Listing [ray-color-gamut]: <kbd>[camera.h]</kbd> ray_color() with 10% reflectance]
+            vec3 unit_direction = unit_vector(r.direction());
+            auto a = 0.5*(unit_direction.y() + 1.0);
+            return (1.0-a)*color(1.0, 1.0, 1.0) + a*color(0.5, 0.7, 1.0);
+        }
+    };
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    [Listing [ray-color-gamut]: <kbd>[camera.h]</kbd> ray_color() with 10% reflectance]
 
 We render out at this new 10% reflectance. We then set reflectance to 30% and render again. We
 repeat for 50%, 70%, and finally 90%. You can overlay these images from left to right in the photo
@@ -2673,7 +2677,6 @@ robustly handle negative inputs.
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [write-color-gamma]: <kbd>[color.h]</kbd> write_color(), with gamma correction]
-
 
 <div class='together'>
 Using this gamma correction, we now get a much more consistent ramp from darkness to lightness:
@@ -2799,7 +2802,8 @@ To achieve this, `hit_record` needs to be told the material that is assigned to 
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [sphere-material]: <kbd>[sphere.h]</kbd>
-        Ray-sphere intersection with added material information]
+        Ray-sphere intersection with added material information
+    ]
 
 </div>
 
@@ -3248,7 +3252,8 @@ And the dielectric material that always refracts is:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [dielectric-always-refract]: <kbd>[material.h]</kbd>
-        Dielectric material class that always refracts]
+        Dielectric material class that always refracts
+    ]
 
 </div>
 
@@ -3306,6 +3311,7 @@ solution does not exist, the glass cannot refract, and therefore must reflect th
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [dielectric-can-refract-1]: <kbd>[material.h]</kbd> Determining if the ray can refract]
+
 </div>
 
 Here all the light is reflected, and because in practice that is usually inside solid objects, it is
@@ -3370,7 +3376,8 @@ And the dielectric material that always refracts (when possible) is:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [dielectric-with-refraction]: <kbd>[material.h]</kbd>
-        Dielectric material class with reflection]
+        Dielectric material class with reflection
+    ]
 
 </div>
 
@@ -3468,7 +3475,8 @@ In your own implementation, you might have been tempted to instead do something 
     vec3 outward_normal = (rec.p - center).unit_vector();
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [improper-invert-sphere-normal]:
-    Problematic normal calculation for spheres with negative radii]
+        Problematic normal calculation for spheres with negative radii
+    ]
 
 If you do that, spheres with negative radii won't work properly. Since a sphere with a negative
 radius is a _bubble_, its interior is the infinite space outside the sphere. Its exterior is the

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -543,7 +543,7 @@ between $x_0$ and $x_1$. So, using min and max should get us the right answers:
 
 The remaining troublesome case if we do that is if $d_x = 0$ and either $x_0 - A_x = 0$ or
 $x_1 - A_x = 0$ so we get a `NaN`. In that case we can arbitrarily interpret that as either hit or
-no hit, but we’ll revisit that later.
+no hit. If you look at the code below, you'll see that we go with "no hit".
 
 Now, let’s look at the pseudo-function `overlaps`. Suppose we can assume the intervals are not
 reversed, and we want to return true when the intervals overlap. The boolean `overlaps()` function
@@ -569,8 +569,10 @@ given amount:
     class interval {
       public:
         ...
-        double size() const {
-            return max - min;
+        double clamp(double x) const {
+            if (x < min) return min;
+            if (x > max) return max;
+            return x;
         }
 
 
@@ -581,7 +583,7 @@ given amount:
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-        ...
+        static const interval empty, universe;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [interval-expand]: <kbd>[interval.h]</kbd> interval::expand() method]
@@ -612,9 +614,9 @@ Now we have everything we need to implment the new AABB class.
         aabb(const point3& a, const point3& b) {
             // Treat the two points a and b as extrema for the bounding box, so we don't require a
             // particular minimum/maximum coordinate order.
-            x = interval(fmin(a[0],b[0]), fmax(a[0],b[0]));
-            y = interval(fmin(a[1],b[1]), fmax(a[1],b[1]));
-            z = interval(fmin(a[2],b[2]), fmax(a[2],b[2]));
+            x = span(a[0],b[0]);
+            y = span(a[1],b[1]);
+            z = span(a[2],b[2]);
 
             pad_to_minimums();
         }
@@ -627,13 +629,14 @@ Now we have everything we need to implment the new AABB class.
 
         bool hit(const ray& r, interval ray_t) const {
             for (int a = 0; a < 3; a++) {
-                auto t0 = fmin((axis(a).min - r.origin()[a]) / r.direction()[a],
-                               (axis(a).max - r.origin()[a]) / r.direction()[a]);
-                auto t1 = fmax((axis(a).min - r.origin()[a]) / r.direction()[a],
-                               (axis(a).max - r.origin()[a]) / r.direction()[a]);
-                ray_t.min = fmax(t0, ray_t.min);
-                ray_t.max = fmin(t1, ray_t.max);
-                if (ray_t.max <= ray_t.min)
+                const interval& ax = axis(a);
+                auto ao = r.origin()[a];
+                auto ad = r.direction()[a];
+
+                auto t_interval = span((ax.min - ao) / ad, (ax.max - ao) / ad);
+                ray_t = ray_t.intersect(t_interval);
+
+                if (ray_t.is_empty())
                     return false;
             }
             return true;
@@ -657,40 +660,67 @@ Now we have everything we need to implment the new AABB class.
 
 </div>
 
-
-An Optimized AABB Hit Method
------------------------------
-In reviewing this intersection method, Andrew Kensler at Pixar tried some experiments and proposed
-the following version of the code. It works extremely well on many compilers, and I have adopted it
-as my go-to method:
+<div class='together'>
+The new code above introduces new interval functions we need to write: `interval::is_empty()`,
+`interval::intersect()`, and `span()`.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    class aabb {
-      public:
+    class interval {
         ...
-        bool hit(const ray& r, interval ray_t) const {
-            for (int a = 0; a < 3; a++) {
-                auto invD = 1 / r.direction()[a];
-                auto orig = r.origin()[a];
-
-                auto t0 = (axis(a).min - orig) * invD;
-                auto t1 = (axis(a).max - orig) * invD;
-
-                if (invD < 0)
-                    std::swap(t0, t1);
-
-                if (t0 > ray_t.min) ray_t.min = t0;
-                if (t1 < ray_t.max) ray_t.max = t1;
-
-                if (ray_t.max <= ray_t.min)
-                    return false;
-            }
-            return true;
+        interval(const interval& a, const interval& b) {
+            // Create the interval tightly enclosing the two input intervals.
+            min = a.min <= b.min ? a.min : b.min;
+            max = a.max >= b.max ? a.max : b.max;
         }
+
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ Highlight
+        bool is_empty() const {
+            // Returns false if the interval is empty (inside out), or if either bound is a
+            // floating-point NaN (not a number).
+            return !(min <= max);
+        }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
         ...
+
+        interval expand(double delta) const {
+            auto padding = delta/2;
+            return interval(min - padding, max + padding);
+        }
+
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+        interval intersect(interval& other) const {
+            double a = min >= other.min ? min : other.min;
+            double b = max <= other.max ? max : other.max;
+            return interval(a,b);
+        }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
+        static const interval empty, universe;
     };
+
+    ...
+
+    interval operator+(double displacement, const interval& ival) {
+        return ival + displacement;
+    }
+
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ Highlight
+    inline interval span(double a, double b) {
+        // Return the non-empty interval between a and b, regardless of their order.
+        if (a > b)
+            return interval(b, a);
+        return interval(a, b);
+    }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [aabb-hit]: <kbd>[aabb.h]</kbd> Optional optimized AABB hit function]
+    [Listing [new-interval-funcs]: <kbd>[interval.h]</kbd>
+        New interval functions is_empty(), intersect() and span()
+    ]
+
+</div>
 
 
 Constructing Bounding Boxes for Hittables
@@ -793,12 +823,19 @@ constructor that takes two intervals as input:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class interval {
       public:
-        ...
+        double min, max;
+
+        interval() : min(+infinity), max(-infinity) {} // Default interval is empty
+
+        interval(double _min, double _max) : min(_min), max(_max) {}
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        interval(const interval& a, const interval& b)
-          : min(fmin(a.min, b.min)), max(fmax(a.max, b.max)) {}
+        interval(const interval& a, const interval& b) {
+            // Create the interval tightly enclosing the two input intervals.
+            min = a.min <= b.min ? a.min : b.min;
+            max = a.max >= b.max ? a.max : b.max;
+        }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         double size() const {

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -463,20 +463,20 @@ undefined.)
 How do we find the intersection between a ray and a plane? Recall that the ray is just defined by a
 function that--given a parameter $t$--returns a location $\mathbf{P}(t)$:
 
-  $$ \mathbf{P}(t) = \mathbf{A} + t \mathbf{d} $$
+  $$ \mathbf{P}(t) = \mathbf{Q} + t \mathbf{d} $$
 
-This equation applies to all three of the x/y/z coordinates. For example, $x(t) = A_x + t d_x$. This
+This equation applies to all three of the x/y/z coordinates. For example, $x(t) = Q_x + t d_x$. This
 ray hits the plane $x = x_0$ at the parameter $t$ that satisfies this equation:
 
-  $$ x_0 = A_x + t_0 d_x $$
+  $$ x_0 = Q_x + t_0 d_x $$
 
 So $t$ at the intersection is given by
 
-  $$ t_0 = \frac{x_0 - A_x}{d_x} $$
+  $$ t_0 = \frac{x_0 - Q_x}{d_x} $$
 
 We get the similar expression for $x_1$:
 
-  $$ t_1 = \frac{x_1 - A_x}{d_x} $$
+  $$ t_1 = \frac{x_1 - Q_x}{d_x} $$
 
 <div class='together'>
 The key observation to turn that 1D math into a 2D or 3D hit test is this: if a ray intersects the
@@ -519,8 +519,8 @@ love the slab method:
 There are some caveats that make this less pretty than it first appears. Consider again the 1D
 equations for $t_0$ and $t_1$:
 
-  $$ t_0 = \frac{x_0 - A_x}{d_x} $$
-  $$ t_1 = \frac{x_1 - A_x}{d_x} $$
+  $$ t_0 = \frac{x_0 - Q_x}{d_x} $$
+  $$ t_1 = \frac{x_1 - Q_x}{d_x} $$
 
 First, suppose the ray is traveling in the negative $\mathbf{x}$ direction. The interval $(t_{x0},
 t_{x1})$ as computed above might be reversed, like $(7, 3)$ for example. Second, the denominator
@@ -532,17 +532,17 @@ The good news for $d_x = 0$ is that $t_{x0}$ and $t_{x1}$ will be equal: both +â
 between $x_0$ and $x_1$. So, using min and max should get us the right answers:
 
   $$ t_{x0} = \min(
-     \frac{x_0 - A_x}{d_x},
-     \frac{x_1 - A_x}{d_x})
+     \frac{x_0 - Q_x}{d_x},
+     \frac{x_1 - Q_x}{d_x})
   $$
 
   $$ t_{x1} = \max(
-     \frac{x_0 - A_x}{d_x},
-     \frac{x_1 - A_x}{d_x})
+     \frac{x_0 - Q_x}{d_x},
+     \frac{x_1 - Q_x}{d_x})
   $$
 
-The remaining troublesome case if we do that is if $d_x = 0$ and either $x_0 - A_x = 0$ or
-$x_1 - A_x = 0$ so we get a `NaN`. In that case we can arbitrarily interpret that as either hit or
+The remaining troublesome case if we do that is if $d_x = 0$ and either $x_0 - Q_x = 0$ or
+$x_1 - Q_x = 0$ so we get a `NaN`. In that case we can arbitrarily interpret that as either hit or
 no hit. If you look at the code below, you'll see that we go with "no hit".
 
 Now, letâ€™s look at the pseudo-function `overlaps`. Suppose we can assume the intervals are not
@@ -661,17 +661,17 @@ Now we have everything we need to implment the new AABB class.
 </div>
 
 <div class='together'>
-The new code above introduces new interval functions we need to write: `interval::is_empty()`,
+The new code above relies on three new interval functions we need to write: `interval::is_empty()`,
 `interval::intersect()`, and `span()`.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class interval {
-        ...
-        interval(const interval& a, const interval& b) {
-            // Create the interval tightly enclosing the two input intervals.
-            min = a.min <= b.min ? a.min : b.min;
-            max = a.max >= b.max ? a.max : b.max;
-        }
+      public:
+        double min, max;
+
+        interval() : min(+infinity), max(-infinity) {} // Default interval is empty
+
+        interval(double _min, double _max) : min(_min), max(_max) {}
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ Highlight
@@ -854,13 +854,20 @@ Now we can use this to construct an axis-aligned bounding box from two input box
     class aabb {
       public:
         ...
+
+        aabb(const point3& a, const point3& b) {
+            ...
+        }
+
+
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         aabb(const aabb& box0, const aabb& box1) {
             x = interval(box0.x, box1.x);
             y = interval(box0.y, box1.y);
             z = interval(box0.z, box1.z);
         }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
         ...
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -353,8 +353,9 @@ $t=0$ to $\mathbf{C} + (0, r/2, 0)$ at time $t=1$:
         cam.render(world);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [scene-spheres-moving]:
-    <kbd>[main.cc]</kbd> Last book's final scene, but with moving spheres]
+    [Listing [scene-spheres-moving]: <kbd>[main.cc]</kbd>
+        Last book's final scene, but with moving spheres
+    ]
 
 <div class='together'>
 This gives the following result:
@@ -1164,7 +1165,8 @@ Now to implement the empty `aabb` code and the new `aabb::longest_axis()` functi
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [aabb-empty-and-axis]: <kbd>[aabb.h]</kbd>
-    New aabb constants and longest_axis() function]
+        New aabb constants and longest_axis() function
+    ]
 
 As before, you should see identical results to [image 1](#image-bouncing-spheres), but rendering a
 little bit faster. On my system, this yields something like an additional 18% render speedup. Not
@@ -2659,8 +2661,7 @@ Add the planar values to the `quad` class:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [quad-plane1]:
-        <kbd>[quad.h]</kbd> Caching thel planar values]
+    [Listing [quad-plane1]: <kbd>[quad.h]</kbd> Caching the planar values]
 
 </div>
 
@@ -3006,6 +3007,7 @@ And now we add a new scene to demonstrate our new `quad` primitive:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [quad-scene]: <kbd>[main.cc]</kbd> A new scene with quads]
+
 </div>
 
   ![<span class='num'>Image 16:</span> Quads](../images/img-2.16-quads.png class='pixel')
@@ -3139,7 +3141,8 @@ the new `color_from_emission` value.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-emitted]: <kbd>[camera.h]</kbd>
-    ray_color function with background and emitting materials]
+        ray_color function with background and emitting materials
+    ]
 
 <div class='together'>
 `main()` is updated to set the background color for the prior scenes:
@@ -3580,8 +3583,9 @@ with an addition operator as well.
         return ival + displacement;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [interval-plus-displacement]:
-    <kbd>[interval.h]</kbd> The interval + displacement operator]
+    [Listing [interval-plus-displacement]: <kbd>[interval.h]</kbd>
+        The interval + displacement operator
+    ]
 
 
 Instance Rotation

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -463,20 +463,20 @@ undefined.)
 How do we find the intersection between a ray and a plane? Recall that the ray is just defined by a
 function that--given a parameter $t$--returns a location $\mathbf{P}(t)$:
 
-  $$ \mathbf{P}(t) = \mathbf{A} + t \mathbf{b} $$
+  $$ \mathbf{P}(t) = \mathbf{A} + t \mathbf{d} $$
 
-This equation applies to all three of the x/y/z coordinates. For example, $x(t) = A_x + t b_x$. This
+This equation applies to all three of the x/y/z coordinates. For example, $x(t) = A_x + t d_x$. This
 ray hits the plane $x = x_0$ at the parameter $t$ that satisfies this equation:
 
-  $$ x_0 = A_x + t_0 b_x $$
+  $$ x_0 = A_x + t_0 d_x $$
 
 So $t$ at the intersection is given by
 
-  $$ t_0 = \frac{x_0 - A_x}{b_x} $$
+  $$ t_0 = \frac{x_0 - A_x}{d_x} $$
 
 We get the similar expression for $x_1$:
 
-  $$ t_1 = \frac{x_1 - A_x}{b_x} $$
+  $$ t_1 = \frac{x_1 - A_x}{d_x} $$
 
 <div class='together'>
 The key observation to turn that 1D math into a 2D or 3D hit test is this: if a ray intersects the
@@ -519,29 +519,29 @@ love the slab method:
 There are some caveats that make this less pretty than it first appears. Consider again the 1D
 equations for $t_0$ and $t_1$:
 
-  $$ t_0 = \frac{x_0 - A_x}{b_x} $$
-  $$ t_1 = \frac{x_1 - A_x}{b_x} $$
+  $$ t_0 = \frac{x_0 - A_x}{d_x} $$
+  $$ t_1 = \frac{x_1 - A_x}{d_x} $$
 
 First, suppose the ray is traveling in the negative $\mathbf{x}$ direction. The interval $(t_{x0},
 t_{x1})$ as computed above might be reversed, like $(7, 3)$ for example. Second, the denominator
-$b_x$ could be zero, yielding infinite values. And if the ray origin lies on one of the slab
+$d_x$ could be zero, yielding infinite values. And if the ray origin lies on one of the slab
 boundaries, we can get a `NaN`, since both the numerator and the denominator can be zero. Also, the
 zero will have a ± sign when using IEEE floating point.
 
-The good news for $b_x = 0$ is that $t_{x0}$ and $t_{x1}$ will be equal: both +∞ or -∞, if not
+The good news for $d_x = 0$ is that $t_{x0}$ and $t_{x1}$ will be equal: both +∞ or -∞, if not
 between $x_0$ and $x_1$. So, using min and max should get us the right answers:
 
   $$ t_{x0} = \min(
-     \frac{x_0 - A_x}{b_x},
-     \frac{x_1 - A_x}{b_x})
+     \frac{x_0 - A_x}{d_x},
+     \frac{x_1 - A_x}{d_x})
   $$
 
   $$ t_{x1} = \max(
-     \frac{x_0 - A_x}{b_x},
-     \frac{x_1 - A_x}{b_x})
+     \frac{x_0 - A_x}{d_x},
+     \frac{x_1 - A_x}{d_x})
   $$
 
-The remaining troublesome case if we do that is if $b_x = 0$ and either $x_0 - A_x = 0$ or
+The remaining troublesome case if we do that is if $d_x = 0$ and either $x_0 - A_x = 0$ or
 $x_1 - A_x = 0$ so we get a `NaN`. In that case we can arbitrarily interpret that as either hit or
 no hit, but we’ll revisit that later.
 

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -1371,7 +1371,8 @@ the $z$ axis:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-sphereimp]: <kbd>[sphere_importance.cc]</kbd>
-    Generating importance-sampled points on the unit sphere]
+        Generating importance-sampled points on the unit sphere
+    ]
 
 The analytic answer is $\frac{4}{3} \pi$ -- if you remember enough advanced calc, check me! And the
 code above produces that. The key point here is that all of the integrals and the probability and
@@ -1625,7 +1626,8 @@ We modify the base-class `material` to enable this importance sampling:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-material]: <kbd>[material.h]</kbd>
-    The material class, adding importance sampling]
+        The material class, adding importance sampling
+    ]
 
 </div>
 
@@ -1664,7 +1666,8 @@ And the `lambertian` material becomes:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-lambertian-impsample]: <kbd>[material.h]</kbd>
-    Lambertian material, modified for importance sampling]
+        Lambertian material, modified for importance sampling
+    ]
 
 </div>
 
@@ -1708,7 +1711,8 @@ And the `camera::ray_color` function gets a minor modification:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-impsample]: <kbd>[camera.h]</kbd>
-    The ray_color function, modified for importance sampling]
+        The ray_color function, modified for importance sampling
+    ]
 
 </div>
 
@@ -1762,7 +1766,8 @@ a noisier image:
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-uniform]: <kbd>[camera.h]</kbd>
-    The ray_color function, now with a uniform PDF in the denominator]
+        The ray_color function, now with a uniform PDF in the denominator
+    ]
 
 You should get a very similar result to before, only with slightly more noise, it may be hard to
 see.
@@ -2059,7 +2064,8 @@ Here's a function that generates random vectors weighted by this PDF:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [random-cosine-direction]: <kbd>[vec3.h]</kbd>
-    Random cosine direction utility function]
+        Random cosine direction utility function
+    ]
 
 </div>
 
@@ -2321,7 +2327,8 @@ But first, let's quickly update the `isotropic` material:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-isotropic-impsample]: <kbd>[material.h]</kbd>
-    Isotropic material, modified for importance sampling]
+        Isotropic material, modified for importance sampling
+    ]
 
 </div>
 
@@ -3353,7 +3360,8 @@ materials that we're treating specularly.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-implicit]: <kbd>[camera.h]</kbd>
-    Ray color function with implicitly-sampled rays]
+        Ray color function with implicitly-sampled rays
+    ]
 
 </div>
 

--- a/src/TheNextWeek/interval.h
+++ b/src/TheNextWeek/interval.h
@@ -17,16 +17,20 @@ class interval {
 
     interval(double _min, double _max) : min(_min), max(_max) {}
 
-    interval(const interval& a, const interval& b)
-      : min(fmin(a.min, b.min)), max(fmax(a.max, b.max)) {}
+    interval(const interval& a, const interval& b) {
+        // Create the interval tightly enclosing the two input intervals.
+        min = a.min <= b.min ? a.min : b.min;
+        max = a.max >= b.max ? a.max : b.max;
+    }
+
+    bool is_empty() const {
+        // Returns false if the interval is empty (inside out), or if either bound is a
+        // floating-point NaN (not a number).
+        return !(min <= max);
+    }
 
     double size() const {
         return max - min;
-    }
-
-    interval expand(double delta) const {
-        auto padding = delta/2;
-        return interval(min - padding, max + padding);
     }
 
     bool contains(double x) const {
@@ -43,6 +47,17 @@ class interval {
         return x;
     }
 
+    interval expand(double delta) const {
+        auto padding = delta/2;
+        return interval(min - padding, max + padding);
+    }
+
+    interval intersect(interval& other) const {
+        double a = min >= other.min ? min : other.min;
+        double b = max <= other.max ? max : other.max;
+        return interval(a,b);
+    }
+
     static const interval empty, universe;
 };
 
@@ -56,6 +71,14 @@ interval operator+(const interval& ival, double displacement) {
 interval operator+(double displacement, const interval& ival) {
     return ival + displacement;
 }
+
+inline interval span(double a, double b) {
+    // Return the non-empty interval between a and b, regardless of their order.
+    if (a > b)
+        return interval(b, a);
+    return interval(a, b);
+}
+
 
 
 #endif

--- a/src/TheRestOfYourLife/interval.h
+++ b/src/TheRestOfYourLife/interval.h
@@ -17,16 +17,20 @@ class interval {
 
     interval(double _min, double _max) : min(_min), max(_max) {}
 
-    interval(const interval& a, const interval& b)
-      : min(fmin(a.min, b.min)), max(fmax(a.max, b.max)) {}
+    interval(const interval& a, const interval& b) {
+        // Create the interval tightly enclosing the two input intervals.
+        min = a.min <= b.min ? a.min : b.min;
+        max = a.max >= b.max ? a.max : b.max;
+    }
+
+    bool is_empty() const {
+        // Returns false if the interval is empty (inside out), or if either bound is a
+        // floating-point NaN (not a number).
+        return !(min <= max);
+    }
 
     double size() const {
         return max - min;
-    }
-
-    interval expand(double delta) const {
-        auto padding = delta/2;
-        return interval(min - padding, max + padding);
     }
 
     bool contains(double x) const {
@@ -43,6 +47,17 @@ class interval {
         return x;
     }
 
+    interval expand(double delta) const {
+        auto padding = delta/2;
+        return interval(min - padding, max + padding);
+    }
+
+    interval intersect(interval& other) const {
+        double a = min >= other.min ? min : other.min;
+        double b = max <= other.max ? max : other.max;
+        return interval(a,b);
+    }
+
     static const interval empty, universe;
 };
 
@@ -56,6 +71,14 @@ interval operator+(const interval& ival, double displacement) {
 interval operator+(double displacement, const interval& ival) {
     return ival + displacement;
 }
+
+inline interval span(double a, double b) {
+    // Return the non-empty interval between a and b, regardless of their order.
+    if (a > b)
+        return interval(b, a);
+    return interval(a, b);
+}
+
 
 
 #endif


### PR DESCRIPTION
Revise AABB hit function to use intervals

Increases program run by about 10%, and the code is easier to understand using interval arithmetic. A separate change to ray.origin() and ray.direction() returning const refs adds another 5% speedup.

In addition, I discovered that in many cases using `fmin()` and `fmax()` are performance bombs. Likely this is because these functions have special handling for NaNs. Instead, I switched to using ternary expressions like `a < b ? a : b`, which had a large performance impact. For the `aabb::hit()` function, this improved performance of the new interval code from 100% worse to about 10% better.

Added a new `span()` function that returns an interval of two doubles, regardless of their order.

Added new `interval::is_empty()` function that also returns true when either of the bounds is a NaN.

Added new `interval::intersect()` function.