### PR TITLE
Clarify the addition of the inverted glass sphere

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -3481,7 +3481,8 @@ finite bubble inside the sphere, so the outward normal needs to point toward the
 Dividing by the (negative) radius flips the normal as we want. If you implmented your code like the
 second example above, you'll want to fix that now.
 
-Let's use this hollow sphere hack to model a sphere with a given thickness:
+Let's use this hollow sphere hack to model a sphere with a given thickness -- that is, with an
+interior surface. To do this, add a second _inverted_ glass sphere inside the original glass sphere:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     ...

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -3481,8 +3481,8 @@ finite bubble inside the sphere, so the outward normal needs to point toward the
 Dividing by the (negative) radius flips the normal as we want. If you implmented your code like the
 second example above, you'll want to fix that now.
 
-Let's use this hollow sphere hack to model a sphere with a given thickness -- that is, with an
-interior surface. To do this, add a second _inverted_ glass sphere inside the original glass sphere:
+Let's use this hollow sphere hack to model the interior of a sphere with a given thickness. To do
+this, add a second _inverted_ glass sphere inside the original glass sphere:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     ...


### PR DESCRIPTION
It turns out that several readers missed the fact that the hollow glass sphere is modeled by _adding_ a second inverted sphere, and instead mistook the change to be a _modification_ of the original glass sphere. This change should helpfully make this mistake less likely.

Resolves #1278