### PR TITLE
Update RayTracingInOneWeekend.html

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1101,9 +1101,9 @@ And here’s the sphere:
             auto sqrtd = sqrt(discriminant);
 
             // Find the nearest root that lies in the acceptable range.
-            auto root = (-half_b - sqrtd) / a;
+            auto root = (half_b - sqrtd) / a;
             if (root <= ray_tmin || ray_tmax <= root) {
-                root = (-half_b + sqrtd) / a;
+                root = (half_b + sqrtd) / a;
                 if (root <= ray_tmin || ray_tmax <= root)
                     return false;
             }


### PR DESCRIPTION
fix wrong expression:
`auto root = (-half_b - sqrtd) / a;`

since half_b expression contains negative sign.