### PR TITLE
Use const ref params

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -322,7 +322,7 @@ vector utility functions in the bottom half:
         double operator[](int i) const { return e[i]; }
         double& operator[](int i) { return e[i]; }
 
-        vec3& operator+=(const vec3 &v) {
+        vec3& operator+=(const vec3& v) {
             e[0] += v.e[0];
             e[1] += v.e[1];
             e[2] += v.e[2];
@@ -355,47 +355,47 @@ vector utility functions in the bottom half:
 
     // Vector Utility Functions
 
-    inline std::ostream& operator<<(std::ostream &out, const vec3 &v) {
+    inline std::ostream& operator<<(std::ostream& out, const vec3& v) {
         return out << v.e[0] << ' ' << v.e[1] << ' ' << v.e[2];
     }
 
-    inline vec3 operator+(const vec3 &u, const vec3 &v) {
+    inline vec3 operator+(const vec3& u, const vec3& v) {
         return vec3(u.e[0] + v.e[0], u.e[1] + v.e[1], u.e[2] + v.e[2]);
     }
 
-    inline vec3 operator-(const vec3 &u, const vec3 &v) {
+    inline vec3 operator-(const vec3& u, const vec3& v) {
         return vec3(u.e[0] - v.e[0], u.e[1] - v.e[1], u.e[2] - v.e[2]);
     }
 
-    inline vec3 operator*(const vec3 &u, const vec3 &v) {
+    inline vec3 operator*(const vec3& u, const vec3& v) {
         return vec3(u.e[0] * v.e[0], u.e[1] * v.e[1], u.e[2] * v.e[2]);
     }
 
-    inline vec3 operator*(double t, const vec3 &v) {
+    inline vec3 operator*(double t, const vec3& v) {
         return vec3(t*v.e[0], t*v.e[1], t*v.e[2]);
     }
 
-    inline vec3 operator*(const vec3 &v, double t) {
+    inline vec3 operator*(const vec3& v, double t) {
         return t * v;
     }
 
-    inline vec3 operator/(vec3 v, double t) {
+    inline vec3 operator/(const vec3& v, double t) {
         return (1/t) * v;
     }
 
-    inline double dot(const vec3 &u, const vec3 &v) {
+    inline double dot(const vec3& u, const vec3& v) {
         return u.e[0] * v.e[0]
              + u.e[1] * v.e[1]
              + u.e[2] * v.e[2];
     }
 
-    inline vec3 cross(const vec3 &u, const vec3 &v) {
+    inline vec3 cross(const vec3& u, const vec3& v) {
         return vec3(u.e[1] * v.e[2] - u.e[2] * v.e[1],
                     u.e[2] * v.e[0] - u.e[0] * v.e[2],
                     u.e[0] * v.e[1] - u.e[1] * v.e[0]);
     }
 
-    inline vec3 unit_vector(vec3 v) {
+    inline vec3 unit_vector(const vec3& v) {
         return v / v.length();
     }
 
@@ -424,7 +424,7 @@ that writes a single pixel's color out to the standard output stream.
 
     using color = vec3;
 
-    void write_color(std::ostream &out, color pixel_color) {
+    void write_color(std::ostream& out, const color& pixel_color) {
         // Write the translated [0,255] value of each color component.
         out << int(255.999 * pixel_color.x()) << ' '
             << int(255.999 * pixel_color.y()) << ' '
@@ -1107,7 +1107,7 @@ And here’s the sphere:
 
     class sphere : public hittable {
       public:
-        sphere(point3 _center, double _radius) : center(_center), radius(_radius) {}
+        sphere(const point3& _center, double _radius) : center(_center), radius(_radius) {}
 
         bool hit(const ray& r, double ray_tmin, double ray_tmax, hit_record& rec) const override {
             vec3 oc = center - r.origin();
@@ -2012,7 +2012,7 @@ And here's the updated `write_color()` function that takes the sum total of all 
 and the number of samples involved:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-    void write_color(std::ostream &out, color pixel_color, int samples_per_pixel) {
+    void write_color(std::ostream& out, const color& pixel_color, int samples_per_pixel) {
         auto r = pixel_color.x();
         auto g = pixel_color.y();
         auto b = pixel_color.z();
@@ -2224,7 +2224,7 @@ point if it is outside the unit sphere.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     ...
 
-    inline vec3 unit_vector(vec3 v) {
+    inline vec3 unit_vector(const vec3& v) {
         return v / v.length();
     }
 
@@ -2650,7 +2650,7 @@ robustly handle negative inputs.
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-    void write_color(std::ostream &out, color pixel_color, int samples_per_pixel) {
+    void write_color(std::ostream& out, const color& pixel_color, int samples_per_pixel) {
         auto r = pixel_color.x();
         auto g = pixel_color.y();
         auto b = pixel_color.z();
@@ -2776,7 +2776,7 @@ To achieve this, `hit_record` needs to be told the material that is assigned to 
     class sphere : public hittable {
       public:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        sphere(point3 _center, double _radius, shared_ptr<material> _material)
+        sphere(const point3& _center, double _radius, shared_ptr<material> _material)
           : center(_center), radius(_radius), mat(_material) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
@@ -3876,7 +3876,7 @@ Since we'll be choosing random points from the defocus disk, we'll need a functi
 `random_in_unit_sphere()`, just for two dimensions.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    inline vec3 unit_vector(vec3 u) {
+    inline vec3 unit_vector(const vec3& u) {
         return v / v.length();
     }
 

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -176,11 +176,12 @@ interval, so it really can be sampled at any time.)
       public:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         // Stationary Sphere
-        sphere(point3 _center, double _radius, shared_ptr<material> _material)
+        sphere(const point3& _center, double _radius, shared_ptr<material> _material)
           : center1(_center), radius(_radius), mat(_material), is_moving(false) {}
 
         // Moving Sphere
-        sphere(point3 _center1, point3 _center2, double _radius, shared_ptr<material> _material)
+        sphere(const point3& _center1, const point3& _center2, double _radius,
+               shared_ptr<material> _material)
           : center1(_center1), radius(_radius), mat(_material), is_moving(true)
         {
             center_vec = _center2 - _center1;
@@ -735,7 +736,7 @@ For a stationary sphere, the `bounding_box` function is easy:
       public:
         // Stationary Sphere
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        sphere(point3 _center, double _radius, shared_ptr<material> _material)
+        sphere(const point3& _center, double _radius, shared_ptr<material> _material)
           : center1(_center), radius(_radius), mat(_material), is_moving(false)
         {
             auto rvec = vec3(radius, radius, radius);
@@ -770,7 +771,8 @@ two boxes.
       public:
         ...
         // Moving Sphere
-        sphere(point3 _center1, point3 _center2, double _radius, shared_ptr<material> _material)
+        sphere(const point3& _center1, const point3& _center2, double _radius,
+               shared_ptr<material> _material)
           : center1(_center1), radius(_radius), mat(_material), is_moving(true)
         {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -1222,7 +1224,7 @@ Constant Color Texture
 
     class solid_color : public texture {
       public:
-        solid_color(color c) : color_value(c) {}
+        solid_color(const color& c) : color_value(c) {}
 
         solid_color(double red, double green, double blue) : solid_color(color(red,green,blue)) {}
 
@@ -1290,7 +1292,7 @@ pattern in the scene.
         checker_texture(double _scale, shared_ptr<texture> _even, shared_ptr<texture> _odd)
           : inv_scale(1.0 / _scale), even(_even), odd(_odd) {}
 
-        checker_texture(double _scale, color c1, color c2)
+        checker_texture(double _scale, const color& c1, const color& c2)
           : inv_scale(1.0 / _scale),
             even(make_shared<solid_color>(c1)),
             odd(make_shared<solid_color>(c2))
@@ -1692,7 +1694,7 @@ Adjust according to your directory structure.
 
         ~rtw_image() { STBI_FREE(data); }
 
-        bool load(const std::string filename) {
+        bool load(const std::string& filename) {
             // Loads image data from the given file name. Returns true if the load succeeded.
             auto n = bytes_per_pixel; // Dummy out parameter: original components per pixel
             data = stbi_load(filename.c_str(), &image_width, &image_height, &n, bytes_per_pixel);
@@ -1748,7 +1750,6 @@ The `image_texture` class uses the `rtw_image` class:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
     #include "rtw_stb_image.h"
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    #include "perlin.h"
 
     ...
 
@@ -1947,9 +1948,13 @@ code to make it all happen:
 <div class='together'>
 Now if we create an actual texture that takes these floats between 0 and 1 and creates grey colors:
 
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
     #include "perlin.h"
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
+    ...
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
     class noise_texture : public texture {
       public:
         noise_texture() {}
@@ -2278,8 +2283,15 @@ And the interpolation becomes a bit more complicated:
       ...
       private:
         ...
-        static double perlin_interp(vec3 c[2][2][2], double u, double v, double w) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ delete
+        static double trilinear_interp(double c[2][2][2], double u, double v, double w) {
+            ...
+        }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
+
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+        static double perlin_interp(const vec3 c[2][2][2], double u, double v, double w) {
             auto uu = u*u*(3-2*u);
             auto vv = v*v*(3-2*v);
             auto ww = w*w*(3-2*w);
@@ -2296,9 +2308,8 @@ And the interpolation becomes a bit more complicated:
                     }
 
             return accum;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
-        ...
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [perlin-interp]: <kbd>[perlin.h]</kbd> Perlin interpolation function so far]
@@ -3049,7 +3060,7 @@ the ray what color it is and performs no reflection. It’s very simple:
     class diffuse_light : public material {
       public:
         diffuse_light(shared_ptr<texture> a) : emit(a) {}
-        diffuse_light(color c) : emit(make_shared<solid_color>(c)) {}
+        diffuse_light(const color& c) : emit(make_shared<solid_color>(c)) {}
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
         const override {
@@ -3841,7 +3852,7 @@ The resulting class is:
           : boundary(b), neg_inv_density(-1/d), phase_function(make_shared<isotropic>(a))
         {}
 
-        constant_medium(shared_ptr<hittable> b, double d, color c)
+        constant_medium(shared_ptr<hittable> b, double d, const color& c)
           : boundary(b), neg_inv_density(-1/d), phase_function(make_shared<isotropic>(c))
         {}
 
@@ -3912,7 +3923,7 @@ The scattering function of isotropic picks a uniform random direction:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class isotropic : public material {
       public:
-        isotropic(color c) : albedo(make_shared<solid_color>(c)) {}
+        isotropic(const color& c) : albedo(make_shared<solid_color>(c)) {}
         isotropic(shared_ptr<texture> a) : albedo(a) {}
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -2291,7 +2291,7 @@ But first, let's quickly update the `isotropic` material:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class isotropic : public material {
       public:
-        isotropic(color c) : albedo(make_shared<solid_color>(c)) {}
+        isotropic(const color& c) : albedo(make_shared<solid_color>(c)) {}
         isotropic(shared_ptr<texture> a) : albedo(a) {}
 
 
@@ -3167,7 +3167,7 @@ As does the `isotropic` material:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class isotropic : public material {
       public:
-        isotropic(color c) : albedo(make_shared<solid_color>(c)) {}
+        isotropic(const color& c) : albedo(make_shared<solid_color>(c)) {}
         isotropic(shared_ptr<texture> a) : albedo(a) {}
 
 
@@ -3595,9 +3595,9 @@ think both tactics would work fine, but I will go with instrumenting `hittable_l
             return sum;
         }
 
-        vec3 random(const vec3& o) const override {
+        vec3 random(const vec3& origin) const override {
             auto int_size = int(objects.size());
-            return objects[random_int(0, int_size-1)]->random(o);
+            return objects[random_int(0, int_size-1)]->random(origin);
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
@@ -3659,7 +3659,7 @@ always remember for `NaN`s is that a `NaN` does not equal itself. Using this tri
 `write_color()` function to replace any `NaN` components with zero:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    void write_color(std::ostream &out, color pixel_color, int samples_per_pixel) {
+    void write_color(std::ostream& out, const color& pixel_color, int samples_per_pixel) {
         auto r = pixel_color.x();
         auto g = pixel_color.y();
         auto b = pixel_color.z();

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -2709,7 +2709,7 @@ functions through to subclasses if you want a purely abstract `hittable` interfa
             return 0.0;
         }
 
-        virtual vec3 random(const vec3& o) const {
+        virtual vec3 random(const point3& origin) const {
             return vec3(1, 0, 0);
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -3496,8 +3496,8 @@ The sphere class needs the two PDF-related functions:
             return  1 / solid_angle;
         }
 
-        vec3 random(const point3& o) const override {
-            vec3 direction = center1 - o;
+        vec3 random(const point3& origin) const override {
+            vec3 direction = center1 - origin;
             auto distance_squared = direction.length_squared();
             onb uvw;
             uvw.build_from_w(direction);
@@ -3595,7 +3595,7 @@ think both tactics would work fine, but I will go with instrumenting `hittable_l
             return sum;
         }
 
-        vec3 random(const vec3& origin) const override {
+        vec3 random(const point3& origin) const override {
             auto int_size = int(objects.size());
             return objects[random_int(0, int_size-1)]->random(origin);
         }

--- a/src/InOneWeekend/color.h
+++ b/src/InOneWeekend/color.h
@@ -25,7 +25,7 @@ inline double linear_to_gamma(double linear_component)
     return 0;
 }
 
-void write_color(std::ostream &out, color pixel_color, int samples_per_pixel) {
+void write_color(std::ostream& out, const color& pixel_color, int samples_per_pixel) {
     auto r = pixel_color.x();
     auto g = pixel_color.y();
     auto b = pixel_color.z();
@@ -36,7 +36,7 @@ void write_color(std::ostream &out, color pixel_color, int samples_per_pixel) {
     g *= scale;
     b *= scale;
 
-    // Apply a linear to gamma transform for gamma 2
+    // Apply the linear to gamma transform.
     r = linear_to_gamma(r);
     g = linear_to_gamma(g);
     b = linear_to_gamma(b);

--- a/src/InOneWeekend/rtw_stb_image.h
+++ b/src/InOneWeekend/rtw_stb_image.h
@@ -45,7 +45,7 @@ class rtw_image {
 
     ~rtw_image() { STBI_FREE(data); }
 
-    bool load(const std::string filename) {
+    bool load(const std::string& filename) {
         // Loads image data from the given file name. Returns true if the load succeeded.
         auto n = bytes_per_pixel; // Dummy out parameter: original components per pixel
         data = stbi_load(filename.c_str(), &image_width, &image_height, &n, bytes_per_pixel);

--- a/src/InOneWeekend/sphere.h
+++ b/src/InOneWeekend/sphere.h
@@ -18,7 +18,7 @@
 
 class sphere : public hittable {
   public:
-    sphere(point3 _center, double _radius, shared_ptr<material> _material)
+    sphere(const point3& _center, double _radius, shared_ptr<material> _material)
       : center(_center), radius(_radius), mat(_material) {}
 
     bool hit(const ray& r, interval ray_t, hit_record& rec) const override {

--- a/src/InOneWeekend/vec3.h
+++ b/src/InOneWeekend/vec3.h
@@ -32,7 +32,7 @@ class vec3 {
     double operator[](int i) const { return e[i]; }
     double& operator[](int i) { return e[i]; }
 
-    vec3& operator+=(const vec3 &v) {
+    vec3& operator+=(const vec3& v) {
         e[0] += v.e[0];
         e[1] += v.e[1];
         e[2] += v.e[2];
@@ -79,47 +79,47 @@ using point3 = vec3;
 
 // Vector Utility Functions
 
-inline std::ostream& operator<<(std::ostream &out, const vec3 &v) {
+inline std::ostream& operator<<(std::ostream& out, const vec3& v) {
     return out << v.e[0] << ' ' << v.e[1] << ' ' << v.e[2];
 }
 
-inline vec3 operator+(const vec3 &u, const vec3 &v) {
+inline vec3 operator+(const vec3& u, const vec3& v) {
     return vec3(u.e[0] + v.e[0], u.e[1] + v.e[1], u.e[2] + v.e[2]);
 }
 
-inline vec3 operator-(const vec3 &u, const vec3 &v) {
+inline vec3 operator-(const vec3& u, const vec3& v) {
     return vec3(u.e[0] - v.e[0], u.e[1] - v.e[1], u.e[2] - v.e[2]);
 }
 
-inline vec3 operator*(const vec3 &u, const vec3 &v) {
+inline vec3 operator*(const vec3& u, const vec3& v) {
     return vec3(u.e[0] * v.e[0], u.e[1] * v.e[1], u.e[2] * v.e[2]);
 }
 
-inline vec3 operator*(double t, const vec3 &v) {
+inline vec3 operator*(double t, const vec3& v) {
     return vec3(t*v.e[0], t*v.e[1], t*v.e[2]);
 }
 
-inline vec3 operator*(const vec3 &v, double t) {
+inline vec3 operator*(const vec3& v, double t) {
     return t * v;
 }
 
-inline vec3 operator/(vec3 v, double t) {
+inline vec3 operator/(const vec3& v, double t) {
     return (1/t) * v;
 }
 
-inline double dot(const vec3 &u, const vec3 &v) {
+inline double dot(const vec3& u, const vec3& v) {
     return u.e[0] * v.e[0]
          + u.e[1] * v.e[1]
          + u.e[2] * v.e[2];
 }
 
-inline vec3 cross(const vec3 &u, const vec3 &v) {
+inline vec3 cross(const vec3& u, const vec3& v) {
     return vec3(u.e[1] * v.e[2] - u.e[2] * v.e[1],
                 u.e[2] * v.e[0] - u.e[0] * v.e[2],
                 u.e[0] * v.e[1] - u.e[1] * v.e[0]);
 }
 
-inline vec3 unit_vector(vec3 v) {
+inline vec3 unit_vector(const vec3& v) {
     return v / v.length();
 }
 

--- a/src/TheNextWeek/camera.h
+++ b/src/TheNextWeek/camera.h
@@ -22,11 +22,11 @@
 
 class camera {
   public:
-    double aspect_ratio      = 1.0;    // Ratio of image width over height
-    int    image_width       = 100;    // Rendered image width in pixel count
-    int    samples_per_pixel = 10;     // Count of random samples for each pixel
-    int    max_depth         = 10;     // Maximum number of ray bounces into scene
-    color  background;                 // Scene background color
+    double aspect_ratio      = 1.0;  // Ratio of image width over height
+    int    image_width       = 100;  // Rendered image width in pixel count
+    int    samples_per_pixel = 10;   // Count of random samples for each pixel
+    int    max_depth         = 10;   // Maximum number of ray bounces into scene
+    color  background;               // Scene background color
 
     double vfov     = 90;              // Vertical view angle (field of view)
     point3 lookfrom = point3(0,0,-1);  // Point camera is looking from

--- a/src/TheNextWeek/color.h
+++ b/src/TheNextWeek/color.h
@@ -25,7 +25,7 @@ inline double linear_to_gamma(double linear_component)
     return 0;
 }
 
-void write_color(std::ostream &out, color pixel_color, int samples_per_pixel) {
+void write_color(std::ostream& out, const color& pixel_color, int samples_per_pixel) {
     auto r = pixel_color.x();
     auto g = pixel_color.y();
     auto b = pixel_color.z();

--- a/src/TheNextWeek/constant_medium.h
+++ b/src/TheNextWeek/constant_medium.h
@@ -24,7 +24,7 @@ class constant_medium : public hittable {
       : boundary(b), neg_inv_density(-1/d), phase_function(make_shared<isotropic>(a))
     {}
 
-    constant_medium(shared_ptr<hittable> b, double d, color c)
+    constant_medium(shared_ptr<hittable> b, double d, const color& c)
       : boundary(b), neg_inv_density(-1/d), phase_function(make_shared<isotropic>(c))
     {}
 

--- a/src/TheNextWeek/material.h
+++ b/src/TheNextWeek/material.h
@@ -112,7 +112,7 @@ class dielectric : public material {
 class diffuse_light : public material {
   public:
     diffuse_light(shared_ptr<texture> a) : emit(a) {}
-    diffuse_light(color c) : emit(make_shared<solid_color>(c)) {}
+    diffuse_light(const color& c) : emit(make_shared<solid_color>(c)) {}
 
     bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
     const override {
@@ -130,7 +130,7 @@ class diffuse_light : public material {
 
 class isotropic : public material {
   public:
-    isotropic(color c) : albedo(make_shared<solid_color>(c)) {}
+    isotropic(const color& c) : albedo(make_shared<solid_color>(c)) {}
     isotropic(shared_ptr<texture> a) : albedo(a) {}
 
     bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)

--- a/src/TheNextWeek/perlin.h
+++ b/src/TheNextWeek/perlin.h
@@ -96,7 +96,7 @@ class perlin {
         }
     }
 
-    static double perlin_interp(vec3 c[2][2][2], double u, double v, double w) {
+    static double perlin_interp(const vec3 c[2][2][2], double u, double v, double w) {
         auto uu = u*u*(3-2*u);
         auto vv = v*v*(3-2*v);
         auto ww = w*w*(3-2*w);

--- a/src/TheNextWeek/rtw_stb_image.h
+++ b/src/TheNextWeek/rtw_stb_image.h
@@ -45,7 +45,7 @@ class rtw_image {
 
     ~rtw_image() { STBI_FREE(data); }
 
-    bool load(const std::string filename) {
+    bool load(const std::string& filename) {
         // Loads image data from the given file name. Returns true if the load succeeded.
         auto n = bytes_per_pixel; // Dummy out parameter: original components per pixel
         data = stbi_load(filename.c_str(), &image_width, &image_height, &n, bytes_per_pixel);

--- a/src/TheNextWeek/sphere.h
+++ b/src/TheNextWeek/sphere.h
@@ -19,7 +19,7 @@
 class sphere : public hittable {
   public:
     // Stationary Sphere
-    sphere(point3 _center, double _radius, shared_ptr<material> _material)
+    sphere(const point3& _center, double _radius, shared_ptr<material> _material)
       : center1(_center), radius(_radius), mat(_material), is_moving(false)
     {
         auto rvec = vec3(radius, radius, radius);
@@ -27,7 +27,8 @@ class sphere : public hittable {
     }
 
     // Moving Sphere
-    sphere(point3 _center1, point3 _center2, double _radius, shared_ptr<material> _material)
+    sphere(const point3& _center1, const point3& _center2, double _radius,
+           shared_ptr<material> _material)
       : center1(_center1), radius(_radius), mat(_material), is_moving(true)
     {
         auto rvec = vec3(radius, radius, radius);

--- a/src/TheNextWeek/texture.h
+++ b/src/TheNextWeek/texture.h
@@ -27,7 +27,7 @@ class texture {
 
 class solid_color : public texture {
   public:
-    solid_color(color c) : color_value(c) {}
+    solid_color(const color& c) : color_value(c) {}
 
     solid_color(double red, double green, double blue)
       : solid_color(color(red,green,blue)) {}
@@ -46,7 +46,7 @@ class checker_texture : public texture {
     checker_texture(double _scale, shared_ptr<texture> _even, shared_ptr<texture> _odd)
       : inv_scale(1.0 / _scale), even(_even), odd(_odd) {}
 
-    checker_texture(double _scale, color c1, color c2)
+    checker_texture(double _scale, const color& c1, const color& c2)
       : inv_scale(1.0 / _scale),
         even(make_shared<solid_color>(c1)),
         odd(make_shared<solid_color>(c2))

--- a/src/TheNextWeek/vec3.h
+++ b/src/TheNextWeek/vec3.h
@@ -32,7 +32,7 @@ class vec3 {
     double operator[](int i) const { return e[i]; }
     double& operator[](int i) { return e[i]; }
 
-    vec3& operator+=(const vec3 &v) {
+    vec3& operator+=(const vec3& v) {
         e[0] += v.e[0];
         e[1] += v.e[1];
         e[2] += v.e[2];
@@ -79,47 +79,47 @@ using point3 = vec3;
 
 // Vector Utility Functions
 
-inline std::ostream& operator<<(std::ostream &out, const vec3 &v) {
+inline std::ostream& operator<<(std::ostream& out, const vec3& v) {
     return out << v.e[0] << ' ' << v.e[1] << ' ' << v.e[2];
 }
 
-inline vec3 operator+(const vec3 &u, const vec3 &v) {
+inline vec3 operator+(const vec3& u, const vec3& v) {
     return vec3(u.e[0] + v.e[0], u.e[1] + v.e[1], u.e[2] + v.e[2]);
 }
 
-inline vec3 operator-(const vec3 &u, const vec3 &v) {
+inline vec3 operator-(const vec3& u, const vec3& v) {
     return vec3(u.e[0] - v.e[0], u.e[1] - v.e[1], u.e[2] - v.e[2]);
 }
 
-inline vec3 operator*(const vec3 &u, const vec3 &v) {
+inline vec3 operator*(const vec3& u, const vec3& v) {
     return vec3(u.e[0] * v.e[0], u.e[1] * v.e[1], u.e[2] * v.e[2]);
 }
 
-inline vec3 operator*(double t, const vec3 &v) {
+inline vec3 operator*(double t, const vec3& v) {
     return vec3(t*v.e[0], t*v.e[1], t*v.e[2]);
 }
 
-inline vec3 operator*(const vec3 &v, double t) {
+inline vec3 operator*(const vec3& v, double t) {
     return t * v;
 }
 
-inline vec3 operator/(vec3 v, double t) {
+inline vec3 operator/(const vec3& v, double t) {
     return (1/t) * v;
 }
 
-inline double dot(const vec3 &u, const vec3 &v) {
+inline double dot(const vec3& u, const vec3& v) {
     return u.e[0] * v.e[0]
          + u.e[1] * v.e[1]
          + u.e[2] * v.e[2];
 }
 
-inline vec3 cross(const vec3 &u, const vec3 &v) {
+inline vec3 cross(const vec3& u, const vec3& v) {
     return vec3(u.e[1] * v.e[2] - u.e[2] * v.e[1],
                 u.e[2] * v.e[0] - u.e[0] * v.e[2],
                 u.e[0] * v.e[1] - u.e[1] * v.e[0]);
 }
 
-inline vec3 unit_vector(vec3 v) {
+inline vec3 unit_vector(const vec3& v) {
     return v / v.length();
 }
 

--- a/src/TheRestOfYourLife/color.h
+++ b/src/TheRestOfYourLife/color.h
@@ -25,7 +25,7 @@ inline double linear_to_gamma(double linear_component)
     return 0;
 }
 
-void write_color(std::ostream &out, color pixel_color, int samples_per_pixel) {
+void write_color(std::ostream& out, const color& pixel_color, int samples_per_pixel) {
     auto r = pixel_color.x();
     auto g = pixel_color.y();
     auto b = pixel_color.z();

--- a/src/TheRestOfYourLife/constant_medium.h
+++ b/src/TheRestOfYourLife/constant_medium.h
@@ -24,7 +24,7 @@ class constant_medium : public hittable {
       : boundary(b), neg_inv_density(-1/d), phase_function(make_shared<isotropic>(a))
     {}
 
-    constant_medium(shared_ptr<hittable> b, double d, color c)
+    constant_medium(shared_ptr<hittable> b, double d, const color& c)
       : boundary(b), neg_inv_density(-1/d), phase_function(make_shared<isotropic>(c))
     {}
 

--- a/src/TheRestOfYourLife/hittable.h
+++ b/src/TheRestOfYourLife/hittable.h
@@ -47,11 +47,11 @@ class hittable {
 
     virtual aabb bounding_box() const = 0;
 
-    virtual double pdf_value(const vec3& o, const vec3& v) const {
+    virtual double pdf_value(const point3& origin, const vec3& direction) const {
         return 0.0;
     }
 
-    virtual vec3 random(const vec3& o) const {
+    virtual vec3 random(const point3& origin) const {
         return vec3(1,0,0);
     }
 };

--- a/src/TheRestOfYourLife/hittable_list.h
+++ b/src/TheRestOfYourLife/hittable_list.h
@@ -62,7 +62,7 @@ class hittable_list : public hittable {
         return sum;
     }
 
-    vec3 random(const vec3& origin) const override {
+    vec3 random(const point3& origin) const override {
         auto int_size = int(objects.size());
         return objects[random_int(0, int_size-1)]->random(origin);
     }

--- a/src/TheRestOfYourLife/hittable_list.h
+++ b/src/TheRestOfYourLife/hittable_list.h
@@ -52,19 +52,19 @@ class hittable_list : public hittable {
 
     aabb bounding_box() const override { return bbox; }
 
-    double pdf_value(const point3& o, const vec3& v) const override {
+    double pdf_value(const point3& origin, const vec3& direction) const override {
         auto weight = 1.0 / objects.size();
         auto sum = 0.0;
 
         for (const auto& object : objects)
-            sum += weight * object->pdf_value(o, v);
+            sum += weight * object->pdf_value(origin, direction);
 
         return sum;
     }
 
-    vec3 random(const vec3& o) const override {
+    vec3 random(const vec3& origin) const override {
         auto int_size = int(objects.size());
-        return objects[random_int(0, int_size-1)]->random(o);
+        return objects[random_int(0, int_size-1)]->random(origin);
     }
 
   private:

--- a/src/TheRestOfYourLife/hittable_list.h
+++ b/src/TheRestOfYourLife/hittable_list.h
@@ -52,7 +52,7 @@ class hittable_list : public hittable {
 
     aabb bounding_box() const override { return bbox; }
 
-    double pdf_value(const point3 &o, const vec3 &v) const override {
+    double pdf_value(const point3& o, const vec3& v) const override {
         auto weight = 1.0 / objects.size();
         auto sum = 0.0;
 
@@ -62,7 +62,7 @@ class hittable_list : public hittable {
         return sum;
     }
 
-    vec3 random(const vec3 &o) const override {
+    vec3 random(const vec3& o) const override {
         auto int_size = int(objects.size());
         return objects[random_int(0, int_size-1)]->random(o);
     }

--- a/src/TheRestOfYourLife/material.h
+++ b/src/TheRestOfYourLife/material.h
@@ -131,7 +131,7 @@ class dielectric : public material {
 class diffuse_light : public material {
   public:
     diffuse_light(shared_ptr<texture> a) : emit(a) {}
-    diffuse_light(color c) : emit(make_shared<solid_color>(c)) {}
+    diffuse_light(const color& c) : emit(make_shared<solid_color>(c)) {}
 
     color emitted(const ray& r_in, const hit_record& rec, double u, double v, const point3& p)
     const override {
@@ -147,7 +147,7 @@ class diffuse_light : public material {
 
 class isotropic : public material {
   public:
-    isotropic(color c) : albedo(make_shared<solid_color>(c)) {}
+    isotropic(const color& c) : albedo(make_shared<solid_color>(c)) {}
     isotropic(shared_ptr<texture> a) : albedo(a) {}
 
     bool scatter(const ray& r_in, const hit_record& rec, scatter_record& srec) const override {

--- a/src/TheRestOfYourLife/perlin.h
+++ b/src/TheRestOfYourLife/perlin.h
@@ -96,7 +96,7 @@ class perlin {
         }
     }
 
-    static double perlin_interp(vec3 c[2][2][2], double u, double v, double w) {
+    static double perlin_interp(const vec3 c[2][2][2], double u, double v, double w) {
         auto uu = u*u*(3-2*u);
         auto vv = v*v*(3-2*v);
         auto ww = w*w*(3-2*w);

--- a/src/TheRestOfYourLife/rtw_stb_image.h
+++ b/src/TheRestOfYourLife/rtw_stb_image.h
@@ -45,7 +45,7 @@ class rtw_image {
 
     ~rtw_image() { STBI_FREE(data); }
 
-    bool load(const std::string filename) {
+    bool load(const std::string& filename) {
         // Loads image data from the given file name. Returns true if the load succeeded.
         auto n = bytes_per_pixel; // Dummy out parameter: original components per pixel
         data = stbi_load(filename.c_str(), &image_width, &image_height, &n, bytes_per_pixel);

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -20,7 +20,7 @@
 class sphere : public hittable {
   public:
     // Stationary Sphere
-    sphere(point3 _center, double _radius, shared_ptr<material> _material)
+    sphere(const point3& _center, double _radius, shared_ptr<material> _material)
       : center1(_center), radius(_radius), mat(_material), is_moving(false)
     {
         auto rvec = vec3(radius, radius, radius);
@@ -28,7 +28,8 @@ class sphere : public hittable {
     }
 
     // Moving Sphere
-    sphere(point3 _center1, point3 _center2, double _radius, shared_ptr<material> _material)
+    sphere(const point3& _center1, const point3& _center2, double _radius,
+           shared_ptr<material> _material)
       : center1(_center1), radius(_radius), mat(_material), is_moving(true)
     {
         auto rvec = vec3(radius, radius, radius);

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -72,21 +72,21 @@ class sphere : public hittable {
 
     aabb bounding_box() const override { return bbox; }
 
-    double pdf_value(const point3& o, const vec3& v) const override {
+    double pdf_value(const point3& origin, const vec3& direction) const override {
         // This method only works for stationary spheres.
 
         hit_record rec;
-        if (!this->hit(ray(o, v), interval(0.001, infinity), rec))
+        if (!this->hit(ray(origin, direction), interval(0.001, infinity), rec))
             return 0;
 
-        auto cos_theta_max = sqrt(1 - radius*radius/(center1 - o).length_squared());
+        auto cos_theta_max = sqrt(1 - radius*radius/(center1 - origin).length_squared());
         auto solid_angle = 2*pi*(1-cos_theta_max);
 
         return  1 / solid_angle;
     }
 
-    vec3 random(const point3& o) const override {
-        vec3 direction = center1 - o;
+    vec3 random(const point3& origin) const override {
+        vec3 direction = center1 - origin;
         auto distance_squared = direction.length_squared();
         onb uvw;
         uvw.build_from_w(direction);

--- a/src/TheRestOfYourLife/texture.h
+++ b/src/TheRestOfYourLife/texture.h
@@ -27,7 +27,7 @@ class texture {
 
 class solid_color : public texture {
   public:
-    solid_color(color c) : color_value(c) {}
+    solid_color(const color& c) : color_value(c) {}
 
     solid_color(double red, double green, double blue)
       : solid_color(color(red,green,blue)) {}
@@ -46,7 +46,7 @@ class checker_texture : public texture {
     checker_texture(double _scale, shared_ptr<texture> _even, shared_ptr<texture> _odd)
       : inv_scale(1.0 / _scale), even(_even), odd(_odd) {}
 
-    checker_texture(double _scale, color c1, color c2)
+    checker_texture(double _scale, const color& c1, const color& c2)
       : inv_scale(1.0 / _scale),
         even(make_shared<solid_color>(c1)),
         odd(make_shared<solid_color>(c2))

--- a/src/TheRestOfYourLife/vec3.h
+++ b/src/TheRestOfYourLife/vec3.h
@@ -32,7 +32,7 @@ class vec3 {
     double operator[](int i) const { return e[i]; }
     double& operator[](int i) { return e[i]; }
 
-    vec3& operator+=(const vec3 &v) {
+    vec3& operator+=(const vec3& v) {
         e[0] += v.e[0];
         e[1] += v.e[1];
         e[2] += v.e[2];
@@ -79,47 +79,47 @@ using point3 = vec3;
 
 // Vector Utility Functions
 
-inline std::ostream& operator<<(std::ostream &out, const vec3 &v) {
+inline std::ostream& operator<<(std::ostream& out, const vec3& v) {
     return out << v.e[0] << ' ' << v.e[1] << ' ' << v.e[2];
 }
 
-inline vec3 operator+(const vec3 &u, const vec3 &v) {
+inline vec3 operator+(const vec3& u, const vec3& v) {
     return vec3(u.e[0] + v.e[0], u.e[1] + v.e[1], u.e[2] + v.e[2]);
 }
 
-inline vec3 operator-(const vec3 &u, const vec3 &v) {
+inline vec3 operator-(const vec3& u, const vec3& v) {
     return vec3(u.e[0] - v.e[0], u.e[1] - v.e[1], u.e[2] - v.e[2]);
 }
 
-inline vec3 operator*(const vec3 &u, const vec3 &v) {
+inline vec3 operator*(const vec3& u, const vec3& v) {
     return vec3(u.e[0] * v.e[0], u.e[1] * v.e[1], u.e[2] * v.e[2]);
 }
 
-inline vec3 operator*(double t, const vec3 &v) {
+inline vec3 operator*(double t, const vec3& v) {
     return vec3(t*v.e[0], t*v.e[1], t*v.e[2]);
 }
 
-inline vec3 operator*(const vec3 &v, double t) {
+inline vec3 operator*(const vec3& v, double t) {
     return t * v;
 }
 
-inline vec3 operator/(vec3 v, double t) {
+inline vec3 operator/(const vec3& v, double t) {
     return (1/t) * v;
 }
 
-inline double dot(const vec3 &u, const vec3 &v) {
+inline double dot(const vec3& u, const vec3& v) {
     return u.e[0] * v.e[0]
          + u.e[1] * v.e[1]
          + u.e[2] * v.e[2];
 }
 
-inline vec3 cross(const vec3 &u, const vec3 &v) {
+inline vec3 cross(const vec3& u, const vec3& v) {
     return vec3(u.e[1] * v.e[2] - u.e[2] * v.e[1],
                 u.e[2] * v.e[0] - u.e[0] * v.e[2],
                 u.e[0] * v.e[1] - u.e[1] * v.e[0]);
 }
 
-inline vec3 unit_vector(vec3 v) {
+inline vec3 unit_vector(const vec3& v) {
     return v / v.length();
 }
 


### PR DESCRIPTION
There were many cases where we were passing vectors, points, rays and colors by value. Passing by const reference or mutable reference is more efficient.

This speeds up book1 by 13% and book2 by 3.5%.

Resolves #1250