### PR TITLE
Fix: bounding box for quad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ then.
              yielding a 15-20% speedup (#1007)
 
 ### The Next Week
-  - Change - BBox for quad now consider all 4 points (#1402)
+  - Change - BBox for `quad` now considers all 4 points (#1402)
   - Change - `perlin::turb()` no longer defaults the value for the depth parameter.
   - Change - AABB automatically pads to mininmum size for any dimension; no longer requires
              primitives to call aabb::pad() function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ then.
              yielding a 15-20% speedup (#1007)
 
 ### The Next Week
+  - Change - BBox for quad now consider all 4 points (#1402)
   - Change - `perlin::turb()` no longer defaults the value for the depth parameter.
   - Change - AABB automatically pads to mininmum size for any dimension; no longer requires
              primitives to call aabb::pad() function.
@@ -622,4 +623,3 @@ typesetting and source-code cleanup.
 # v1.42.0  (2018-08-26)
 
   - New - First GitHub release of _Ray Tracing: The Next Week_.
-

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -1031,7 +1031,7 @@ function.
 At this point, we're ready to use our new BVH code. Let's use it on our random spheres scene.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-    #include "bvh.h" 
+    #include "bvh.h"
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     ...
 
@@ -2547,7 +2547,9 @@ Now we're ready for the first sketch of the new `quad` class:
         }
 
         virtual void set_bounding_box() {
-            bbox = aabb(Q, Q + u + v);
+            aabb bbox1 = aabb(Q, Q + u + v);
+            aabb bbox2 = aabb(Q + u, Q + v);
+            bbox = aabb(bbox1, bbox2)
         }
 
         aabb bounding_box() const override { return bbox; }
@@ -3580,7 +3582,7 @@ offset` above requires some additional support.
     const aabb aabb::empty    = aabb(interval::empty,    interval::empty,    interval::empty);
     const aabb aabb::universe = aabb(interval::universe, interval::universe, interval::universe);
 
-    
+
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
     aabb operator+(const aabb& bbox, const vec3& offset) {
         return aabb(bbox.x + offset.x(), bbox.y + offset.y(), bbox.z + offset.z());

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -2452,7 +2452,7 @@ Though we'll name our new primitive a `quad`, it will technically be a parallelo
 are parallel) instead of a general quadrilateral. For our purposes, we'll use three geometric
 entities to define a quad:
 
-  1. $\mathbf{Q}$, the lower-left corner.
+  1. $\mathbf{Q}$, the starting corner.
   2. $\mathbf{u}$, a vector representing the first side.
      $\mathbf{Q} + \mathbf{u}$ gives one of the corners adjacent to $\mathbf{Q}$.
   3. $\mathbf{v}$, a vector representing the second side.
@@ -2528,7 +2528,7 @@ constructed AABBs always have a non-zero volume:
 </div>
 
 <div class='together'>
-Now we're ready for the first sketch of the new `quad` class:
+A quad's bounding box should be calculated based on its 4 points. While ordering of these points doesn’t matter, we decide to calculate the bounding boxes for each of the two diagonals, and then combine them. Now we're ready for the first sketch of the new `quad` class:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #ifndef QUAD_H

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -2549,7 +2549,7 @@ A quad's bounding box should be calculated based on its 4 points. While ordering
         virtual void set_bounding_box() {
             aabb bbox1 = aabb(Q, Q + u + v);
             aabb bbox2 = aabb(Q + u, Q + v);
-            bbox = aabb(bbox1, bbox2)
+            bbox = aabb(bbox1, bbox2);
         }
 
         aabb bounding_box() const override { return bbox; }

--- a/src/TheNextWeek/aabb.h
+++ b/src/TheNextWeek/aabb.h
@@ -40,8 +40,6 @@ class aabb {
         x = interval(box0.x, box1.x);
         y = interval(box0.y, box1.y);
         z = interval(box0.z, box1.z);
-
-        pad_to_minimums();
     }
 
     const interval& axis(int n) const {

--- a/src/TheNextWeek/aabb.h
+++ b/src/TheNextWeek/aabb.h
@@ -40,6 +40,8 @@ class aabb {
         x = interval(box0.x, box1.x);
         y = interval(box0.y, box1.y);
         z = interval(box0.z, box1.z);
+
+        pad_to_minimums();
     }
 
     const interval& axis(int n) const {

--- a/src/TheNextWeek/quad.h
+++ b/src/TheNextWeek/quad.h
@@ -28,7 +28,9 @@ class quad : public hittable {
     }
 
     virtual void set_bounding_box() {
-        bbox = aabb(Q, Q + u + v);
+        aabb bbox1 = aabb(Q, Q + u + v);
+        aabb bbox2 = aabb(Q + u, Q + v);
+        bbox = aabb(bbox1, bbox2).pad();
     }
 
     aabb bounding_box() const override { return bbox; }

--- a/src/TheNextWeek/quad.h
+++ b/src/TheNextWeek/quad.h
@@ -30,7 +30,7 @@ class quad : public hittable {
     virtual void set_bounding_box() {
         aabb bbox1 = aabb(Q, Q + u + v);
         aabb bbox2 = aabb(Q + u, Q + v);
-        bbox = aabb(bbox1, bbox2).pad();
+        bbox = aabb(bbox1, bbox2);
     }
 
     aabb bounding_box() const override { return bbox; }

--- a/src/TheRestOfYourLife/quad.h
+++ b/src/TheRestOfYourLife/quad.h
@@ -30,7 +30,9 @@ class quad : public hittable {
     }
 
     virtual void set_bounding_box() {
-        bbox = aabb(Q, Q + u + v);
+        aabb bbox1 = aabb(Q, Q + u + v);
+        aabb bbox2 = aabb(Q + u, Q + v);
+        bbox = aabb(bbox1, bbox2);
     }
 
     aabb bounding_box() const override { return bbox; }


### PR DESCRIPTION
bounding box for quad should consider all the 4 points of quad instead of the opposite corner points, for the other 2 points could enlarge the box along that direction

Fix: https://github.com/RayTracing/raytracing.github.io/issues/1402