### PR TITLE
ref: change order check

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ _**please review the [CONTRIBUTING][] document for the most effective way to pro
 [milestone 19]:    https://github.com/RayTracing/raytracing.github.io/milestone/19
 [v3.2.3]:          https://github.com/RayTracing/raytracing.github.io/releases/tag/v3.2.3
 [web1]:            https://raytracing.github.io/books/RayTracingInOneWeekend.html
-[web1-v3]:         https://raytracing.github.io/books/v3/RayTracingInOneWeekend.html
 [web2]:            https://raytracing.github.io/books/RayTracingTheNextWeek.html
-[web2-v3]:         https://raytracing.github.io/books/v3/RayTracingTheNextWeek.html
 [web3]:            https://raytracing.github.io/books/RayTracingTheRestOfYourLife.html
-[web3-v3]:         https://raytracing.github.io/books/v3/RayTracingTheRestOfYourLife.html
+[web1-v3]:         https://raytracing.github.io/v3/books/RayTracingInOneWeekend.html
+[web2-v3]:         https://raytracing.github.io/v3/books/RayTracingTheNextWeek.html
+[web3-v3]:         https://raytracing.github.io/v3/books/RayTracingTheRestOfYourLife.html

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -2374,16 +2374,12 @@ depth, returning no light contribution at the maximum depth:
         ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         color ray_color(const ray& r, int depth, const hittable& world) const {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-            hit_record rec;
-
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             // If we've exceeded the ray bounce limit, no more light is gathered.
             if (depth <= 0)
                 return color(0,0,0);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-
+            
+            hit_record rec;
             if (world.hit(r, interval(0, infinity), rec)) {
                 vec3 direction = random_on_hemisphere(rec.normal);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -2449,13 +2445,11 @@ to address this is just to ignore hits that are very close to the calculated int
       private:
         ...
         color ray_color(const ray& r, int depth, const hittable& world) const {
-            hit_record rec;
-
             // If we've exceeded the ray bounce limit, no more light is gathered.
             if (depth <= 0)
                 return color(0,0,0);
 
-
+            hit_record rec;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             if (world.hit(r, interval(0.001, infinity), rec)) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2522,12 +2516,11 @@ The change is actually fairly minimal:
     class camera {
         ...
         color ray_color(const ray& r, int depth, const hittable& world) const {
-            hit_record rec;
-
             // If we've exceeded the ray bounce limit, no more light is gathered.
             if (depth <= 0)
                 return color(0,0,0);
 
+            hit_record rec;
             if (world.hit(r, interval(0.001, infinity), rec)) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 vec3 direction = rec.normal + random_unit_vector();
@@ -2583,12 +2576,11 @@ the `ray_color` function from `0.5` (50%) to `0.1` (10%):
 class camera {
     ...
     color ray_color(const ray& r, int depth, const hittable& world) const {
-        hit_record rec;
-
         // If we've exceeded the ray bounce limit, no more light is gathered.
         if (depth <= 0)
             return color(0,0,0);
 
+        hit_record rec;
         if (world.hit(r, interval(0.001, infinity), rec)) {
             vec3 direction = rec.normal + random_unit_vector();
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -2967,12 +2959,11 @@ We need to modify the `ray_color()` function for all of our changes:
       private:
         ...
         color ray_color(const ray& r, int depth, const hittable& world) const {
-            hit_record rec;
-
             // If we've exceeded the ray bounce limit, no more light is gathered.
             if (depth <= 0)
                 return color(0,0,0);
 
+            hit_record rec;
             if (world.hit(r, interval(0.001, infinity), rec)) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                 ray scattered;


### PR DESCRIPTION
Little bit refactoring. We don't need create `hit_record rec;` objects if `depth <= 0` condition is true.