### PR TITLE
Listing 68: Should include "aabb::empty" and "aabb::universe" to be consistent with Listing 69

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -3564,7 +3564,10 @@ offset` above requires some additional support.
         ...
     };
 
+    const aabb aabb::empty    = aabb(interval::empty,    interval::empty,    interval::empty);
+    const aabb aabb::universe = aabb(interval::universe, interval::universe, interval::universe);
 
+    
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
     aabb operator+(const aabb& bbox, const vec3& offset) {
         return aabb(bbox.x + offset.x(), bbox.y + offset.y(), bbox.z + offset.z());


### PR DESCRIPTION
Addresses #1361 