### PR TITLE
Fix broken link to in1week.blogspot.com in Book 1

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -66,7 +66,7 @@ check out the online [_Graphics Codex_][gfx-codex] by Morgan McGuire, _Fundament
 Graphics_ by Steve Marschner and Peter Shirley, or _Computer Graphics: Principles and Practice_
 by J.D. Foley and Andy Van Dam.
 
-Peter maintains a site related to this book series at https://in1weekend.blogspot.com/, which
+Peter maintains a site related to this book series at <a>https://in1weekend.blogspot.com/</a>, which
 includes further reading and links to resources.
 
 These books have been formatted to print well directly from your browser. We also include PDFs of


### PR DESCRIPTION
Fixes #1326 

Wrap `https://in1weekend.blogspot.com/` in `<a>` tags to avoid 404, since the url points to `/,`.