### PR TITLE
Camera default lookfrom/lookat to match prior

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -3690,8 +3690,8 @@ angles.
 
         double vfov     = 90;              // Vertical view angle (field of view)
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        point3 lookfrom = point3(0,0,-1);  // Point camera is looking from
-        point3 lookat   = point3(0,0,0);   // Point camera is looking at
+        point3 lookfrom = point3(0,0,0);   // Point camera is looking from
+        point3 lookat   = point3(0,0,-1);  // Point camera is looking at
         vec3   vup      = vec3(0,1,0);     // Camera-relative "up" direction
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
@@ -3931,8 +3931,8 @@ Now let's update the camera to originate rays from the defocus disk:
         int    max_depth         = 10;   // Maximum number of ray bounces into scene
 
         double vfov     = 90;              // Vertical view angle (field of view)
-        point3 lookfrom = point3(0,0,-1);  // Point camera is looking from
-        point3 lookat   = point3(0,0,0);   // Point camera is looking at
+        point3 lookfrom = point3(0,0,0);   // Point camera is looking from
+        point3 lookat   = point3(0,0,-1);  // Point camera is looking at
         vec3   vup      = vec3(0,1,0);     // Camera-relative "up" direction
 
 

--- a/src/InOneWeekend/camera.h
+++ b/src/InOneWeekend/camera.h
@@ -28,8 +28,8 @@ class camera {
     int    max_depth         = 10;   // Maximum number of ray bounces into scene
 
     double vfov     = 90;              // Vertical view angle (field of view)
-    point3 lookfrom = point3(0,0,-1);  // Point camera is looking from
-    point3 lookat   = point3(0,0,0);   // Point camera is looking at
+    point3 lookfrom = point3(0,0,0);   // Point camera is looking from
+    point3 lookat   = point3(0,0,-1);  // Point camera is looking at
     vec3   vup      = vec3(0,1,0);     // Camera-relative "up" direction
 
     double defocus_angle = 0;  // Variation angle of rays through each pixel

--- a/src/TheNextWeek/camera.h
+++ b/src/TheNextWeek/camera.h
@@ -29,8 +29,8 @@ class camera {
     color  background;               // Scene background color
 
     double vfov     = 90;              // Vertical view angle (field of view)
-    point3 lookfrom = point3(0,0,-1);  // Point camera is looking from
-    point3 lookat   = point3(0,0,0);   // Point camera is looking at
+    point3 lookfrom = point3(0,0,0);   // Point camera is looking from
+    point3 lookat   = point3(0,0,-1);  // Point camera is looking at
     vec3   vup      = vec3(0,1,0);     // Camera-relative "up" direction
 
     double defocus_angle = 0;  // Variation angle of rays through each pixel

--- a/src/TheRestOfYourLife/camera.h
+++ b/src/TheRestOfYourLife/camera.h
@@ -29,8 +29,8 @@ class camera {
     color  background;               // Scene background color
 
     double vfov     = 90;              // Vertical view angle (field of view)
-    point3 lookfrom = point3(0,0,-1);  // Point camera is looking from
-    point3 lookat   = point3(0,0,0);   // Point camera is looking at
+    point3 lookfrom = point3(0,0,0);   // Point camera is looking from
+    point3 lookat   = point3(0,0,-1);  // Point camera is looking at
     vec3   vup      = vec3(0,1,0);     // Camera-relative "up" direction
 
     double defocus_angle = 0;  // Variation angle of rays through each pixel


### PR DESCRIPTION
When providing default values for the camera lookfrom/lookat points, we mixed up the two from the earlier coded values. In any event, we always explicitly set camera pose for each scene, so this didn't affect any rendered image.

Resolves #1341