### PR TITLE
[All Books] Use 1 / (sqrt_spp * sqrt_spp) for sample scale. 

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1984,9 +1984,9 @@ pixel and average the resulting light (color) values together.
 
 First we'll update the `write_color()` function to account for the number of samples we use: we need
 to find the average across all of the samples that we take. To do this, we'll add the full color
-from each iteration, and then finish with a single division (by the number of samples) at the end,
-before writing out the color. To ensure that the color components of the final result remain within
-the proper $[0,1]$ bounds, we'll add and use a small helper function: `interval::clamp(x)`.
+from each iteration, and then finish with a single division (by the number of samples in the unit square)
+at the end, before writing out the color. To ensure that the color components of the final result remain
+within the proper $[0,1]$ bounds, we'll add and use a small helper function: `interval::clamp(x)`.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class interval {
@@ -2011,19 +2011,18 @@ the proper $[0,1]$ bounds, we'll add and use a small helper function: `interval:
     [Listing [clamp]: <kbd>[interval.h]</kbd> The interval::clamp() utility function]
 
 And here's the updated `write_color()` function that takes the sum total of all light for the pixel
-and the number of samples involved:
+and a sampling scale value:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-    void write_color(std::ostream& out, const color& pixel_color, int samples_per_pixel) {
+    void write_color(std::ostream& out, const color& pixel_color, double spp_scale) {
         auto r = pixel_color.x();
         auto g = pixel_color.y();
         auto b = pixel_color.z();
 
-        // Divide the color by the number of samples.
-        auto scale = 1.0 / samples_per_pixel;
-        r *= scale;
-        g *= scale;
-        b *= scale;
+        // Divide the color by the sampling scale.
+        r *= spp_scale;
+        g *= spp_scale;
+        b *= spp_scale;
 
         // Write the translated [0,255] value of each color component.
         static const interval intensity(0.000, 0.999);
@@ -2059,11 +2058,13 @@ we're currently sampling.
                 for (int i = 0; i < image_width; i++) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
                     color pixel_color(0,0,0);
-                    for (int sample = 0; sample < samples_per_pixel; sample++) {
-                        ray r = get_ray(i, j);
-                        pixel_color += ray_color(r, world);
+                    for(int s_j = 0; s_j < sqrt_spp; s_j++){
+                        for(int s_i = 0; s_i < sqrt_spp; s_i++){
+                            ray r = get_ray(i, j);
+                            pixel_color += ray_color(r, max_depth, world);
+                        }
                     }
-                    write_color(std::cout, pixel_color, samples_per_pixel);
+                    write_color(std::cout, pixel_color, spp_scale);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 }
             }
@@ -2072,8 +2073,21 @@ we're currently sampling.
         }
         ...
       private:
-        ...
+        int    image_height;    // Rendered image height
+        point3 center;          // Camera center
+        point3 pixel00_loc;     // Location of pixel 0, 0
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+        int    sqrt_spp;        // Square Root of random samples for each pixel
+        double spp_scale;       // Scale value for the random samples for each pixel
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
         void initialize() {
+          image_height = int(image_width / aspect_ratio);
+          image_height = (image_height < 1) ? 1 : image_height;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+          sqrt_spp = int(sqrt(samples_per_pixel));
+          spp_scale = 1.0 / (sqrt_spp * sqrt_spp);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
           ...
         }
 
@@ -2372,11 +2386,13 @@ depth, returning no light contribution at the maximum depth:
                 std::clog << "\rScanlines remaining: " << (image_height - j) << ' ' << std::flush;
                 for (int i = 0; i < image_width; i++) {
                     color pixel_color(0,0,0);
-                    for (int sample = 0; sample < samples_per_pixel; sample++) {
-                        ray r = get_ray(i, j);
+                    for (int s_j = 0; s_j < sqrt_spp; s_j++) {
+                        for (int s_i = 0; s_i < sqrt_spp; s_i++) {
+                            ray r = get_ray(i, j);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-                        pixel_color += ray_color(r, max_depth, world);
+                            pixel_color += ray_color(r, max_depth, world);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+                        }
                     }
                     write_color(std::cout, pixel_color, samples_per_pixel);
                 }
@@ -3682,6 +3698,8 @@ angles.
         int    image_height;   // Rendered image height
         point3 center;         // Camera center
         point3 pixel00_loc;    // Location of pixel 0, 0
+        int    sqrt_spp;       // Square Root of random samples for each pixel
+        double spp_scale;      // Scale value for the random samples for each pixel
         vec3   pixel_delta_u;  // Offset to pixel to the right
         vec3   pixel_delta_v;  // Offset to pixel below
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -3925,6 +3943,8 @@ Now let's update the camera to originate rays from the defocus disk:
         int    image_height;    // Rendered image height
         point3 center;          // Camera center
         point3 pixel00_loc;     // Location of pixel 0, 0
+        int    sqrt_spp;        // Square Root of random samples for each pixel
+        double spp_scale;       // Scale value for the random samples for each pixel
         vec3   pixel_delta_u;   // Offset to pixel to the right
         vec3   pixel_delta_v;   // Offset to pixel below
         vec3   u, v, w;         // Camera frame basis vectors

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -307,8 +307,9 @@ location.
     class camera {
       private:
         int    image_height;    // Rendered image height
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         int    sqrt_spp;        // Square root of number of samples per pixel
+        double spp_scale;       // Scale value for the random samples for each pixel
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         double recip_sqrt_spp;  // 1 / sqrt_spp
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         point3 center;          // Camera center
@@ -317,9 +318,9 @@ location.
             ...
             auto viewport_width = viewport_height * (double(image_width)/image_height);
 
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             sqrt_spp = int(sqrt(samples_per_pixel));
+            spp_scale = 1.0 / (sqrt_spp * sqrt_spp);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             recip_sqrt_spp = 1.0 / sqrt_spp;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -305,32 +305,6 @@ location.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class camera {
-      public:
-        ...
-        void render(const hittable& world) {
-            initialize();
-
-            std::cout << "P3\n" << image_width << ' ' << image_height << "\n255\n";
-
-            for (int j = 0; j < image_height; j++) {
-                std::clog << "\rScanlines remaining: " << (image_height - j) << ' ' << std::flush;
-                for (int i = 0; i < image_width; i++) {
-                    color pixel_color(0,0,0);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-                    for (int s_j = 0; s_j < sqrt_spp; s_j++) {
-                        for (int s_i = 0; s_i < sqrt_spp; s_i++) {
-                            ray r = get_ray(i, j, s_i, s_j);
-                            pixel_color += ray_color(r, max_depth, world);
-                        }
-                    }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-                    write_color(std::cout, pixel_color, samples_per_pixel);
-                }
-            }
-
-            std::clog << "\rDone.                 \n";
-        }
-        ...
       private:
         ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight

--- a/src/InOneWeekend/camera.h
+++ b/src/InOneWeekend/camera.h
@@ -44,11 +44,13 @@ class camera {
             std::clog << "\rScanlines remaining: " << (image_height - j) << ' ' << std::flush;
             for (int i = 0; i < image_width; i++) {
                 color pixel_color(0,0,0);
-                for (int sample = 0; sample < samples_per_pixel; sample++) {
-                    ray r = get_ray(i, j);
-                    pixel_color += ray_color(r, max_depth, world);
+                for (int s_j = 0; s_j < sqrt_spp; s_j++) {
+                    for (int s_i = 0; s_i < sqrt_spp; s_i++) {
+                        ray r = get_ray(i, j);
+                        pixel_color += ray_color(r, max_depth, world);
+                    }
                 }
-                write_color(std::cout, pixel_color, samples_per_pixel);
+                write_color(std::cout, pixel_color, spp_scale);
             }
         }
 
@@ -59,6 +61,8 @@ class camera {
     int    image_height;    // Rendered image height
     point3 center;          // Camera center
     point3 pixel00_loc;     // Location of pixel 0, 0
+    int    sqrt_spp;        // Square Root of random samples for each pixel
+    double spp_scale;       // Scale value for the random samples for each pixel
     vec3   pixel_delta_u;   // Offset to pixel to the right
     vec3   pixel_delta_v;   // Offset to pixel below
     vec3   u, v, w;         // Camera frame basis vectors
@@ -68,6 +72,9 @@ class camera {
     void initialize() {
         image_height = int(image_width / aspect_ratio);
         image_height = (image_height < 1) ? 1 : image_height;
+
+        sqrt_spp = int(sqrt(samples_per_pixel));
+        spp_scale = 1.0 / (sqrt_spp * sqrt_spp);
 
         center = lookfrom;
 

--- a/src/InOneWeekend/color.h
+++ b/src/InOneWeekend/color.h
@@ -25,16 +25,15 @@ inline double linear_to_gamma(double linear_component)
     return 0;
 }
 
-void write_color(std::ostream& out, const color& pixel_color, int samples_per_pixel) {
+void write_color(std::ostream& out, const color& pixel_color, double spp_scale) {
     auto r = pixel_color.x();
     auto g = pixel_color.y();
     auto b = pixel_color.z();
 
-    // Divide the color by the number of samples.
-    auto scale = 1.0 / samples_per_pixel;
-    r *= scale;
-    g *= scale;
-    b *= scale;
+    // Divide the color by the sampling scale.
+    r *= spp_scale;
+    g *= spp_scale;
+    b *= spp_scale;
 
     // Apply the linear to gamma transform.
     r = linear_to_gamma(r);

--- a/src/TheNextWeek/camera.h
+++ b/src/TheNextWeek/camera.h
@@ -45,11 +45,13 @@ class camera {
             std::clog << "\rScanlines remaining: " << (image_height - j) << ' ' << std::flush;
             for (int i = 0; i < image_width; i++) {
                 color pixel_color(0,0,0);
-                for (int sample = 0; sample < samples_per_pixel; sample++) {
-                    ray r = get_ray(i, j);
-                    pixel_color += ray_color(r, max_depth, world);
+                for (int s_j = 0; s_j < sqrt_spp; s_j++) {
+                    for (int s_i = 0; s_i < sqrt_spp; s_i++) {
+                        ray r = get_ray(i, j);
+                        pixel_color += ray_color(r, max_depth, world);
+                    }
                 }
-                write_color(std::cout, pixel_color, samples_per_pixel);
+                write_color(std::cout, pixel_color, spp_scale);
             }
         }
 
@@ -60,6 +62,8 @@ class camera {
     int    image_height;    // Rendered image height
     point3 center;          // Camera center
     point3 pixel00_loc;     // Location of pixel 0, 0
+    int    sqrt_spp;        // Square Root of random samples for each pixel
+    double spp_scale;       // Scale value for the random samples for each pixel
     vec3   pixel_delta_u;   // Offset to pixel to the right
     vec3   pixel_delta_v;   // Offset to pixel below
     vec3   u, v, w;         // Camera frame basis vectors
@@ -69,6 +73,9 @@ class camera {
     void initialize() {
         image_height = int(image_width / aspect_ratio);
         image_height = (image_height < 1) ? 1 : image_height;
+
+        sqrt_spp = int(sqrt(samples_per_pixel));
+        spp_scale = 1.0 / (sqrt_spp * sqrt_spp);
 
         center = lookfrom;
 

--- a/src/TheNextWeek/color.h
+++ b/src/TheNextWeek/color.h
@@ -25,16 +25,15 @@ inline double linear_to_gamma(double linear_component)
     return 0;
 }
 
-void write_color(std::ostream& out, const color& pixel_color, int samples_per_pixel) {
+void write_color(std::ostream& out, const color& pixel_color, double spp_scale) {
     auto r = pixel_color.x();
     auto g = pixel_color.y();
     auto b = pixel_color.z();
 
-    // Divide the color by the number of samples.
-    auto scale = 1.0 / samples_per_pixel;
-    r *= scale;
-    g *= scale;
-    b *= scale;
+    // Divide the color by the sampling scale.
+    r *= spp_scale;
+    g *= spp_scale;
+    b *= spp_scale;
 
     // Apply the linear to gamma transform.
     r = linear_to_gamma(r);

--- a/src/TheRestOfYourLife/camera.h
+++ b/src/TheRestOfYourLife/camera.h
@@ -61,8 +61,8 @@ class camera {
   private:
     int    image_height;    // Rendered image height
     int    sqrt_spp;        // Square root of number of samples per pixel
-    double recip_sqrt_spp;  // 1 / sqrt_spp
     double spp_scale;       // Scale value for the random samples for each pixel
+    double recip_sqrt_spp;  // 1 / sqrt_spp
     point3 center;          // Camera center
     point3 pixel00_loc;     // Location of pixel 0, 0
     vec3   pixel_delta_u;   // Offset to pixel to the right

--- a/src/TheRestOfYourLife/camera.h
+++ b/src/TheRestOfYourLife/camera.h
@@ -51,7 +51,7 @@ class camera {
                         pixel_color += ray_color(r, max_depth, world, lights);
                     }
                 }
-                write_color(std::cout, pixel_color, samples_per_pixel);
+                write_color(std::cout, pixel_color, spp_scale);
             }
         }
 
@@ -62,6 +62,7 @@ class camera {
     int    image_height;    // Rendered image height
     int    sqrt_spp;        // Square root of number of samples per pixel
     double recip_sqrt_spp;  // 1 / sqrt_spp
+    double spp_scale;       // Scale value for the random samples for each pixel
     point3 center;          // Camera center
     point3 pixel00_loc;     // Location of pixel 0, 0
     vec3   pixel_delta_u;   // Offset to pixel to the right
@@ -83,6 +84,7 @@ class camera {
         auto viewport_width = viewport_height * (double(image_width)/image_height);
 
         sqrt_spp = int(sqrt(samples_per_pixel));
+        spp_scale = 1.0 / (sqrt_spp * sqrt_spp);
         recip_sqrt_spp = 1.0 / sqrt_spp;
 
         // Calculate the u,v,w unit basis vectors for the camera coordinate frame.

--- a/src/TheRestOfYourLife/color.h
+++ b/src/TheRestOfYourLife/color.h
@@ -25,23 +25,17 @@ inline double linear_to_gamma(double linear_component)
     return 0;
 }
 
-void write_color(std::ostream& out, const color& pixel_color, int samples_per_pixel) {
+void write_color(std::ostream& out, const color& pixel_color, double spp_scale) {
     auto r = pixel_color.x();
     auto g = pixel_color.y();
     auto b = pixel_color.z();
 
-    // Replace NaN components with zero.
-    if (r != r) r = 0.0;
-    if (g != g) g = 0.0;
-    if (b != b) b = 0.0;
+    // Divide the color by the sampling scale.
+    r *= spp_scale;
+    g *= spp_scale;
+    b *= spp_scale;
 
-    // Divide the color by the number of samples.
-    auto scale = 1.0 / samples_per_pixel;
-    r *= scale;
-    g *= scale;
-    b *= scale;
-
-    // Apply a linear to gamma transform for gamma 2
+    // Apply the linear to gamma transform.
     r = linear_to_gamma(r);
     g = linear_to_gamma(g);
     b = linear_to_gamma(b);

--- a/src/TheRestOfYourLife/color.h
+++ b/src/TheRestOfYourLife/color.h
@@ -30,6 +30,11 @@ void write_color(std::ostream& out, const color& pixel_color, double spp_scale) 
     auto g = pixel_color.y();
     auto b = pixel_color.z();
 
+    // Replace NaN components with zero.
+    if (r != r) r = 0.0;
+    if (g != g) g = 0.0;
+    if (b != b) b = 0.0;
+
     // Divide the color by the sampling scale.
     r *= spp_scale;
     g *= spp_scale;


### PR DESCRIPTION
Addresses #1370 


From the naked eye, the color difference isn't noticeable:

| 1.0 / samples_per_pixel  | 1.0 / (sqrt_spp * sqrt_spp) |
| ------------- | ------------- |
| ![IOWDefualtColor](https://github.com/RayTracing/raytracing.github.io/assets/9646385/568db177-8c2c-472c-ae46-39f734e9f340)  | ![IOWNoColorLoss](https://github.com/RayTracing/raytracing.github.io/assets/9646385/48402880-1638-4d07-af7f-d1b0558f1a8c)  |

Differencing the two images, we see that there is in fact a _slight_ increase in value:
![value_difference](https://github.com/RayTracing/raytracing.github.io/assets/9646385/74df1000-4d8a-4ee8-9201-5adbf49d2e1d)

Highlighted difference:
![highlighted_difference](https://github.com/RayTracing/raytracing.github.io/assets/9646385/d9a7e6db-0d14-4d33-8730-aa2776db58ec)



