### PR TITLE
Make code listing captions consistent

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1236,7 +1236,8 @@ know more about the specific geometry.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [front-face-tracking]: <kbd>[hittable.h]</kbd>
-        Adding front-face tracking to hit_record]
+        Adding front-face tracking to hit_record
+    ]
 
 <div class='together'>
 And then we add the surface side determination to the class:
@@ -1623,7 +1624,8 @@ and a maximum. We'll end up using this class quite often as we proceed.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [hittable-list-with-interval]: <kbd>[hittable_list.h]</kbd>
-        hittable_list::hit() using interval]
+        hittable_list::hit() using interval
+    ]
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2333,7 +2335,8 @@ return 50% of the color from a bounce. We should expect to get a nice gray color
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-random-unit]: <kbd>[camera.h]</kbd>
-        ray_color() using a random ray direction]
+        ray_color() using a random ray direction
+    ]
 
 <div class='together'>
 ... Indeed we do get rather nice gray spheres:
@@ -2480,7 +2483,8 @@ to address this is just to ignore hits that are very close to the calculated int
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [reflect-tolerance]: <kbd>[camera.h]</kbd>
-        Calculating reflected ray origins with tolerance]
+        Calculating reflected ray origins with tolerance
+    ]
 
 <div class='together'>
 This gets rid of the shadow acne problem. Yes it is really called that. Here's the result:
@@ -2587,30 +2591,30 @@ life, a light grey) but they appear to be rather dark. We can see this more clea
 through the full brightness gamut for our diffuse material. We start by setting the reflectance of
 the `ray_color` function from `0.5` (50%) to `0.1` (10%):
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-class camera {
-    ...
-    color ray_color(const ray& r, int depth, const hittable& world) const {
-        // If we've exceeded the ray bounce limit, no more light is gathered.
-        if (depth <= 0)
-            return color(0,0,0);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    class camera {
+        ...
+        color ray_color(const ray& r, int depth, const hittable& world) const {
+            // If we've exceeded the ray bounce limit, no more light is gathered.
+            if (depth <= 0)
+                return color(0,0,0);
 
-        hit_record rec;
+            hit_record rec;
 
-        if (world.hit(r, interval(0.001, infinity), rec)) {
-            vec3 direction = rec.normal + random_unit_vector();
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-            return 0.1 * ray_color(ray(rec.p, direction), depth-1, world);
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    }
+            if (world.hit(r, interval(0.001, infinity), rec)) {
+                vec3 direction = rec.normal + random_unit_vector();
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+                return 0.1 * ray_color(ray(rec.p, direction), depth-1, world);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+        }
 
-        vec3 unit_direction = unit_vector(r.direction());
-        auto a = 0.5*(unit_direction.y() + 1.0);
-        return (1.0-a)*color(1.0, 1.0, 1.0) + a*color(0.5, 0.7, 1.0);
-    }
-};
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[Listing [ray-color-gamut]: <kbd>[camera.h]</kbd> ray_color() with 10% reflectance]
+            vec3 unit_direction = unit_vector(r.direction());
+            auto a = 0.5*(unit_direction.y() + 1.0);
+            return (1.0-a)*color(1.0, 1.0, 1.0) + a*color(0.5, 0.7, 1.0);
+        }
+    };
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    [Listing [ray-color-gamut]: <kbd>[camera.h]</kbd> ray_color() with 10% reflectance]
 
 We render out at this new 10% reflectance. We then set reflectance to 30% and render again. We
 repeat for 50%, 70%, and finally 90%. You can overlay these images from left to right in the photo
@@ -2675,7 +2679,6 @@ robustly handle negative inputs.
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [write-color-gamma]: <kbd>[color.h]</kbd> write_color(), with gamma correction]
-
 
 <div class='together'>
 Using this gamma correction, we now get a much more consistent ramp from darkness to lightness:
@@ -2801,7 +2804,8 @@ To achieve this, `hit_record` needs to be told the material that is assigned to 
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [sphere-material]: <kbd>[sphere.h]</kbd>
-        Ray-sphere intersection with added material information]
+        Ray-sphere intersection with added material information
+    ]
 
 </div>
 
@@ -3250,7 +3254,8 @@ And the dielectric material that always refracts is:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [dielectric-always-refract]: <kbd>[material.h]</kbd>
-        Dielectric material class that always refracts]
+        Dielectric material class that always refracts
+    ]
 
 </div>
 
@@ -3308,6 +3313,7 @@ solution does not exist, the glass cannot refract, and therefore must reflect th
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [dielectric-can-refract-1]: <kbd>[material.h]</kbd> Determining if the ray can refract]
+
 </div>
 
 Here all the light is reflected, and because in practice that is usually inside solid objects, it is
@@ -3372,7 +3378,8 @@ And the dielectric material that always refracts (when possible) is:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [dielectric-with-refraction]: <kbd>[material.h]</kbd>
-        Dielectric material class with reflection]
+        Dielectric material class with reflection
+    ]
 
 </div>
 
@@ -3470,7 +3477,8 @@ In your own implementation, you might have been tempted to instead do something 
     vec3 outward_normal = (rec.p - center).unit_vector();
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [improper-invert-sphere-normal]:
-    Problematic normal calculation for spheres with negative radii]
+        Problematic normal calculation for spheres with negative radii
+    ]
 
 If you do that, spheres with negative radii won't work properly. Since a sphere with a negative
 radius is a _bubble_, its interior is the infinite space outside the sphere. Its exterior is the

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -356,8 +356,9 @@ $t=0$ to $\mathbf{C} + (0, r/2, 0)$ at time $t=1$:
         cam.render(world);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [scene-spheres-moving]:
-    <kbd>[main.cc]</kbd> Last book's final scene, but with moving spheres]
+    [Listing [scene-spheres-moving]: <kbd>[main.cc]</kbd>
+        Last book's final scene, but with moving spheres
+    ]
 
 <div class='together'>
 This gives the following result:
@@ -1168,7 +1169,8 @@ Now to implement the empty `aabb` code and the new `aabb::longest_axis()` functi
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [aabb-empty-and-axis]: <kbd>[aabb.h]</kbd>
-    New aabb constants and longest_axis() function]
+        New aabb constants and longest_axis() function
+    ]
 
 As before, you should see identical results to [image 1](#image-bouncing-spheres), but rendering a
 little bit faster. On my system, this yields something like an additional 18% render speedup. Not
@@ -2673,8 +2675,7 @@ Add the planar values to the `quad` class:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [quad-plane1]:
-        <kbd>[quad.h]</kbd> Caching thel planar values]
+    [Listing [quad-plane1]: <kbd>[quad.h]</kbd> Caching the planar values]
 
 </div>
 
@@ -3020,6 +3021,7 @@ And now we add a new scene to demonstrate our new `quad` primitive:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [quad-scene]: <kbd>[main.cc]</kbd> A new scene with quads]
+
 </div>
 
   ![<span class='num'>Image 16:</span> Quads](../images/img-2.16-quads.png class='pixel')
@@ -3153,7 +3155,8 @@ the new `color_from_emission` value.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-emitted]: <kbd>[camera.h]</kbd>
-    ray_color function with background and emitting materials]
+        ray_color function with background and emitting materials
+    ]
 
 <div class='together'>
 `main()` is updated to set the background color for the prior scenes:
@@ -3594,8 +3597,9 @@ with an addition operator as well.
         return ival + displacement;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [interval-plus-displacement]:
-    <kbd>[interval.h]</kbd> The interval + displacement operator]
+    [Listing [interval-plus-displacement]: <kbd>[interval.h]</kbd>
+        The interval + displacement operator
+    ]
 
 
 Instance Rotation

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -1371,7 +1371,8 @@ the $z$ axis:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [main-sphereimp]: <kbd>[sphere_importance.cc]</kbd>
-    Generating importance-sampled points on the unit sphere]
+        Generating importance-sampled points on the unit sphere
+    ]
 
 The analytic answer is $\frac{4}{3} \pi$ -- if you remember enough advanced calc, check me! And the
 code above produces that. The key point here is that all of the integrals and the probability and
@@ -1625,7 +1626,8 @@ We modify the base-class `material` to enable this importance sampling:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-material]: <kbd>[material.h]</kbd>
-    The material class, adding importance sampling]
+        The material class, adding importance sampling
+    ]
 
 </div>
 
@@ -1664,7 +1666,8 @@ And the `lambertian` material becomes:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-lambertian-impsample]: <kbd>[material.h]</kbd>
-    Lambertian material, modified for importance sampling]
+        Lambertian material, modified for importance sampling
+    ]
 
 </div>
 
@@ -1708,7 +1711,8 @@ And the `camera::ray_color` function gets a minor modification:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-impsample]: <kbd>[camera.h]</kbd>
-    The ray_color function, modified for importance sampling]
+        The ray_color function, modified for importance sampling
+    ]
 
 </div>
 
@@ -1762,7 +1766,8 @@ a noisier image:
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-uniform]: <kbd>[camera.h]</kbd>
-    The ray_color function, now with a uniform PDF in the denominator]
+        The ray_color function, now with a uniform PDF in the denominator
+    ]
 
 You should get a very similar result to before, only with slightly more noise, it may be hard to
 see.
@@ -2059,7 +2064,8 @@ Here's a function that generates random vectors weighted by this PDF:
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [random-cosine-direction]: <kbd>[vec3.h]</kbd>
-    Random cosine direction utility function]
+        Random cosine direction utility function
+    ]
 
 </div>
 
@@ -2321,7 +2327,8 @@ But first, let's quickly update the `isotropic` material:
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-isotropic-impsample]: <kbd>[material.h]</kbd>
-    Isotropic material, modified for importance sampling]
+        Isotropic material, modified for importance sampling
+    ]
 
 </div>
 
@@ -3353,7 +3360,8 @@ materials that we're treating specularly.
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [ray-color-implicit]: <kbd>[camera.h]</kbd>
-    Ray color function with implicitly-sampled rays]
+        Ray color function with implicitly-sampled rays
+    ]
 
 </div>
 


### PR DESCRIPTION
[Cherry-picked from my original AABB rewrite attempt.]

- Use a consistent wrap format for long captions.
- Always have a blank line before a closing </div> tag following a listing, due to Markdeep behavior.
- Minor correction to one caption typo.
- Fix neglected indent for a code listing.