### PR TITLE
Enclose free URLs with angle-bracket delimiters

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -66,7 +66,7 @@ check out the online [_Graphics Codex_][gfx-codex] by Morgan McGuire, _Fundament
 Graphics_ by Steve Marschner and Peter Shirley, or _Computer Graphics: Principles and Practice_
 by J.D. Foley and Andy Van Dam.
 
-Peter maintains a site related to this book series at https://in1weekend.blogspot.com/, which
+Peter maintains a site related to this book series at <https://in1weekend.blogspot.com/>, which
 includes further reading and links to resources.
 
 These books have been formatted to print well directly from your browser. We also include PDFs of
@@ -238,7 +238,7 @@ everything in the remainder of this series uses this same simple mechanism for g
 images.
 
 If you want to produce other image formats, I am a fan of `stb_image.h`, a header-only image library
-available on GitHub at https://github.com/nothings/stb.
+available on GitHub at <https://github.com/nothings/stb>.
 
 
 Adding a Progress Indicator
@@ -4221,8 +4221,8 @@ Basic Data
   - **Author**: Peter Shirley, Trevor David Black, Steve Hollasch
   - **Version/Edition**: v4.0.0-alpha.2
   - **Date**: 2023-XX-XX
-  - **URL (series)**: https://raytracing.github.io/
-  - **URL (book)**: https://raytracing.github.io/books/RayTracingInOneWeekend.html
+  - **URL (series)**: <https://raytracing.github.io/>
+  - **URL (book)**: <https://raytracing.github.io/books/RayTracingInOneWeekend.html>
 
 Snippets
 ---------

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -21,7 +21,7 @@ using a BVH. When done, you’ll have a “real” ray tracer.
 
 A heuristic in ray tracing that many people--including me--believe, is that most optimizations
 complicate the code without delivering much speedup. What I will do in this mini-book is go with the
-simplest approach in each design decision I make. Check https://in1weekend.blogspot.com/ for
+simplest approach in each design decision I make. Check <https://in1weekend.blogspot.com/> for
 readings and references to a more sophisticated approach. However, I strongly encourage you to do no
 premature optimization; if it doesn’t show up high in the execution time profile, it doesn’t need
 optimization until all the features are supported!
@@ -4163,7 +4163,7 @@ Running it with 10,000 rays per pixel (sweet dreams) yields:
 
   ![<span class='num'>Image 23:</span> Final scene](../images/img-2.23-book2-final.jpg)
 
-Now go off and make a really cool image of your own! See https://in1weekend.blogspot.com/ for
+Now go off and make a really cool image of your own! See <https://in1weekend.blogspot.com/> for
 pointers to further reading and features, and feel free to email questions, comments, and cool
 images to me at ptrshrl@gmail.com.
 
@@ -4187,8 +4187,8 @@ Basic Data
   - **Author**: Peter Shirley, Trevor David Black, Steve Hollasch
   - **Version/Edition**: v4.0.0-alpha.2
   - **Date**: 2023-XX-XX
-  - **URL (series)**: https://raytracing.github.io/
-  - **URL (book)**: https://raytracing.github.io/books/RayTracingTheNextWeek.html
+  - **URL (series)**: <https://raytracing.github.io/>
+  - **URL (book)**: <https://raytracing.github.io/books/RayTracingTheNextWeek.html>
 
 Snippets
 ---------

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -39,7 +39,7 @@ need in order to study these and other interesting techniques.
 
 I hope that you find the math as fascinating as I do.
 
-As before, https://in1weekend.blogspot.com/ will have further readings and references.
+As before, <https://in1weekend.blogspot.com/> will have further readings and references.
 
 These books have been formatted to print well directly from your browser. We also include PDFs of
 each book [with each release][releases], in the "Assets" section.
@@ -3757,8 +3757,8 @@ Basic Data
   - **Author**: Peter Shirley, Trevor David Black, Steve Hollasch
   - **Version/Edition**: v4.0.0-alpha.2
   - **Date**: 2023-XX-XX
-  - **URL (series)**: https://raytracing.github.io/
-  - **URL (book)**: https://raytracing.github.io/books/RayTracingTheRestOfYourLife.html
+  - **URL (series)**: <https://raytracing.github.io/>
+  - **URL (book)**: <https://raytracing.github.io/books/RayTracingTheRestOfYourLife.html>
 
 Snippets
 ---------


### PR DESCRIPTION
This makes the parsing unambiguous in the presence of trailing punctuation (fixing one bug) and is more clear to read.