### PR TITLE
correct call to reflectance()

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -3447,7 +3447,7 @@ material:
             vec3 direction;
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-            if (cannot_refract || reflectance(cos_theta, refraction_ratio) > random_double())
+            if (cannot_refract || reflectance(cos_theta, ir) > random_double())
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 direction = reflect(unit_direction, rec.normal);
             else

--- a/src/InOneWeekend/material.h
+++ b/src/InOneWeekend/material.h
@@ -82,7 +82,7 @@ class dielectric : public material {
         bool cannot_refract = refraction_ratio * sin_theta > 1.0;
         vec3 direction;
 
-        if (cannot_refract || reflectance(cos_theta, refraction_ratio) > random_double())
+        if (cannot_refract || reflectance(cos_theta, ir) > random_double())
             direction = reflect(unit_direction, rec.normal);
         else
             direction = refract(unit_direction, rec.normal, refraction_ratio);

--- a/src/TheNextWeek/material.h
+++ b/src/TheNextWeek/material.h
@@ -88,7 +88,7 @@ class dielectric : public material {
         bool cannot_refract = refraction_ratio * sin_theta > 1.0;
         vec3 direction;
 
-        if (cannot_refract || reflectance(cos_theta, refraction_ratio) > random_double())
+        if (cannot_refract || reflectance(cos_theta, ir) > random_double())
             direction = reflect(unit_direction, rec.normal);
         else
             direction = refract(unit_direction, rec.normal, refraction_ratio);

--- a/src/TheRestOfYourLife/material.h
+++ b/src/TheRestOfYourLife/material.h
@@ -108,7 +108,7 @@ class dielectric : public material {
         bool cannot_refract = refraction_ratio * sin_theta > 1.0;
         vec3 direction;
 
-        if (cannot_refract || reflectance(cos_theta, refraction_ratio) > random_double())
+        if (cannot_refract || reflectance(cos_theta, ir) > random_double())
             direction = reflect(unit_direction, rec.normal);
         else
             direction = refract(unit_direction, rec.normal, refraction_ratio);


### PR DESCRIPTION
reflectance() takes `double ref_idx` (which is `ir` in the outer scope), not `refraction_ratio`. Confirmed with the formula for Schlick's approximation (https://en.wikipedia.org/wiki/Schlick%27s_approximation) which uses two indexes of refraction, of which one is hard coded to `1` in the function here.

A future todo would be to keep track of the "ir of the current medium" in the ray and use that instead of a hard coded `1` in the reflectance formula.