### PR TITLE
Fix missing backslash for LaTeX operatorname

### DIFF
--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -1554,7 +1554,7 @@ Playing with Importance Sampling
 Our goal over the next several chapters is to instrument our program to send a bunch of extra rays
 toward light sources so that our picture is less noisy. Let’s assume we can send a bunch of rays
 toward the light source using a PDF $\operatorname{pLight}(\omega_o)$. Let’s also assume we have a
-PDF related to $operatorname{pScatter}$, and let’s call that $operatorname{pSurface}(\omega_o)$. A
+PDF related to $\operatorname{pScatter}$, and let’s call that $\operatorname{pSurface}(\omega_o)$. A
 great thing about PDFs is that you can just use linear mixtures of them to form mixture densities
 that are also PDFs. For example, the simplest would be:
 


### PR DESCRIPTION
Resolves #1311