### PR TITLE
Interval-based AABB update / Attempt #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Change Log -- Ray Tracing in One Weekend
 
 # v4.0.0-alpha.2 (In Progress)
 
-This will likely change to the official v4.0.0 release, but we _might_ put out another alpha before
+This will likely change to the official v4.0.0 release, but we might put out another alpha before
 then.
 
 ### Common
@@ -29,8 +29,11 @@ then.
   - Change - Reworked the AABB chapter (#1236)
   - New - add section on alternative 2D primitives such as triangle, ellipse and annulus (#1204,
           #1205)
-  - Change - changed bvh construction (removed const qualifer for objects vector) so sorting is done 
+  - Change - changed bvh construction (removed const qualifer for objects vector) so sorting is done
              in place and copying of vector is avoided, better bvh build performance (#1388, #1391)
+  - Change - AABB code now uses interval arithmetic for the `hit()` function. In my testing, this
+             yields about a 2% slowdown in debug builds, and a 9% speedup in release builds.
+             (#927, #1270)
 
 ### The Rest of Your Life
 

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -615,9 +615,9 @@ Now we have everything we need to implement the new AABB class.
             // Treat the two points a and b as extrema for the bounding box, so we don't require a
             // particular minimum/maximum coordinate order.
 
-            x = span(a[0],b[0]);
-            y = span(a[1],b[1]);
-            z = span(a[2],b[2]);
+            x = (a[0] <= b[0]) ? interval(a[0], b[0]) : interval(b[0], a[0]);
+            y = (a[1] <= b[1]) ? interval(a[1], b[1]) : interval(b[1], a[1]);
+            z = (a[2] <= b[2]) ? interval(a[2], b[2]) : interval(b[2], a[2]);
         }
 
         const interval& axis_interval(int n) const {
@@ -634,12 +634,18 @@ Now we have everything we need to implement the new AABB class.
                 const interval& ax = axis_interval(axis);
                 const double adinv = 1.0 / ray_dir[axis];
 
-                auto s = (ax.min - ray_orig[axis]) * adinv;
-                auto t = (ax.max - ray_orig[axis]) * adinv;
+                auto t0 = (ax.min - ray_orig[axis]) * adinv;
+                auto t1 = (ax.max - ray_orig[axis]) * adinv;
 
-                ray_t = ray_t.intersect(span(s,t));
+                if (t0 < t1) {
+                    if (t0 > ray_t.min) ray_t.min = t0;
+                    if (t1 < ray_t.max) ray_t.max = t1;
+                } else {
+                    if (t1 > ray_t.min) ray_t.min = t1;
+                    if (t0 < ray_t.max) ray_t.max = t0;
+                }
 
-                if (ray_t.is_empty())
+                if (ray_t.max <= ray_t.min)
                     return false;
             }
             return true;
@@ -652,67 +658,6 @@ Now we have everything we need to implement the new AABB class.
 
 </div>
 
-<div class='together'>
-The new code above relies on three new interval functions we need to write: `interval::is_empty()`,
-`interval::intersect()`, and `span()`.
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    class interval {
-      public:
-        double min, max;
-
-        interval() : min(+infinity), max(-infinity) {} // Default interval is empty
-
-        interval(double _min, double _max) : min(_min), max(_max) {}
-
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ Highlight
-        bool is_empty() const {
-            // Returns false if the interval is empty (inside out), or if either bound is a
-            // floating-point NaN (not a number).
-            return !(min <= max);
-        }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-
-        ...
-
-        interval expand(double delta) const {
-            auto padding = delta/2;
-            return interval(min - padding, max + padding);
-        }
-
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        interval intersect(const interval& other) const {
-            double a = min >= other.min ? min : other.min;
-            double b = max <= other.max ? max : other.max;
-            return interval(a,b);
-        }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-
-        static const interval empty, universe;
-    };
-
-    ...
-
-    interval operator+(double displacement, const interval& ival) {
-        return ival + displacement;
-    }
-
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ Highlight
-    inline interval span(double a, double b) {
-        // Return the non-empty interval between a and b, regardless of their order.
-        if (a > b)
-            return interval(b, a);
-        return interval(a, b);
-    }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [new-interval-funcs]: <kbd>[interval.h]</kbd>
-        New interval functions is_empty(), intersect() and span()
-    ]
-
-</div>
 
 
 Constructing Bounding Boxes for Hittables

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -572,8 +572,10 @@ given amount:
     class interval {
       public:
         ...
-        double size() const {
-            return max - min;
+        double clamp(double x) const {
+            if (x < min) return min;
+            if (x > max) return max;
+            return x;
         }
 
 
@@ -584,7 +586,7 @@ given amount:
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
-        ...
+        static const interval empty, universe;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [interval-expand]: <kbd>[interval.h]</kbd> interval::expand() method]
@@ -612,26 +614,32 @@ Now we have everything we need to implement the new AABB class.
         aabb(const point3& a, const point3& b) {
             // Treat the two points a and b as extrema for the bounding box, so we don't require a
             // particular minimum/maximum coordinate order.
-            x = interval(fmin(a[0],b[0]), fmax(a[0],b[0]));
-            y = interval(fmin(a[1],b[1]), fmax(a[1],b[1]));
-            z = interval(fmin(a[2],b[2]), fmax(a[2],b[2]));
+
+            x = span(a[0],b[0]);
+            y = span(a[1],b[1]);
+            z = span(a[2],b[2]);
         }
 
-        const interval& axis(int n) const {
+        const interval& axis_interval(int n) const {
             if (n == 1) return y;
             if (n == 2) return z;
             return x;
         }
 
         bool hit(const ray& r, interval ray_t) const {
-            for (int a = 0; a < 3; a++) {
-                auto t0 = fmin((axis(a).min - r.origin()[a]) / r.direction()[a],
-                               (axis(a).max - r.origin()[a]) / r.direction()[a]);
-                auto t1 = fmax((axis(a).min - r.origin()[a]) / r.direction()[a],
-                               (axis(a).max - r.origin()[a]) / r.direction()[a]);
-                ray_t.min = fmax(t0, ray_t.min);
-                ray_t.max = fmin(t1, ray_t.max);
-                if (ray_t.max <= ray_t.min)
+            const point3& ray_orig = r.origin();
+            const vec3&   ray_dir  = r.direction();
+
+            for (int axis = 0; axis < 3; axis++) {
+                const interval& ax = axis_interval(axis);
+                const double adinv = 1.0 / ray_dir[axis];
+
+                auto s = (ax.min - ray_orig[axis]) * adinv;
+                auto t = (ax.max - ray_orig[axis]) * adinv;
+
+                ray_t = ray_t.intersect(span(s,t));
+
+                if (ray_t.is_empty())
                     return false;
             }
             return true;
@@ -644,40 +652,67 @@ Now we have everything we need to implement the new AABB class.
 
 </div>
 
-
-An Optimized AABB Hit Method
------------------------------
-In reviewing this intersection method, Andrew Kensler at Pixar tried some experiments and proposed
-the following version of the code. It works extremely well on many compilers, and I have adopted it
-as my go-to method:
+<div class='together'>
+The new code above relies on three new interval functions we need to write: `interval::is_empty()`,
+`interval::intersect()`, and `span()`.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    class aabb {
+    class interval {
       public:
-        ...
-        bool hit(const ray& r, interval ray_t) const {
-            for (int a = 0; a < 3; a++) {
-                auto invD = 1 / r.direction()[a];
-                auto orig = r.origin()[a];
+        double min, max;
 
-                auto t0 = (axis(a).min - orig) * invD;
-                auto t1 = (axis(a).max - orig) * invD;
+        interval() : min(+infinity), max(-infinity) {} // Default interval is empty
 
-                if (invD < 0)
-                    std::swap(t0, t1);
+        interval(double _min, double _max) : min(_min), max(_max) {}
 
-                if (t0 > ray_t.min) ray_t.min = t0;
-                if (t1 < ray_t.max) ray_t.max = t1;
 
-                if (ray_t.max <= ray_t.min)
-                    return false;
-            }
-            return true;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ Highlight
+        bool is_empty() const {
+            // Returns false if the interval is empty (inside out), or if either bound is a
+            // floating-point NaN (not a number).
+            return !(min <= max);
         }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
         ...
+
+        interval expand(double delta) const {
+            auto padding = delta/2;
+            return interval(min - padding, max + padding);
+        }
+
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+        interval intersect(const interval& other) const {
+            double a = min >= other.min ? min : other.min;
+            double b = max <= other.max ? max : other.max;
+            return interval(a,b);
+        }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
+        static const interval empty, universe;
     };
+
+    ...
+
+    interval operator+(double displacement, const interval& ival) {
+        return ival + displacement;
+    }
+
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ Highlight
+    inline interval span(double a, double b) {
+        // Return the non-empty interval between a and b, regardless of their order.
+        if (a > b)
+            return interval(b, a);
+        return interval(a, b);
+    }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [aabb-hit]: <kbd>[aabb.h]</kbd> Optional optimized AABB hit function]
+    [Listing [new-interval-funcs]: <kbd>[interval.h]</kbd>
+        New interval functions is_empty(), intersect() and span()
+    ]
+
+</div>
 
 
 Constructing Bounding Boxes for Hittables
@@ -776,17 +811,24 @@ two boxes.
 
 <div class='together'>
 Now we need a new `aabb` constructor that takes two boxes as input. First, we'll add a new interval
-constructor that takes two intervals as input:
+constructor to do this:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class interval {
       public:
-        ...
+        double min, max;
+
+        interval() : min(+infinity), max(-infinity) {} // Default interval is empty
+
+        interval(double _min, double _max) : min(_min), max(_max) {}
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        interval(const interval& a, const interval& b)
-          : min(fmin(a.min, b.min)), max(fmax(a.max, b.max)) {}
+        interval(const interval& a, const interval& b) {
+            // Create the interval tightly enclosing the two input intervals.
+            min = a.min <= b.min ? a.min : b.min;
+            max = a.max >= b.max ? a.max : b.max;
+        }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         double size() const {
@@ -805,6 +847,12 @@ Now we can use this to construct an axis-aligned bounding box from two input box
     class aabb {
       public:
         ...
+
+        aabb(const point3& a, const point3& b) {
+            ...
+        }
+
+
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         aabb(const aabb& box0, const aabb& box1) {
             x = interval(box0.x, box1.x);
@@ -812,6 +860,7 @@ Now we can use this to construct an axis-aligned bounding box from two input box
             z = interval(box0.z, box1.z);
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
         ...
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1008,7 +1057,9 @@ function.
         static bool box_compare(
             const shared_ptr<hittable> a, const shared_ptr<hittable> b, int axis_index
         ) {
-            return a->bounding_box().axis(axis_index).min < b->bounding_box().axis(axis_index).min;
+            auto a_axis_interval = a->bounding_box().axis_interval(axis_index);
+            auto b_axis_interval = b->bounding_box().axis_interval(axis_index);
+            return a_axis_interval.min < b_axis_interval.min;
         }
 
         static bool box_x_compare (const shared_ptr<hittable> a, const shared_ptr<hittable> b) {
@@ -2495,6 +2546,7 @@ constructed AABBs always have a non-zero volume:
         aabb(const point3& a, const point3& b) {
             // Treat the two points a and b as extrema for the bounding box, so we don't require a
             // particular minimum/maximum coordinate order.
+
             x = interval(fmin(a[0],b[0]), fmax(a[0],b[0]));
             y = interval(fmin(a[1],b[1]), fmax(a[1],b[1]));
             z = interval(fmin(a[2],b[2]), fmax(a[2],b[2]));

--- a/src/TheNextWeek/aabb.h
+++ b/src/TheNextWeek/aabb.h
@@ -30,9 +30,9 @@ class aabb {
         // Treat the two points a and b as extrema for the bounding box, so we don't require a
         // particular minimum/maximum coordinate order.
 
-        x = span(a[0],b[0]);
-        y = span(a[1],b[1]);
-        z = span(a[2],b[2]);
+        x = (a[0] <= b[0]) ? interval(a[0], b[0]) : interval(b[0], a[0]);
+        y = (a[1] <= b[1]) ? interval(a[1], b[1]) : interval(b[1], a[1]);
+        z = (a[2] <= b[2]) ? interval(a[2], b[2]) : interval(b[2], a[2]);
 
         pad_to_minimums();
     }
@@ -57,12 +57,18 @@ class aabb {
             const interval& ax = axis_interval(axis);
             const double adinv = 1.0 / ray_dir[axis];
 
-            auto s = (ax.min - ray_orig[axis]) * adinv;
-            auto t = (ax.max - ray_orig[axis]) * adinv;
+            auto t0 = (ax.min - ray_orig[axis]) * adinv;
+            auto t1 = (ax.max - ray_orig[axis]) * adinv;
 
-            ray_t = ray_t.intersect(span(s,t));
+            if (t0 < t1) {
+                if (t0 > ray_t.min) ray_t.min = t0;
+                if (t1 < ray_t.max) ray_t.max = t1;
+            } else {
+                if (t1 > ray_t.min) ray_t.min = t1;
+                if (t0 < ray_t.max) ray_t.max = t0;
+            }
 
-            if (ray_t.is_empty())
+            if (ray_t.max <= ray_t.min)
                 return false;
         }
         return true;

--- a/src/TheNextWeek/bvh.h
+++ b/src/TheNextWeek/bvh.h
@@ -77,7 +77,9 @@ class bvh_node : public hittable {
     static bool box_compare(
         const shared_ptr<hittable> a, const shared_ptr<hittable> b, int axis_index
     ) {
-        return a->bounding_box().axis(axis_index).min < b->bounding_box().axis(axis_index).min;
+        auto a_axis_interval = a->bounding_box().axis_interval(axis_index);
+        auto b_axis_interval = b->bounding_box().axis_interval(axis_index);
+        return a_axis_interval.min < b_axis_interval.min;
     }
 
     static bool box_x_compare (const shared_ptr<hittable> a, const shared_ptr<hittable> b) {

--- a/src/TheNextWeek/interval.h
+++ b/src/TheNextWeek/interval.h
@@ -23,12 +23,6 @@ class interval {
         max = a.max >= b.max ? a.max : b.max;
     }
 
-    bool is_empty() const {
-        // Returns false if the interval is empty (inside out), or if either bound is a
-        // floating-point NaN (not a number).
-        return !(min <= max);
-    }
-
     double size() const {
         return max - min;
     }
@@ -52,12 +46,6 @@ class interval {
         return interval(min - padding, max + padding);
     }
 
-    interval intersect(const interval& other) const {
-        double a = min >= other.min ? min : other.min;
-        double b = max <= other.max ? max : other.max;
-        return interval(a,b);
-    }
-
     static const interval empty, universe;
 };
 
@@ -70,13 +58,6 @@ interval operator+(const interval& ival, double displacement) {
 
 interval operator+(double displacement, const interval& ival) {
     return ival + displacement;
-}
-
-inline interval span(double a, double b) {
-    // Return the non-empty interval between a and b, regardless of their order.
-    if (a > b)
-        return interval(b, a);
-    return interval(a, b);
 }
 
 

--- a/src/TheNextWeek/interval.h
+++ b/src/TheNextWeek/interval.h
@@ -17,16 +17,20 @@ class interval {
 
     interval(double _min, double _max) : min(_min), max(_max) {}
 
-    interval(const interval& a, const interval& b)
-      : min(fmin(a.min, b.min)), max(fmax(a.max, b.max)) {}
+    interval(const interval& a, const interval& b) {
+        // Create the interval tightly enclosing the two input intervals.
+        min = a.min <= b.min ? a.min : b.min;
+        max = a.max >= b.max ? a.max : b.max;
+    }
+
+    bool is_empty() const {
+        // Returns false if the interval is empty (inside out), or if either bound is a
+        // floating-point NaN (not a number).
+        return !(min <= max);
+    }
 
     double size() const {
         return max - min;
-    }
-
-    interval expand(double delta) const {
-        auto padding = delta/2;
-        return interval(min - padding, max + padding);
     }
 
     bool contains(double x) const {
@@ -43,6 +47,17 @@ class interval {
         return x;
     }
 
+    interval expand(double delta) const {
+        auto padding = delta/2;
+        return interval(min - padding, max + padding);
+    }
+
+    interval intersect(const interval& other) const {
+        double a = min >= other.min ? min : other.min;
+        double b = max <= other.max ? max : other.max;
+        return interval(a,b);
+    }
+
     static const interval empty, universe;
 };
 
@@ -56,6 +71,14 @@ interval operator+(const interval& ival, double displacement) {
 interval operator+(double displacement, const interval& ival) {
     return ival + displacement;
 }
+
+inline interval span(double a, double b) {
+    // Return the non-empty interval between a and b, regardless of their order.
+    if (a > b)
+        return interval(b, a);
+    return interval(a, b);
+}
+
 
 
 #endif

--- a/src/TheRestOfYourLife/aabb.h
+++ b/src/TheRestOfYourLife/aabb.h
@@ -30,9 +30,9 @@ class aabb {
         // Treat the two points a and b as extrema for the bounding box, so we don't require a
         // particular minimum/maximum coordinate order.
 
-        x = span(a[0],b[0]);
-        y = span(a[1],b[1]);
-        z = span(a[2],b[2]);
+        x = (a[0] <= b[0]) ? interval(a[0], b[0]) : interval(b[0], a[0]);
+        y = (a[1] <= b[1]) ? interval(a[1], b[1]) : interval(b[1], a[1]);
+        z = (a[2] <= b[2]) ? interval(a[2], b[2]) : interval(b[2], a[2]);
 
         pad_to_minimums();
     }
@@ -57,12 +57,18 @@ class aabb {
             const interval& ax = axis_interval(axis);
             const double adinv = 1.0 / ray_dir[axis];
 
-            auto s = (ax.min - ray_orig[axis]) * adinv;
-            auto t = (ax.max - ray_orig[axis]) * adinv;
+            auto t0 = (ax.min - ray_orig[axis]) * adinv;
+            auto t1 = (ax.max - ray_orig[axis]) * adinv;
 
-            ray_t = ray_t.intersect(span(s,t));
+            if (t0 < t1) {
+                if (t0 > ray_t.min) ray_t.min = t0;
+                if (t1 < ray_t.max) ray_t.max = t1;
+            } else {
+                if (t1 > ray_t.min) ray_t.min = t1;
+                if (t0 < ray_t.max) ray_t.max = t0;
+            }
 
-            if (ray_t.is_empty())
+            if (ray_t.max <= ray_t.min)
                 return false;
         }
         return true;

--- a/src/TheRestOfYourLife/bvh.h
+++ b/src/TheRestOfYourLife/bvh.h
@@ -77,7 +77,9 @@ class bvh_node : public hittable {
     static bool box_compare(
         const shared_ptr<hittable> a, const shared_ptr<hittable> b, int axis_index
     ) {
-        return a->bounding_box().axis(axis_index).min < b->bounding_box().axis(axis_index).min;
+        auto a_axis_interval = a->bounding_box().axis_interval(axis_index);
+        auto b_axis_interval = b->bounding_box().axis_interval(axis_index);
+        return a_axis_interval.min < b_axis_interval.min;
     }
 
     static bool box_x_compare (const shared_ptr<hittable> a, const shared_ptr<hittable> b) {

--- a/src/TheRestOfYourLife/interval.h
+++ b/src/TheRestOfYourLife/interval.h
@@ -23,12 +23,6 @@ class interval {
         max = a.max >= b.max ? a.max : b.max;
     }
 
-    bool is_empty() const {
-        // Returns false if the interval is empty (inside out), or if either bound is a
-        // floating-point NaN (not a number).
-        return !(min <= max);
-    }
-
     double size() const {
         return max - min;
     }
@@ -52,12 +46,6 @@ class interval {
         return interval(min - padding, max + padding);
     }
 
-    interval intersect(const interval& other) const {
-        double a = min >= other.min ? min : other.min;
-        double b = max <= other.max ? max : other.max;
-        return interval(a,b);
-    }
-
     static const interval empty, universe;
 };
 
@@ -70,13 +58,6 @@ interval operator+(const interval& ival, double displacement) {
 
 interval operator+(double displacement, const interval& ival) {
     return ival + displacement;
-}
-
-inline interval span(double a, double b) {
-    // Return the non-empty interval between a and b, regardless of their order.
-    if (a > b)
-        return interval(b, a);
-    return interval(a, b);
 }
 
 

--- a/src/TheRestOfYourLife/interval.h
+++ b/src/TheRestOfYourLife/interval.h
@@ -17,16 +17,20 @@ class interval {
 
     interval(double _min, double _max) : min(_min), max(_max) {}
 
-    interval(const interval& a, const interval& b)
-      : min(fmin(a.min, b.min)), max(fmax(a.max, b.max)) {}
+    interval(const interval& a, const interval& b) {
+        // Create the interval tightly enclosing the two input intervals.
+        min = a.min <= b.min ? a.min : b.min;
+        max = a.max >= b.max ? a.max : b.max;
+    }
+
+    bool is_empty() const {
+        // Returns false if the interval is empty (inside out), or if either bound is a
+        // floating-point NaN (not a number).
+        return !(min <= max);
+    }
 
     double size() const {
         return max - min;
-    }
-
-    interval expand(double delta) const {
-        auto padding = delta/2;
-        return interval(min - padding, max + padding);
     }
 
     bool contains(double x) const {
@@ -43,6 +47,17 @@ class interval {
         return x;
     }
 
+    interval expand(double delta) const {
+        auto padding = delta/2;
+        return interval(min - padding, max + padding);
+    }
+
+    interval intersect(const interval& other) const {
+        double a = min >= other.min ? min : other.min;
+        double b = max <= other.max ? max : other.max;
+        return interval(a,b);
+    }
+
     static const interval empty, universe;
 };
 
@@ -56,6 +71,14 @@ interval operator+(const interval& ival, double displacement) {
 interval operator+(double displacement, const interval& ival) {
     return ival + displacement;
 }
+
+inline interval span(double a, double b) {
+    // Return the non-empty interval between a and b, regardless of their order.
+    if (a > b)
+        return interval(b, a);
+    return interval(a, b);
+}
+
 
 
 #endif


### PR DESCRIPTION
In my environment, this slows down debug builds about 2%, and speeds up
release builds about 9%. More importantly, I believe the code is easier
to understand using interval arithmetic.

In addition, I discovered that in many cases using `fmin()` and `fmax()`
are performance bombs. Likely this is because these functions have
special handling for NaNs. Instead, I switched to using ternary
expressions like `a < b ? a : b`, which had a large performance impact.
For the `aabb::hit()` function, this improved performance of the new
interval code from 100% worse to about 10% better.

Added a new `span()` function that returns an interval of two doubles,
regardless of their order.

Added new `interval::is_empty()` function that also returns true when
either of the bounds is a NaN.

Added new `interval::intersect()` function.

This should resolve #927