### PR TITLE
Simplify vec3 initialization

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -310,8 +310,15 @@ vector utility functions in the bottom half:
       public:
         double e[3];
 
-        vec3() : e{0,0,0} {}
-        vec3(double e0, double e1, double e2) : e{e0, e1, e2} {}
+        vec3() {
+            e[0] = e[1] = e[2] = 0;
+        }
+
+        vec3(double e0, double e1, double e2) {
+            e[0] = e0;
+            e[1] = e1;
+            e[2] = e2;
+        }
 
         double x() const { return e[0]; }
         double y() const { return e[1]; }

--- a/src/InOneWeekend/vec3.h
+++ b/src/InOneWeekend/vec3.h
@@ -21,8 +21,15 @@ class vec3 {
   public:
     double e[3];
 
-    vec3() : e{0,0,0} {}
-    vec3(double e0, double e1, double e2) : e{e0, e1, e2} {}
+    vec3() {
+        e[0] = e[1] = e[2] = 0;
+    }
+
+    vec3(double e0, double e1, double e2) {
+        e[0] = e0;
+        e[1] = e1;
+        e[2] = e2;
+    }
 
     double x() const { return e[0]; }
     double y() const { return e[1]; }

--- a/src/TheNextWeek/vec3.h
+++ b/src/TheNextWeek/vec3.h
@@ -21,8 +21,15 @@ class vec3 {
   public:
     double e[3];
 
-    vec3() : e{0,0,0} {}
-    vec3(double e0, double e1, double e2) : e{e0, e1, e2} {}
+    vec3() {
+        e[0] = e[1] = e[2] = 0;
+    }
+
+    vec3(double e0, double e1, double e2) {
+        e[0] = e0;
+        e[1] = e1;
+        e[2] = e2;
+    }
 
     double x() const { return e[0]; }
     double y() const { return e[1]; }

--- a/src/TheRestOfYourLife/vec3.h
+++ b/src/TheRestOfYourLife/vec3.h
@@ -21,8 +21,15 @@ class vec3 {
   public:
     double e[3];
 
-    vec3() : e{0,0,0} {}
-    vec3(double e0, double e1, double e2) : e{e0, e1, e2} {}
+    vec3() {
+        e[0] = e[1] = e[2] = 0;
+    }
+
+    vec3(double e0, double e1, double e2) {
+        e[0] = e0;
+        e[1] = e1;
+        e[2] = e2;
+    }
 
     double x() const { return e[0]; }
     double y() const { return e[1]; }


### PR DESCRIPTION
We were using brace initialization like so:

    vec3() : e{0,0,0} {}
    vec3(double e0, double e1, double e2) : e{e0, e1, e2} {}

Some readers reported issues on Mac using braced initialization, so likely an issue with some compiler version. It may be technically legal with C++11 (I think, or perhaps a later C++ version), but it's not really buying anything, so this change uses an older-style initialization.

Resolves #847