### PR TITLE
Delete reflection vector normalization call

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -2928,12 +2928,14 @@ reflected from a metal mirror? Vector math is our friend here:
   ![Figure [reflection]: Ray reflection](../images/fig-1.15-reflection.jpg)
 
 The reflected ray direction in red is just $\mathbf{v} + 2\mathbf{b}$. In our design, $\mathbf{n}$
-is a unit vector, but $\mathbf{v}$ may not be. To get the vector $\mathbf{b}$, we scale the
-unit-length normal vector by the length of the projection of $\mathbf{v}$ onto $\mathbf{n}$, which
-is given by the dot project $\mathbf{v} \cdot \mathbf{n}$. (If $\mathbf{n}$ were not of unit length,
-we'd need to divide the dot project the length of $\mathbf{n}$.)
+is a unit vector (length one), but $\mathbf{v}$ may not be. To get the vector $\mathbf{b}$, we scale
+the normal vector by the length of the projection of $\mathbf{v}$ onto $\mathbf{n}$, which is given
+by the dot project $\mathbf{v} \cdot \mathbf{n}$. (If $\mathbf{n}$ were not a unit vector, we would
+also need to divide this dot project by the length of $\mathbf{n}$.) Finally, because $\mathbf{v}$
+points _into_ the surface, and we want $\mathbf{b}$ to point _out_ of the surface, we need to negate
+this projection length.
 
-Because $\mathbf{v}$ points in, we will need a minus sign, yielding:
+Putting everything together, we get the following computation of the reflected vector:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     ...

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -2928,8 +2928,12 @@ reflected from a metal mirror? Vector math is our friend here:
   ![Figure [reflection]: Ray reflection](../images/fig-1.15-reflection.jpg)
 
 The reflected ray direction in red is just $\mathbf{v} + 2\mathbf{b}$. In our design, $\mathbf{n}$
-is a unit vector, but $\mathbf{v}$ may not be. The length of $\mathbf{b}$ should be $\mathbf{v}
-\cdot \mathbf{n}$. Because $\mathbf{v}$ points in, we will need a minus sign, yielding:
+is a unit vector, but $\mathbf{v}$ may not be. To get the vector $\mathbf{b}$, we scale the
+unit-length normal vector by the length of the projection of $\mathbf{v}$ onto $\mathbf{n}$, which
+is given by the dot project $\mathbf{v} \cdot \mathbf{n}$. (If $\mathbf{n}$ were not of unit length,
+we'd need to divide the dot project the length of $\mathbf{n}$.)
+
+Because $\mathbf{v}$ points in, we will need a minus sign, yielding:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     ...
@@ -2967,7 +2971,7 @@ The metal material just reflects rays using that formula:
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
         const override {
-            vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
+            vec3 reflected = reflect(r_in.direction(), rec.normal);
             scattered = ray(rec.p, reflected);
             attenuation = albedo;
             return true;
@@ -3103,7 +3107,7 @@ those.
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
         const override {
-            vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
+            vec3 reflected = reflect(r_in.direction(), rec.normal);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             scattered = ray(rec.p, reflected + fuzz*random_unit_vector());
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -274,7 +274,7 @@ for the time of intersection:
         ...
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
         const override {
-            vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
+            vec3 reflected = reflect(r_in.direction(), rec.normal);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             scattered = ray(rec.p, reflected + fuzz*random_in_unit_sphere(), r_in.time());
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -3296,7 +3296,7 @@ and dielectric materials are easy to fix.
             srec.pdf_ptr = nullptr;
             srec.skip_pdf = true;
 
-            vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
+            vec3 reflected = reflect(r_in.direction(), rec.normal);
             srec.skip_pdf_ray = ray(rec.p, reflected + fuzz*random_in_unit_sphere(), r_in.time());
 
             return true;

--- a/src/InOneWeekend/material.h
+++ b/src/InOneWeekend/material.h
@@ -54,7 +54,7 @@ class metal : public material {
 
     bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
     const override {
-        vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
+        vec3 reflected = reflect(r_in.direction(), rec.normal);
         scattered = ray(rec.p, reflected + fuzz*random_in_unit_sphere());
         attenuation = albedo;
         return (dot(scattered.direction(), rec.normal) > 0);

--- a/src/TheNextWeek/material.h
+++ b/src/TheNextWeek/material.h
@@ -60,7 +60,7 @@ class metal : public material {
 
     bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
     const override {
-        vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
+        vec3 reflected = reflect(r_in.direction(), rec.normal);
         scattered = ray(rec.p, reflected + fuzz*random_in_unit_sphere(), r_in.time());
         attenuation = albedo;
         return (dot(scattered.direction(), rec.normal) > 0);

--- a/src/TheRestOfYourLife/material.h
+++ b/src/TheRestOfYourLife/material.h
@@ -79,7 +79,7 @@ class metal : public material {
         srec.pdf_ptr = nullptr;
         srec.skip_pdf = true;
 
-        vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
+        vec3 reflected = reflect(r_in.direction(), rec.normal);
         srec.skip_pdf_ray = ray(rec.p, reflected + fuzz*random_in_unit_sphere(), r_in.time());
 
         return true;


### PR DESCRIPTION
When computing the reflected ray, we had code to normalize the result. This is unnecessary, as the reflected ray result will have the same length as the incoming ray, which should be fine.

In addition, I've added some clarification around the computation of the magnitude of the vector b used in the reflection computation.

Resolves #1340