### PR TITLE
Correct call to reflectance()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ then.
   - Change - Increase compile warning levels for MSVC.
   - Change - For clarity across audiences with broad programming backgrounds, we now use `double(x)`
              instead of `static_cast<double>(x)`, and similarly for other types.
+  - Fix - Fix calls to `reflectance()` in `dielectric::scatter()` with index of refraction.
 
 ### In One Weekend
   - Change - Update reference to "Fundamentals of Interactive Computer Graphics" to "Computer
@@ -29,7 +30,7 @@ then.
   - Change - Reworked the AABB chapter (#1236)
   - New - add section on alternative 2D primitives such as triangle, ellipse and annulus (#1204,
           #1205)
-  - Change - changed bvh construction (removed const qualifer for objects vector) so sorting is done 
+  - Change - changed bvh construction (removed const qualifer for objects vector) so sorting is done
              in place and copying of vector is avoided, better bvh build performance (#1388, #1391)
 
 ### The Rest of Your Life

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -3448,7 +3448,7 @@ material:
             vec3 direction;
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-            if (cannot_refract || reflectance(cos_theta, refraction_ratio) > random_double())
+            if (cannot_refract || reflectance(cos_theta, ir) > random_double())
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
                 direction = reflect(unit_direction, rec.normal);
             else

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -3337,7 +3337,7 @@ and dielectric materials are easy to fix.
             bool cannot_refract = refraction_ratio * sin_theta > 1.0;
             vec3 direction;
 
-            if (cannot_refract || reflectance(cos_theta, refraction_ratio) > random_double())
+            if (cannot_refract || reflectance(cos_theta, ir) > random_double())
                 direction = reflect(unit_direction, rec.normal);
             else
                 direction = refract(unit_direction, rec.normal, refraction_ratio);

--- a/books/acknowledgments.md.html
+++ b/books/acknowledgments.md.html
@@ -39,6 +39,7 @@ Acknowledgments
   - Fabio Sancinetti
   - Filipe Scur
   - Frank He
+  - [Gareth Martin](https://github.com/TheThief)
   - [Gerrit Wessendorf](https://github.com/celeph)
   - Grue Debry
   - [Gustaf Waldemarson](https://github.com/xaldew)

--- a/src/InOneWeekend/material.h
+++ b/src/InOneWeekend/material.h
@@ -82,7 +82,7 @@ class dielectric : public material {
         bool cannot_refract = refraction_ratio * sin_theta > 1.0;
         vec3 direction;
 
-        if (cannot_refract || reflectance(cos_theta, refraction_ratio) > random_double())
+        if (cannot_refract || reflectance(cos_theta, ir) > random_double())
             direction = reflect(unit_direction, rec.normal);
         else
             direction = refract(unit_direction, rec.normal, refraction_ratio);

--- a/src/TheNextWeek/material.h
+++ b/src/TheNextWeek/material.h
@@ -88,7 +88,7 @@ class dielectric : public material {
         bool cannot_refract = refraction_ratio * sin_theta > 1.0;
         vec3 direction;
 
-        if (cannot_refract || reflectance(cos_theta, refraction_ratio) > random_double())
+        if (cannot_refract || reflectance(cos_theta, ir) > random_double())
             direction = reflect(unit_direction, rec.normal);
         else
             direction = refract(unit_direction, rec.normal, refraction_ratio);

--- a/src/TheRestOfYourLife/material.h
+++ b/src/TheRestOfYourLife/material.h
@@ -108,7 +108,7 @@ class dielectric : public material {
         bool cannot_refract = refraction_ratio * sin_theta > 1.0;
         vec3 direction;
 
-        if (cannot_refract || reflectance(cos_theta, refraction_ratio) > random_double())
+        if (cannot_refract || reflectance(cos_theta, ir) > random_double())
             direction = reflect(unit_direction, rec.normal);
         else
             direction = refract(unit_direction, rec.normal, refraction_ratio);


### PR DESCRIPTION
The function `reflectance()` takes `double ref_idx` (which is `ir` in the outer scope), not `refraction_ratio`.

Confirmed with the formula for Schlick's approximation (https://en.wikipedia.org/wiki/Schlick%27s_approximation) which uses two indexes of refraction, of which one is hard coded to `1` in the function here.

A future todo would be to keep track of the "ir of the current medium" in the ray and use that instead of a hard coded `1` in the reflectance formula.

Originally due to https://github.com/TheThief.