### PR TITLE
Fix noise_texture regression in call to turb()

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -2395,8 +2395,7 @@ Here `fabs()` is the absolute value function defined in `<cmath>`.
 
         color value(double u, double v, const point3& p) const override {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-            auto s = scale * p;
-            return color(1,1,1) * noise.turb(s, 7);
+            return color(1,1,1) * noise.turb(p, 7);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
 
@@ -2433,8 +2432,7 @@ effect is:
 
         color value(double u, double v, const point3& p) const override {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-            auto s = scale * p;
-            return color(1,1,1) * 0.5 * (1 + sin(s.z() + 10*noise.turb(s, 7)));
+            return color(1,1,1)*0.5*(1 + sin(scale * p.z() + 10*noise.turb(p, 7)));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
 

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -2432,7 +2432,7 @@ effect is:
 
         color value(double u, double v, const point3& p) const override {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-            return color(1,1,1)*0.5*(1 + sin(scale * p.z() + 10*noise.turb(p, 7)));
+            return color(.5, .5, .5) * (1 + sin(scale * p.z() + 10 * noise.turb(p, 7)));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
 
@@ -4106,7 +4106,7 @@ testing.
 
         auto emat = make_shared<lambertian>(make_shared<image_texture>("earthmap.jpg"));
         world.add(make_shared<sphere>(point3(400,200,400), 100, emat));
-        auto pertext = make_shared<noise_texture>(0.1);
+        auto pertext = make_shared<noise_texture>(0.2);
         world.add(make_shared<sphere>(point3(220,280,300), 80, make_shared<lambertian>(pertext)));
 
         hittable_list boxes2;

--- a/src/TheNextWeek/main.cc
+++ b/src/TheNextWeek/main.cc
@@ -364,7 +364,7 @@ void final_scene(int image_width, int samples_per_pixel, int max_depth) {
 
     auto emat = make_shared<lambertian>(make_shared<image_texture>("earthmap.jpg"));
     world.add(make_shared<sphere>(point3(400,200,400), 100, emat));
-    auto pertext = make_shared<noise_texture>(0.1);
+    auto pertext = make_shared<noise_texture>(0.20);
     world.add(make_shared<sphere>(point3(220,280,300), 80, make_shared<lambertian>(pertext)));
 
     hittable_list boxes2;

--- a/src/TheNextWeek/main.cc
+++ b/src/TheNextWeek/main.cc
@@ -364,7 +364,7 @@ void final_scene(int image_width, int samples_per_pixel, int max_depth) {
 
     auto emat = make_shared<lambertian>(make_shared<image_texture>("earthmap.jpg"));
     world.add(make_shared<sphere>(point3(400,200,400), 100, emat));
-    auto pertext = make_shared<noise_texture>(0.20);
+    auto pertext = make_shared<noise_texture>(0.2);
     world.add(make_shared<sphere>(point3(220,280,300), 80, make_shared<lambertian>(pertext)));
 
     hittable_list boxes2;

--- a/src/TheNextWeek/texture.h
+++ b/src/TheNextWeek/texture.h
@@ -76,7 +76,7 @@ class noise_texture : public texture {
     noise_texture(double sc) : scale(sc) {}
 
     color value(double u, double v, const point3& p) const override {
-        return color(1,1,1)*0.5*(1 + sin(scale * p.z() + 10*noise.turb(p, 7)));
+        return color(.5, .5, .5) * (1 + sin(scale * p.z() + 10 * noise.turb(p, 7)));
     }
 
   private:

--- a/src/TheNextWeek/texture.h
+++ b/src/TheNextWeek/texture.h
@@ -76,8 +76,7 @@ class noise_texture : public texture {
     noise_texture(double sc) : scale(sc) {}
 
     color value(double u, double v, const point3& p) const override {
-        auto s = scale * p;
-        return color(1,1,1)*0.5*(1 + sin(s.z() + 10*noise.turb(s, 7)));
+        return color(1,1,1)*0.5*(1 + sin(scale * p.z() + 10*noise.turb(p, 7)));
     }
 
   private:

--- a/src/TheRestOfYourLife/texture.h
+++ b/src/TheRestOfYourLife/texture.h
@@ -76,7 +76,7 @@ class noise_texture : public texture {
     noise_texture(double sc) : scale(sc) {}
 
     color value(double u, double v, const point3& p) const override {
-        return color(1,1,1)*0.5*(1 + sin(scale * p.z() + 10*noise.turb(p, 7)));
+        return color(.5, .5, .5) * (1 + sin(scale * p.z() + 10 * noise.turb(p, 7)));
     }
 
   private:

--- a/src/TheRestOfYourLife/texture.h
+++ b/src/TheRestOfYourLife/texture.h
@@ -76,8 +76,7 @@ class noise_texture : public texture {
     noise_texture(double sc) : scale(sc) {}
 
     color value(double u, double v, const point3& p) const override {
-        auto s = scale * p;
-        return color(1,1,1)*0.5*(1 + sin(s.z() + 10*noise.turb(s, 7)));
+        return color(1,1,1)*0.5*(1 + sin(scale * p.z() + 10*noise.turb(p, 7)));
     }
 
   private:


### PR DESCRIPTION
At some point we passed the scaled point to the noise.turb() function, when we should have continued to pass the unscaled point.

Resolves #1286