### PR TITLE
bvh_node: no more const qualifier of objects array, axis sorting "in place"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ then.
   - Change - Reworked the AABB chapter (#1236)
   - New - add section on alternative 2D primitives such as triangle, ellipse and annulus (#1204,
           #1205)
+  - Change - changed bvh construction (removed const qualifer for objects vector) so sorting is done 
+             in place and copying of vector is avoided, better bvh build performance (#1388, #1391)
 
 ### The Rest of Your Life
 

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -899,7 +899,7 @@ I am a fan of the one class design when feasible. Here is such a class:
 
     class bvh_node : public hittable {
       public:
-        bvh_node(hittable_list& list) : bvh_node(list.objects, 0, list.objects.size()) {}
+        bvh_node(hittable_list list) : bvh_node(list.objects, 0, list.objects.size()) {}
 
         bvh_node(std::vector<shared_ptr<hittable>>& objects, size_t start, size_t end) {
             // To be implemented later.
@@ -968,8 +968,8 @@ we haven't yet defined.
             if (object_span == 1) {
                 left = right = objects[start];
             } else if (object_span == 2) {
-				left = objects[start];
-				right = objects[start+1];              
+                left = objects[start];
+                right = objects[start+1];
             } else {
                 std::sort(objects.begin() + start, objects.begin() + end, comparator);
 

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -899,9 +899,9 @@ I am a fan of the one class design when feasible. Here is such a class:
 
     class bvh_node : public hittable {
       public:
-        bvh_node(const hittable_list& list) : bvh_node(list.objects, 0, list.objects.size()) {}
+        bvh_node(hittable_list& list) : bvh_node(list.objects, 0, list.objects.size()) {}
 
-        bvh_node(const std::vector<shared_ptr<hittable>>& src_objects, size_t start, size_t end) {
+        bvh_node(std::vector<shared_ptr<hittable>>& objects, size_t start, size_t end) {
             // To be implemented later.
         }
 
@@ -956,27 +956,20 @@ we haven't yet defined.
     class bvh_node : public hittable {
       public:
         ...
-        bvh_node(const std::vector<shared_ptr<hittable>>& src_objects, size_t start, size_t end) {
+        bvh_node(std::vector<shared_ptr<hittable>>& objects, size_t start, size_t end) {
             int axis = random_int(0,2);
 
             auto comparator = (axis == 0) ? box_x_compare
                             : (axis == 1) ? box_y_compare
                                           : box_z_compare;
 
-            auto objects = src_objects; // A modifiable array of the source scene objects
-
             size_t object_span = end - start;
 
             if (object_span == 1) {
                 left = right = objects[start];
             } else if (object_span == 2) {
-                if (comparator(objects[start], objects[start+1])) {
-                    left = objects[start];
-                    right = objects[start+1];
-                } else {
-                    left = objects[start+1];
-                    right = objects[start];
-                }
+				left = objects[start];
+				right = objects[start+1];              
             } else {
                 std::sort(objects.begin() + start, objects.begin() + end, comparator);
 
@@ -1094,12 +1087,12 @@ implementing it shortly.
     class bvh_node : public hittable {
       public:
         ...
-        bvh_node(const std::vector<shared_ptr<hittable>>& src_objects, size_t start, size_t end) {
+        bvh_node(std::vector<shared_ptr<hittable>>& objects, size_t start, size_t end) {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             // Build the bounding box of the span of source objects.
             bbox = aabb::empty;
-            for (int object_index=start; object_index < end; object_index++)
-                bbox = aabb(bbox, src_objects[object_index]->bounding_box());
+            for (size_t object_index=start; object_index < end; object_index++)
+                bbox = aabb(bbox, objects[object_index]->bounding_box());
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
             ...
@@ -1115,11 +1108,11 @@ computed it as the union of the left and right sides.
     class bvh_node : public hittable {
       public:
         ...
-        bvh_node(const std::vector<shared_ptr<hittable>>& src_objects, size_t start, size_t end) {
+        bvh_node(std::vector<shared_ptr<hittable>>& objects, size_t start, size_t end) {
             // Build the bounding box of the span of source objects.
             bbox = aabb::empty;
-            for (int object_index=start; object_index < end; object_index++)
-                bbox = aabb(bbox, src_objects[object_index]->bounding_box());
+            for (size_t object_index=start; object_index < end; object_index++)
+                bbox = aabb(bbox, objects[object_index]->bounding_box());
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight

--- a/books/acknowledgments.md.html
+++ b/books/acknowledgments.md.html
@@ -53,6 +53,7 @@ Acknowledgments
   - [Manas Kale](https://github.com/manas96)
   - Marcus Ottosson
   - [Mark Craig](https://github.com/mrmcsoftware)
+  - Markus Boos
   - Matthew Heimlich
   - Nakata Daisuke
   - [Nate Rupsis](https://github.com/rupsis)

--- a/src/TheNextWeek/bvh.h
+++ b/src/TheNextWeek/bvh.h
@@ -22,13 +22,13 @@
 
 class bvh_node : public hittable {
   public:
-    bvh_node(const hittable_list& list) : bvh_node(list.objects, 0, list.objects.size()) {}
+    bvh_node(hittable_list& list) : bvh_node(list.objects, 0, list.objects.size()) {}
 
-    bvh_node(const std::vector<shared_ptr<hittable>>& src_objects, size_t start, size_t end) {
+    bvh_node(std::vector<shared_ptr<hittable>>& objects, size_t start, size_t end) {
         // Build the bounding box of the span of source objects.
         bbox = aabb::empty;
         for (size_t object_index=start; object_index < end; object_index++)
-            bbox = aabb(bbox, src_objects[object_index]->bounding_box());
+            bbox = aabb(bbox, objects[object_index]->bounding_box());
 
         int axis = bbox.longest_axis();
 
@@ -36,20 +36,13 @@ class bvh_node : public hittable {
                         : (axis == 1) ? box_y_compare
                                       : box_z_compare;
 
-        auto objects = src_objects; // A modifiable array of the source scene objects
-
         size_t object_span = end - start;
 
         if (object_span == 1) {
             left = right = objects[start];
         } else if (object_span == 2) {
-            if (comparator(objects[start], objects[start+1])) {
-                left = objects[start];
-                right = objects[start+1];
-            } else {
-                left = objects[start+1];
-                right = objects[start];
-            }
+            left = objects[start];
+            right = objects[start+1];
         } else {
             std::sort(objects.begin() + start, objects.begin() + end, comparator);
 

--- a/src/TheNextWeek/bvh.h
+++ b/src/TheNextWeek/bvh.h
@@ -22,7 +22,7 @@
 
 class bvh_node : public hittable {
   public:
-    bvh_node(hittable_list& list) : bvh_node(list.objects, 0, list.objects.size()) {}
+    bvh_node(hittable_list list) : bvh_node(list.objects, 0, list.objects.size()) {}
 
     bvh_node(std::vector<shared_ptr<hittable>>& objects, size_t start, size_t end) {
         // Build the bounding box of the span of source objects.

--- a/src/TheRestOfYourLife/bvh.h
+++ b/src/TheRestOfYourLife/bvh.h
@@ -22,13 +22,13 @@
 
 class bvh_node : public hittable {
   public:
-    bvh_node(const hittable_list& list) : bvh_node(list.objects, 0, list.objects.size()) {}
+    bvh_node(hittable_list& list) : bvh_node(list.objects, 0, list.objects.size()) {}
 
-    bvh_node(const std::vector<shared_ptr<hittable>>& src_objects, size_t start, size_t end) {
+    bvh_node(std::vector<shared_ptr<hittable>>& objects, size_t start, size_t end) {
         // Build the bounding box of the span of source objects.
         bbox = aabb::empty;
-        for (int object_index=start; object_index < end; object_index++)
-            bbox = aabb(bbox, src_objects[object_index]->bounding_box());
+        for (size_t object_index=start; object_index < end; object_index++)
+            bbox = aabb(bbox, objects[object_index]->bounding_box());
 
         int axis = bbox.longest_axis();
 
@@ -36,20 +36,13 @@ class bvh_node : public hittable {
                         : (axis == 1) ? box_y_compare
                                       : box_z_compare;
 
-        auto objects = src_objects; // A modifiable array of the source scene objects
-
         size_t object_span = end - start;
 
         if (object_span == 1) {
             left = right = objects[start];
         } else if (object_span == 2) {
-            if (comparator(objects[start], objects[start+1])) {
-                left = objects[start];
-                right = objects[start+1];
-            } else {
-                left = objects[start+1];
-                right = objects[start];
-            }
+            left = objects[start];
+            right = objects[start+1];
         } else {
             std::sort(objects.begin() + start, objects.begin() + end, comparator);
 

--- a/src/TheRestOfYourLife/bvh.h
+++ b/src/TheRestOfYourLife/bvh.h
@@ -22,7 +22,7 @@
 
 class bvh_node : public hittable {
   public:
-    bvh_node(hittable_list& list) : bvh_node(list.objects, 0, list.objects.size()) {}
+    bvh_node(hittable_list list) : bvh_node(list.objects, 0, list.objects.size()) {}
 
     bvh_node(std::vector<shared_ptr<hittable>>& objects, size_t start, size_t end) {
         // Build the bounding box of the span of source objects.


### PR DESCRIPTION
based on @armansito's and @hollasch's suggestions in #1391 (see also further explanation and tests in #1388 )

-removed const qualifier for ```objects``` vector in ```bvh_node``` constructor so sorting is done "in place"
-hopefully ok because we don't need the scene objects array after being consumed by the bvh
-removed 2nd unnecessary branch within condition "object_span == 2" 
-did not change for loop of bbox calculation because using ```for (auto& obj : objects)``` instead of ```for (size_t object_index=0; object_index < size; object_index++)``` made everything a lot slower
-updated bvh source code in book2 and book3 
-modified listings in book2
-added note to changelog
-added names to acknowledgements (Arman was already there 😄)