### PR TITLE
No negative radius spheres

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -3503,14 +3503,16 @@ through the air inside. Then it will continue on, hit the inside surface of the 
 refract back, then hit the inside surface of the outer sphere, and finally refract and exit back
 into the scene atmosphere.
 
-The outer sphere is just modeled with a standard glass sphere, with an index of refraction of around
-1.50. The inner sphere is a bit different, because _its_ index of refraction should be relative to
-the "glass atmosphere" of the surrounding outer sphere. This is actually simple to specify, as our
-index-of-refraction parameter to the dielectric material can be interpreted as the ratio of the
-index of refraction of the object over the index of refraction of the enclosing medium.
+The outer sphere is just modeled with a standard glass sphere, with a refractive index of around
+1.50 (modeling a refraction from the outside air into glass). The inner sphere is a bit different
+because _its_ refractive index should be relative to the "glass atmosphere" of the surrounding outer
+sphere, thus modeling a transition from glass into the inner air.
 
-In this case, the inner sphere would have an index of refraction of air (the inner sphere material)
-over the index of refraction of glass (the enclosing medium), or $1.00/1.50 = 0.67$.
+This is actually simple to specify, as the `ref_index` parameter to the dielectric material can be
+interpreted as the _ratio_ of the refractive index of the object divided by the refractive index of
+the enclosing medium. In this case, the inner sphere would have an refractive index of air (the
+inner sphere material) over the index of refraction of glass (the enclosing medium), or $1.00/1.50 =
+0.67$.
 
 Here's the code:
 

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1114,7 +1114,7 @@ And here’s the sphere:
 
     class sphere : public hittable {
       public:
-        sphere(const point3& center, double radius) : center(center), radius(radius) {}
+        sphere(const point3& center, double radius) : center(center), radius(fmax(0,radius)) {}
 
         bool hit(const ray& r, double ray_tmin, double ray_tmax, hit_record& rec) const override {
             vec3 oc = center - r.origin();
@@ -2795,7 +2795,7 @@ To achieve this, `hit_record` needs to be told the material that is assigned to 
       public:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         sphere(const point3& center, double radius, shared_ptr<material> mat)
-          : center(center), radius(radius), mat(mat) {}
+          : center(center), radius(fmax(0,radius)), mat(mat) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
@@ -3477,42 +3477,39 @@ material:
 
 Modeling a Hollow Glass Sphere
 -------------------------------
-An interesting and easy trick with dielectric spheres is to note that if you use a negative radius,
-the geometry is unaffected, but the surface normal points inward.
+Let's model a hollow glass sphere. This is a sphere of some thickness with another sphere of air
+inside it. If you think about the path of a ray going through such an object, it will hit the outer
+sphere, refract, hit the inner sphere (assuming we do hit it), refract a second time, and travel
+through the air inside. Then it will continue on, hit the inside surface of the inner sphere,
+refract back, then hit the inside surface of the outer sphere, and finally refract and exit back
+into the scene atmosphere.
 
-However, properly handling negative radii can be tricky. Recall the line from `sphere::hit()` in
-listing [sphere-material] that calculates the outward normal:
+The outer sphere is just modeled with a standard glass sphere, with an index of refraction of around
+1.50. The inner sphere is a bit different, because _its_ index of refraction will now be relative to
+the "glass atmosphere" of the outer sphere. This is actually simple to specify, as our
+index-of-refraction parameter to the dielectric material can be interpreted as the ratio of the
+index of refraction of the object over the index of refraction of the enclosing medium.
 
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    vec3 outward_normal = (rec.p - center) / radius;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [proper-invert-sphere-normal]: Proper normal handling for spheres with negative radii]
+In this case, the inner sphere would have an index of refraction of air (the inner sphere material)
+over the index of refraction of glass (the enclosing medium), or $1.00/1.50 = 0.67$.
 
-In your own implementation, you might have been tempted to instead do something like this:
-
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    vec3 outward_normal = (rec.p - center).unit_vector();
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [improper-invert-sphere-normal]:
-        Problematic normal calculation for spheres with negative radii
-    ]
-
-If you do that, spheres with negative radii won't work properly. Since a sphere with a negative
-radius is a _bubble_, its interior is the infinite space outside the sphere. Its exterior is the
-finite bubble inside the sphere, so the outward normal needs to point toward the sphere center.
-Dividing by the (negative) radius flips the normal as we want. If you implmented your code like the
-second example above, you'll want to fix that now.
-
-Let's use this hollow sphere hack to model the interior of a sphere with a given thickness. To do
-this, add a second _inverted_ glass sphere inside the original glass sphere:
+Here's the code:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     ...
+    auto material_ground = make_shared<lambertian>(color(0.8, 0.8, 0.0));
+    auto material_center = make_shared<lambertian>(color(0.1, 0.2, 0.5));
+    auto material_left   = make_shared<dielectric>(1.50);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
+    auto material_bubble = make_shared<dielectric>(0.67);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    auto material_right  = make_shared<metal>(color(0.8, 0.6, 0.2), 0.0);
+
     world.add(make_shared<sphere>(point3( 0.0, -100.5, -1.0), 100.0, material_ground));
     world.add(make_shared<sphere>(point3( 0.0,    0.0, -1.0),   0.5, material_center));
     world.add(make_shared<sphere>(point3(-1.0,    0.0, -1.0),   0.5, material_left));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-    world.add(make_shared<sphere>(point3(-1.0,    0.0, -1.0),  -0.4, material_left));
+    world.add(make_shared<sphere>(point3(-1.0,    0.0, -1.0),   0.4, material_bubble));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     world.add(make_shared<sphere>(point3( 1.0,    0.0, -1.0),   0.5, material_right));
     ...
@@ -3520,7 +3517,7 @@ this, add a second _inverted_ glass sphere inside the original glass sphere:
     [Listing [scene-hollow-glass]: <kbd>[main.cc]</kbd> Scene with hollow glass sphere]
 
 <div class='together'>
-This gives:
+And here's the result:
 
   ![<span class='num'>Image 18:</span> A hollow glass sphere
   ](../images/img-1.18-glass-hollow.png class='pixel')
@@ -3772,13 +3769,14 @@ We'll change back to the prior scene, and use the new viewpoint:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         auto material_ground = make_shared<lambertian>(color(0.8, 0.8, 0.0));
         auto material_center = make_shared<lambertian>(color(0.1, 0.2, 0.5));
-        auto material_left   = make_shared<dielectric>(1.5);
+        auto material_left   = make_shared<dielectric>(1.50);
+        auto material_bubble = make_shared<dielectric>(0.67);
         auto material_right  = make_shared<metal>(color(0.8, 0.6, 0.2), 0.0);
 
         world.add(make_shared<sphere>(point3( 0.0, -100.5, -1.0), 100.0, material_ground));
         world.add(make_shared<sphere>(point3( 0.0,    0.0, -1.0),   0.5, material_center));
         world.add(make_shared<sphere>(point3(-1.0,    0.0, -1.0),   0.5, material_left));
-        world.add(make_shared<sphere>(point3(-1.0,    0.0, -1.0),  -0.4, material_left));
+        world.add(make_shared<sphere>(point3(-1.0,    0.0, -1.0),   0.4, material_bubble));
         world.add(make_shared<sphere>(point3( 1.0,    0.0, -1.0),   0.5, material_right));
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1114,7 +1114,7 @@ And here’s the sphere:
 
     class sphere : public hittable {
       public:
-        sphere(const point3& _center, double _radius) : center(_center), radius(_radius) {}
+        sphere(const point3& center, double radius) : center(center), radius(radius) {}
 
         bool hit(const ray& r, double ray_tmin, double ray_tmax, hit_record& rec) const override {
             vec3 oc = center - r.origin();
@@ -1551,7 +1551,7 @@ and a maximum. We'll end up using this class quite often as we proceed.
 
         interval() : min(+infinity), max(-infinity) {} // Default interval is empty
 
-        interval(double _min, double _max) : min(_min), max(_max) {}
+        interval(double min, double max) : min(min), max(max) {}
 
         double size() const {
             return max - min;
@@ -2794,8 +2794,8 @@ To achieve this, `hit_record` needs to be told the material that is assigned to 
     class sphere : public hittable {
       public:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        sphere(const point3& _center, double _radius, shared_ptr<material> _material)
-          : center(_center), radius(_radius), mat(_material) {}
+        sphere(const point3& center, double radius, shared_ptr<material> mat)
+          : center(center), radius(radius), mat(mat) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
@@ -2844,18 +2844,18 @@ class:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ Highlight
     class lambertian : public material {
       public:
-        lambertian(const color& a) : albedo(a) {}
+        lambertian(const color& c) : c(c) {}
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
         const override {
             auto scatter_direction = rec.normal + random_unit_vector();
             scattered = ray(rec.p, scatter_direction);
-            attenuation = albedo;
+            attenuation = c;
             return true;
         }
 
       private:
-        color albedo;
+        color c;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [lambertian-initial]: <kbd>[material.h]</kbd> The new lambertian material class]
@@ -2896,7 +2896,7 @@ the vector is very close to zero in all dimensions.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class lambertian : public material {
       public:
-        lambertian(const color& a) : albedo(a) {}
+        lambertian(const color& c) : c(c) {}
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
         const override {
@@ -2910,12 +2910,12 @@ the vector is very close to zero in all dimensions.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
             scattered = ray(rec.p, scatter_direction);
-            attenuation = albedo;
+            attenuation = c;
             return true;
         }
 
       private:
-        color albedo;
+        color c;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [lambertian-catch-zero]: <kbd>[material.h]</kbd> Lambertian scatter, bullet-proof]
@@ -2964,18 +2964,18 @@ The metal material just reflects rays using that formula:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ Highlight
     class metal : public material {
       public:
-        metal(const color& a) : albedo(a) {}
+        metal(const color& c) : c(c) {}
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
         const override {
             vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
             scattered = ray(rec.p, reflected);
-            attenuation = albedo;
+            attenuation = c;
             return true;
         }
 
       private:
-        color albedo;
+        color c;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [metal-material]: <kbd>[material.h]</kbd> Metal material with reflectance function]
@@ -3099,7 +3099,7 @@ those.
     class metal : public material {
       public:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        metal(const color& a, double f) : albedo(a), fuzz(f < 1 ? f : 1) {}
+        metal(const color& c, double fuzz) : c(c), fuzz(fuzz < 1 ? fuzz : 1) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
@@ -3108,14 +3108,14 @@ those.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             scattered = ray(rec.p, reflected + fuzz*random_unit_vector());
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-            attenuation = albedo;
+            attenuation = c;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             return (dot(scattered.direction(), rec.normal) > 0);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
         }
 
       private:
-        color albedo;
+        color c;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         double fuzz;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -3252,12 +3252,12 @@ And the dielectric material that always refracts is:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ Highlight
     class dielectric : public material {
       public:
-        dielectric(double index_of_refraction) : ir(index_of_refraction) {}
+        dielectric(double ior) : ior(ior) {}
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
         const override {
             attenuation = color(1.0, 1.0, 1.0);
-            double refraction_ratio = rec.front_face ? (1.0/ir) : ir;
+            double refraction_ratio = rec.front_face ? (1.0/ior) : ior;
 
             vec3 unit_direction = unit_vector(r_in.direction());
             vec3 refracted = refract(unit_direction, rec.normal, refraction_ratio);
@@ -3267,7 +3267,7 @@ And the dielectric material that always refracts is:
         }
 
       private:
-        double ir; // Index of Refraction
+        double ior; // Index of Refraction
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [dielectric-always-refract]: <kbd>[material.h]</kbd>
@@ -3365,12 +3365,12 @@ And the dielectric material that always refracts (when possible) is:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class dielectric : public material {
       public:
-        dielectric(double index_of_refraction) : ir(index_of_refraction) {}
+        dielectric(double ior) : ior(ior) {}
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
         const override {
             attenuation = color(1.0, 1.0, 1.0);
-            double refraction_ratio = rec.front_face ? (1.0/ir) : ir;
+            double refraction_ratio = rec.front_face ? (1.0/ior) : ior;
 
             vec3 unit_direction = unit_vector(r_in.direction());
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -3391,7 +3391,7 @@ And the dielectric material that always refracts (when possible) is:
         }
 
       private:
-        double ir; // Index of Refraction
+        double ior; // Index of Refraction
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [dielectric-with-refraction]: <kbd>[material.h]</kbd>
@@ -3433,12 +3433,12 @@ material:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class dielectric : public material {
       public:
-        dielectric(double index_of_refraction) : ir(index_of_refraction) {}
+        dielectric(double ior) : ior(ior) {}
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
         const override {
             attenuation = color(1.0, 1.0, 1.0);
-            double refraction_ratio = rec.front_face ? (1.0/ir) : ir;
+            double refraction_ratio = rec.front_face ? (1.0/ior) : ior;
 
             vec3 unit_direction = unit_vector(r_in.direction());
             double cos_theta = fmin(dot(-unit_direction, rec.normal), 1.0);
@@ -3459,7 +3459,7 @@ material:
         }
 
       private:
-        double ir; // Index of Refraction
+        double ior; // Index of Refraction
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -3152,6 +3152,25 @@ Clear materials such as water, glass, and diamond are dielectrics. When a light 
 splits into a reflected ray and a refracted (transmitted) ray. We’ll handle that by randomly
 choosing between reflection and refraction, only generating one scattered ray per interaction.
 
+As a quick review of terms, a _reflected_ ray hits a surface and then "bounces" off in a new
+direction.
+
+A _refracted_ ray bends as it transitions from a material's surroundings into the material itself
+(as with glass or water). This is why a pencil looks bent when partially inserted in water.
+
+The amount that a refracted ray bends is determined by the material's _refractive index_. Generally,
+this is a single value that describes how much light bends when entering a material from a vacuum.
+Glass has a refractive index of something like 1.5&ndash;1.7, and air has a small refractive index
+of 1.000293.
+
+When a transparent material is embedded in a different transparent material, you can describe the
+refraction with a relative refraction index: the refractive index of the object's material divided
+by the refractive index of the surrounding material. For example, if you want to render a glass ball
+under water, then the glass ball would have an effective refractive index of 1.125. This is given by
+the refractive index of glass (1.5) divided by the refractive index of water (1.333).
+
+You can find the refractive index of most common materials with a quick internet search.
+
 
 Refraction
 -----------
@@ -3485,8 +3504,8 @@ refract back, then hit the inside surface of the outer sphere, and finally refra
 into the scene atmosphere.
 
 The outer sphere is just modeled with a standard glass sphere, with an index of refraction of around
-1.50. The inner sphere is a bit different, because _its_ index of refraction will now be relative to
-the "glass atmosphere" of the outer sphere. This is actually simple to specify, as our
+1.50. The inner sphere is a bit different, because _its_ index of refraction should be relative to
+the "glass atmosphere" of the surrounding outer sphere. This is actually simple to specify, as our
 index-of-refraction parameter to the dielectric material can be interpreted as the ratio of the
 index of refraction of the object over the index of refraction of the enclosing medium.
 

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -179,12 +179,12 @@ interval, so it really can be sampled at any time.)
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         // Stationary Sphere
         sphere(const point3& center, double radius, shared_ptr<material> mat)
-          : center1(center), radius(radius), mat(mat), is_moving(false) {}
+          : center1(center), radius(fmax(0,radius)), mat(mat), is_moving(false) {}
 
         // Moving Sphere
         sphere(const point3& center1, const point3& center2, double radius,
                shared_ptr<material> mat)
-          : center1(center1), radius(radius), mat(mat), is_moving(true)
+          : center1(center1), radius(fmax(0,radius)), mat(mat), is_moving(true)
         {
             center_vec = center2 - center1;
         }
@@ -724,7 +724,7 @@ For a stationary sphere, the `bounding_box` function is easy:
         // Stationary Sphere
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         sphere(const point3& center, double radius, shared_ptr<material> mat)
-          : center1(center), radius(radius), mat(mat), is_moving(false)
+          : center1(center), radius(fmax(0,radius)), mat(mat), is_moving(false)
         {
             auto rvec = vec3(radius, radius, radius);
             bbox = aabb(center1 - rvec, center1 + rvec);
@@ -760,7 +760,7 @@ two boxes.
         // Moving Sphere
         sphere(const point3& center1, const point3& center2, double radius,
                shared_ptr<material> mat)
-          : center1(center1), radius(radius), mat(mat), is_moving(true)
+          : center1(center1), radius(fmax(0,radius)), mat(mat), is_moving(true)
         {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             auto rvec = vec3(radius, radius, radius);

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -178,15 +178,15 @@ interval, so it really can be sampled at any time.)
       public:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         // Stationary Sphere
-        sphere(const point3& _center, double _radius, shared_ptr<material> _material)
-          : center1(_center), radius(_radius), mat(_material), is_moving(false) {}
+        sphere(const point3& center, double radius, shared_ptr<material> mat)
+          : center1(center), radius(radius), mat(mat), is_moving(false) {}
 
         // Moving Sphere
-        sphere(const point3& _center1, const point3& _center2, double _radius,
-               shared_ptr<material> _material)
-          : center1(_center1), radius(_radius), mat(_material), is_moving(true)
+        sphere(const point3& center1, const point3& center2, double radius,
+               shared_ptr<material> mat)
+          : center1(center1), radius(radius), mat(mat), is_moving(true)
         {
-            center_vec = _center2 - _center1;
+            center_vec = center2 - center1;
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
@@ -266,7 +266,7 @@ for the time of intersection:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             scattered = ray(rec.p, scatter_direction, r_in.time());
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-            attenuation = albedo;
+            attenuation = c;
             return true;
         }
         ...
@@ -280,7 +280,7 @@ for the time of intersection:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             scattered = ray(rec.p, reflected + fuzz*random_in_unit_sphere(), r_in.time());
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-            attenuation = albedo;
+            attenuation = c;
             return (dot(scattered.direction(), rec.normal) > 0);
         }
         ...
@@ -608,8 +608,8 @@ Now we have everything we need to implement the new AABB class.
 
         aabb() {} // The default AABB is empty, since intervals are empty by default.
 
-        aabb(const interval& _x, const interval& _y, const interval& _z)
-          : x(_x), y(_y), z(_z) {}
+        aabb(const interval& x, const interval& y, const interval& z)
+          : x(x), y(y), z(z) {}
 
         aabb(const point3& a, const point3& b) {
             // Treat the two points a and b as extrema for the bounding box, so we don't require a
@@ -723,8 +723,8 @@ For a stationary sphere, the `bounding_box` function is easy:
       public:
         // Stationary Sphere
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        sphere(const point3& _center, double _radius, shared_ptr<material> _material)
-          : center1(_center), radius(_radius), mat(_material), is_moving(false)
+        sphere(const point3& center, double radius, shared_ptr<material> mat)
+          : center1(center), radius(radius), mat(mat), is_moving(false)
         {
             auto rvec = vec3(radius, radius, radius);
             bbox = aabb(center1 - rvec, center1 + rvec);
@@ -758,9 +758,9 @@ two boxes.
       public:
         ...
         // Moving Sphere
-        sphere(const point3& _center1, const point3& _center2, double _radius,
-               shared_ptr<material> _material)
-          : center1(_center1), radius(_radius), mat(_material), is_moving(true)
+        sphere(const point3& center1, const point3& center2, double radius,
+               shared_ptr<material> mat)
+          : center1(center1), radius(radius), mat(mat), is_moving(true)
         {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             auto rvec = vec3(radius, radius, radius);
@@ -1280,11 +1280,11 @@ pattern in the scene.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class checker_texture : public texture {
       public:
-        checker_texture(double _scale, shared_ptr<texture> _even, shared_ptr<texture> _odd)
-          : inv_scale(1.0 / _scale), even(_even), odd(_odd) {}
+        checker_texture(double scale, shared_ptr<texture> even, shared_ptr<texture> odd)
+          : inv_scale(1.0 / scale), even(even), odd(odd) {}
 
-        checker_texture(double _scale, const color& c1, const color& c2)
-          : inv_scale(1.0 / _scale),
+        checker_texture(double scale, const color& c1, const color& c2)
+          : inv_scale(1.0 / scale),
             even(make_shared<solid_color>(c1)),
             odd(make_shared<solid_color>(c2))
         {}
@@ -1322,8 +1322,8 @@ colors:
     class lambertian : public material {
       public:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        lambertian(const color& a) : albedo(make_shared<solid_color>(a)) {}
-        lambertian(shared_ptr<texture> a) : albedo(a) {}
+        lambertian(const color& c) : tex(make_shared<solid_color>(c)) {}
+        lambertian(shared_ptr<texture> tex) : tex(tex) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
@@ -1336,14 +1336,14 @@ colors:
 
             scattered = ray(rec.p, scatter_direction, r_in.time());
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-            attenuation = albedo->value(rec.u, rec.v, rec.p);
+            attenuation = tex->value(rec.u, rec.v, rec.p);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             return true;
         }
 
       private:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        shared_ptr<texture> albedo;
+        shared_ptr<texture> tex;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2128,7 +2128,7 @@ It is also a bit low frequency. We can scale the input point to make it vary mor
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        noise_texture(double sc) : scale(sc) {}
+        noise_texture(double scale) : scale(scale) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         color value(double u, double v, const point3& p) const override {
@@ -2320,7 +2320,7 @@ mitigate this, we'll map the $[-1,+1]$ range of values to $[0,1]$.
       public:
         noise_texture() {}
 
-        noise_texture(double sc) : scale(sc) {}
+        noise_texture(double scale) : scale(scale) {}
 
         color value(double u, double v, const point3& p) const override {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -2378,7 +2378,7 @@ Here `fabs()` is the absolute value function defined in `<cmath>`.
       public:
         noise_texture() {}
 
-        noise_texture(double sc) : scale(sc) {}
+        noise_texture(double scale) : scale(scale) {}
 
         color value(double u, double v, const point3& p) const override {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -2415,7 +2415,7 @@ effect is:
       public:
         noise_texture() {}
 
-        noise_texture(double sc) : scale(sc) {}
+        noise_texture(double scale) : scale(scale) {}
 
         color value(double u, double v, const point3& p) const override {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -2485,8 +2485,8 @@ constructed AABBs always have a non-zero volume:
     class aabb {
       public:
         ...
-        aabb(const interval& _x, const interval& _y, const interval& _z)
-          : x(_x), y(_y), z(_z)
+        aabb(const interval& x, const interval& y, const interval& z)
+          : x(x), y(y), z(z)
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         {
             pad_to_minimums();
@@ -2540,8 +2540,8 @@ Now we're ready for the first sketch of the new `quad` class:
 
     class quad : public hittable {
       public:
-        quad(const point3& _Q, const vec3& _u, const vec3& _v, shared_ptr<material> m)
-          : Q(_Q), u(_u), v(_v), mat(m)
+        quad(const point3& Q, const vec3& u, const vec3& v, shared_ptr<material> mat)
+          : Q(Q), u(u), v(v), mat(mat)
         {
             set_bounding_box();
         }
@@ -2665,8 +2665,8 @@ Add the planar values to the `quad` class:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class quad : public hittable {
       public:
-        quad(const point3& _Q, const vec3& _u, const vec3& _v, shared_ptr<material> m)
-          : Q(_Q), u(_u), v(_v), mat(m)
+        quad(const point3& Q, const vec3& u, const vec3& v, shared_ptr<material> mat)
+          : Q(Q), u(u), v(v), mat(mat)
         {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             auto n = cross(u, v);
@@ -2779,8 +2779,8 @@ The vector $\mathbf{w}$ is constant for a given quadrilateral, so we'll cache th
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class quad : public hittable {
       public:
-        quad(const point3& _Q, const vec3& _u, const vec3& _v, shared_ptr<material> m)
-          : Q(_Q), u(_u), v(_v), mat(m)
+        quad(const point3& Q, const vec3& u, const vec3& v, shared_ptr<material> mat)
+          : Q(Q), u(u), v(v), mat(mat)
         {
             auto n = cross(u, v);
             normal = unit_vector(n);
@@ -3078,8 +3078,8 @@ the ray what color it is and performs no reflection. It’s very simple:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class diffuse_light : public material {
       public:
-        diffuse_light(shared_ptr<texture> a) : emit(a) {}
-        diffuse_light(const color& c) : emit(make_shared<solid_color>(c)) {}
+        diffuse_light(shared_ptr<texture> tex) : tex(tex) {}
+        diffuse_light(const color& c) : tex(make_shared<solid_color>(c)) {}
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
         const override {
@@ -3087,11 +3087,11 @@ the ray what color it is and performs no reflection. It’s very simple:
         }
 
         color emitted(double u, double v, const point3& p) const override {
-            return emit->value(u, v, p);
+            return tex->value(u, v, p);
         }
 
       private:
-        shared_ptr<texture> emit;
+        shared_ptr<texture> tex;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [diffuse-light]: <kbd>[material.h]</kbd> A diffuse light class]
@@ -3533,8 +3533,8 @@ make this happen.
     class translate : public hittable {
       public:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        translate(shared_ptr<hittable> p, const vec3& displacement)
-          : object(p), offset(displacement)
+        translate(shared_ptr<hittable> object, const vec3& offset)
+          : object(object), offset(offset)
         {
             bbox = object->bounding_box() + offset;
         }
@@ -3684,7 +3684,7 @@ rotating by $-\theta$.
   $$ z' = \sin(\theta) \cdot x + \cos(\theta) \cdot z $$
 
 <div class='together'>
-We can now create a class for y-rotation:
+We can now create a class for y-rotation. Let's tackle the hit function first:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class rotate_y : public hittable {
@@ -3735,7 +3735,7 @@ We can now create a class for y-rotation:
     class rotate_y : public hittable {
       public:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        rotate_y(shared_ptr<hittable> p, double angle) : object(p) {
+        rotate_y(shared_ptr<hittable> object, double angle) : object(object) {
             auto radians = degrees_to_radians(angle);
             sin_theta = sin(radians);
             cos_theta = cos(radians);
@@ -3947,18 +3947,18 @@ The scattering function of isotropic picks a uniform random direction:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class isotropic : public material {
       public:
-        isotropic(const color& c) : albedo(make_shared<solid_color>(c)) {}
-        isotropic(shared_ptr<texture> a) : albedo(a) {}
+        isotropic(const color& c) : tex(make_shared<solid_color>(c)) {}
+        isotropic(shared_ptr<texture> tex) : tex(tex) {}
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
         const override {
             scattered = ray(rec.p, random_unit_vector(), r_in.time());
-            attenuation = albedo->value(rec.u, rec.v, rec.p);
+            attenuation = tex->value(rec.u, rec.v, rec.p);
             return true;
         }
 
       private:
-        shared_ptr<texture> albedo;
+        shared_ptr<texture> tex;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [isotropic-class]: <kbd>[material.h]</kbd> The isotropic class]

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -1666,8 +1666,8 @@ And the `lambertian` material becomes:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class lambertian : public material {
       public:
-        lambertian(const color& a) : albedo(make_shared<solid_color>(a)) {}
-        lambertian(shared_ptr<texture> a) : albedo(a) {}
+        lambertian(const color& c) : tex(make_shared<solid_color>(c)) {}
+        lambertian(shared_ptr<texture> tex) : tex(tex) {}
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
         const override {
@@ -1678,7 +1678,7 @@ And the `lambertian` material becomes:
                 scatter_direction = rec.normal;
 
             scattered = ray(rec.p, scatter_direction, r_in.time());
-            attenuation = albedo->value(rec.u, rec.v, rec.p);
+            attenuation = tex->value(rec.u, rec.v, rec.p);
             return true;
         }
 
@@ -1691,7 +1691,7 @@ And the `lambertian` material becomes:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
       private:
-        shared_ptr<texture> albedo;
+        shared_ptr<texture> tex;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-lambertian-impsample]: <kbd>[material.h]</kbd>
@@ -1836,8 +1836,8 @@ PDF:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class lambertian : public material {
       public:
-        lambertian(const color& a) : albedo(make_shared<solid_color>(a)) {}
-        lambertian(shared_ptr<texture> a) : albedo(a) {}
+        lambertian(const color& c) : tex(make_shared<solid_color>(c)) {}
+        lambertian(shared_ptr<texture> tex) : tex(tex) {}
 
         bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
         const override {
@@ -1850,7 +1850,7 @@ PDF:
                 scatter_direction = rec.normal;
 
             scattered = ray(rec.p, scatter_direction, r_in.time());
-            attenuation = albedo->value(rec.u, rec.v, rec.p);
+            attenuation = tex->value(rec.u, rec.v, rec.p);
             return true;
         }
 
@@ -2296,7 +2296,7 @@ We can rewrite our Lambertian material using this to get:
 
             scattered = ray(rec.p, unit_vector(scatter_direction), r_in.time());
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-            attenuation = albedo->value(rec.u, rec.v, rec.p);
+            attenuation = tex->value(rec.u, rec.v, rec.p);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
             pdf = dot(uvw.w(), scattered.direction()) / pi;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2326,15 +2326,15 @@ But first, let's quickly update the `isotropic` material:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class isotropic : public material {
       public:
-        isotropic(const color& c) : albedo(make_shared<solid_color>(c)) {}
-        isotropic(shared_ptr<texture> a) : albedo(a) {}
+        isotropic(const color& c) : tex(make_shared<solid_color>(c)) {}
+        isotropic(shared_ptr<texture> tex) : tex(tex) {}
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         bool scatter(
             const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered, double& pdf
         ) const override {
-            attenuation = albedo->value(rec.u, rec.v, rec.p);
+            attenuation = tex->value(rec.u, rec.v, rec.p);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             scattered = ray(rec.p, random_unit_vector(), r_in.time());
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -2352,7 +2352,7 @@ But first, let's quickly update the `isotropic` material:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
       private:
-        shared_ptr<texture> albedo;
+        shared_ptr<texture> tex;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [class-isotropic-impsample]: <kbd>[material.h]</kbd>
@@ -2707,8 +2707,8 @@ Now we can try sampling directions toward a `hittable`, like the light.
     ...
     class hittable_pdf : public pdf {
       public:
-        hittable_pdf(const hittable& _objects, const point3& _origin)
-          : objects(_objects), origin(_origin)
+        hittable_pdf(const hittable& objects, const point3& origin)
+          : objects(objects), origin(origin)
         {}
 
         double value(const vec3& direction) const override {
@@ -2759,8 +2759,8 @@ And then we change `quad` to implement those functions:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class quad : public hittable {
       public:
-        quad(const point3& _Q, const vec3& _u, const vec3& _v, shared_ptr<material> m)
-          : Q(_Q), u(_u), v(_v), mat(m)
+        quad(const point3& Q, const vec3& u, const vec3& v, shared_ptr<material> mat)
+          : Q(Q), u(u), v(v), mat(mat)
         {
             auto n = cross(u, v);
             normal = unit_vector(n);
@@ -3170,13 +3170,13 @@ The `lambertian` material becomes simpler:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class lambertian : public material {
       public:
-        lambertian(const color& a) : albedo(make_shared<solid_color>(a)) {}
-        lambertian(shared_ptr<texture> a) : albedo(a) {}
+        lambertian(const color& c) : tex(make_shared<solid_color>(c)) {}
+        lambertian(shared_ptr<texture> tex) : tex(tex) {}
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         bool scatter(const ray& r_in, const hit_record& rec, scatter_record& srec) const override {
-            srec.attenuation = albedo->value(rec.u, rec.v, rec.p);
+            srec.attenuation = tex->value(rec.u, rec.v, rec.p);
             srec.pdf_ptr = make_shared<cosine_pdf>(rec.normal);
             srec.skip_pdf = false;
             return true;
@@ -3189,7 +3189,7 @@ The `lambertian` material becomes simpler:
         }
 
       private:
-        shared_ptr<texture> albedo;
+        shared_ptr<texture> tex;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [lambertian-scatter]: <kbd>[material.h]</kbd> New lambertian scatter() method]
@@ -3202,13 +3202,13 @@ As does the `isotropic` material:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class isotropic : public material {
       public:
-        isotropic(const color& c) : albedo(make_shared<solid_color>(c)) {}
-        isotropic(shared_ptr<texture> a) : albedo(a) {}
+        isotropic(const color& c) : tex(make_shared<solid_color>(c)) {}
+        isotropic(shared_ptr<texture> tex) : tex(tex) {}
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         bool scatter(const ray& r_in, const hit_record& rec, scatter_record& srec) const override {
-            srec.attenuation = albedo->value(rec.u, rec.v, rec.p);
+            srec.attenuation = tex->value(rec.u, rec.v, rec.p);
             srec.pdf_ptr = make_shared<sphere_pdf>();
             srec.skip_pdf = false;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -3221,7 +3221,7 @@ As does the `isotropic` material:
         }
 
       private:
-        shared_ptr<texture> albedo;
+        shared_ptr<texture> tex;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [isotropic-scatter]: <kbd>[material.h]</kbd> New isotropic scatter() method]
@@ -3294,12 +3294,12 @@ and dielectric materials are easy to fix.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class metal : public material {
       public:
-        metal(const color& a, double f) : albedo(a), fuzz(f < 1 ? f : 1) {}
+        metal(const color& c, double fuzz) : c(c), fuzz(fuzz < 1 ? fuzz : 1) {}
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         bool scatter(const ray& r_in, const hit_record& rec, scatter_record& srec) const override {
-            srec.attenuation = albedo;
+            srec.attenuation = c;
             srec.pdf_ptr = nullptr;
             srec.skip_pdf = true;
 
@@ -3311,7 +3311,7 @@ and dielectric materials are easy to fix.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
       private:
-        color albedo;
+        color c;
         double fuzz;
     };
 
@@ -3319,7 +3319,7 @@ and dielectric materials are easy to fix.
 
     class dielectric : public material {
       public:
-        dielectric(double index_of_refraction) : ir(index_of_refraction) {}
+        dielectric(double ior) : ior(ior) {}
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -3328,7 +3328,7 @@ and dielectric materials are easy to fix.
             srec.pdf_ptr = nullptr;
             srec.skip_pdf = true;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-            double refraction_ratio = rec.front_face ? (1.0/ir) : ir;
+            double refraction_ratio = rec.front_face ? (1.0/ior) : ior;
 
             vec3 unit_direction = unit_vector(r_in.direction());
             double cos_theta = fmin(dot(-unit_direction, rec.normal), 1.0);

--- a/src/InOneWeekend/interval.h
+++ b/src/InOneWeekend/interval.h
@@ -15,7 +15,7 @@ class interval {
 
     interval() : min(+infinity), max(-infinity) {} // Default interval is empty
 
-    interval(double _min, double _max) : min(_min), max(_max) {}
+    interval(double min, double max) : min(min), max(max) {}
 
     double size() const {
         return max - min;

--- a/src/InOneWeekend/material.h
+++ b/src/InOneWeekend/material.h
@@ -28,7 +28,7 @@ class material {
 
 class lambertian : public material {
   public:
-    lambertian(const color& a) : albedo(a) {}
+    lambertian(const color& c) : c(c) {}
 
     bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
     const override {
@@ -39,41 +39,42 @@ class lambertian : public material {
             scatter_direction = rec.normal;
 
         scattered = ray(rec.p, scatter_direction);
-        attenuation = albedo;
+        attenuation = c;
         return true;
     }
 
   private:
-    color albedo;
+    color c;
 };
 
 
 class metal : public material {
   public:
-    metal(const color& a, double f) : albedo(a), fuzz(f < 1 ? f : 1) {}
+    metal(const color& c, double fuzz) : c(c), fuzz(fuzz < 1 ? fuzz : 1) {}
 
     bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
     const override {
         vec3 reflected = reflect(unit_vector(r_in.direction()), rec.normal);
         scattered = ray(rec.p, reflected + fuzz*random_in_unit_sphere());
-        attenuation = albedo;
+        attenuation = c;
+
         return (dot(scattered.direction(), rec.normal) > 0);
     }
 
   private:
-    color albedo;
+    color c;
     double fuzz;
 };
 
 
 class dielectric : public material {
   public:
-    dielectric(double index_of_refraction) : ir(index_of_refraction) {}
+    dielectric(double ior) : ior(ior) {}
 
     bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
     const override {
         attenuation = color(1.0, 1.0, 1.0);
-        double refraction_ratio = rec.front_face ? (1.0/ir) : ir;
+        double refraction_ratio = rec.front_face ? (1.0/ior) : ior;
 
         vec3 unit_direction = unit_vector(r_in.direction());
         double cos_theta = fmin(dot(-unit_direction, rec.normal), 1.0);
@@ -92,7 +93,7 @@ class dielectric : public material {
     }
 
   private:
-    double ir; // Index of Refraction
+    double ior; // Index of Refraction
 
     static double reflectance(double cosine, double ref_idx) {
         // Use Schlick's approximation for reflectance.

--- a/src/InOneWeekend/sphere.h
+++ b/src/InOneWeekend/sphere.h
@@ -18,8 +18,8 @@
 
 class sphere : public hittable {
   public:
-    sphere(const point3& _center, double _radius, shared_ptr<material> _material)
-      : center(_center), radius(_radius), mat(_material) {}
+    sphere(const point3& center, double radius, shared_ptr<material> mat)
+      : center(center), radius(radius), mat(mat) {}
 
     bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
         vec3 oc = center - r.origin();

--- a/src/InOneWeekend/sphere.h
+++ b/src/InOneWeekend/sphere.h
@@ -19,7 +19,7 @@
 class sphere : public hittable {
   public:
     sphere(const point3& center, double radius, shared_ptr<material> mat)
-      : center(center), radius(radius), mat(mat) {}
+      : center(center), radius(fmax(0,radius)), mat(mat) {}
 
     bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
         vec3 oc = center - r.origin();

--- a/src/TheNextWeek/aabb.h
+++ b/src/TheNextWeek/aabb.h
@@ -20,8 +20,8 @@ class aabb {
 
     aabb() {} // The default AABB is empty, since intervals are empty by default.
 
-    aabb(const interval& _x, const interval& _y, const interval& _z)
-      : x(_x), y(_y), z(_z)
+    aabb(const interval& x, const interval& y, const interval& z)
+      : x(x), y(y), z(z)
     {
         pad_to_minimums();
     }

--- a/src/TheNextWeek/constant_medium.h
+++ b/src/TheNextWeek/constant_medium.h
@@ -20,12 +20,14 @@
 
 class constant_medium : public hittable {
   public:
-    constant_medium(shared_ptr<hittable> b, double d, shared_ptr<texture> a)
-      : boundary(b), neg_inv_density(-1/d), phase_function(make_shared<isotropic>(a))
+    constant_medium(shared_ptr<hittable> boundary, double density, shared_ptr<texture> tex)
+      : boundary(boundary), neg_inv_density(-1/density),
+        phase_function(make_shared<isotropic>(tex))
     {}
 
-    constant_medium(shared_ptr<hittable> b, double d, const color& c)
-      : boundary(b), neg_inv_density(-1/d), phase_function(make_shared<isotropic>(c))
+    constant_medium(shared_ptr<hittable> boundary, double density, const color& c)
+      : boundary(boundary), neg_inv_density(-1/density),
+        phase_function(make_shared<isotropic>(c))
     {}
 
     bool hit(const ray& r, interval ray_t, hit_record& rec) const override {

--- a/src/TheNextWeek/hittable.h
+++ b/src/TheNextWeek/hittable.h
@@ -51,8 +51,8 @@ class hittable {
 
 class translate : public hittable {
   public:
-    translate(shared_ptr<hittable> p, const vec3& displacement)
-      : object(p), offset(displacement)
+    translate(shared_ptr<hittable> object, const vec3& offset)
+      : object(object), offset(offset)
     {
         bbox = object->bounding_box() + offset;
     }
@@ -82,7 +82,7 @@ class translate : public hittable {
 
 class rotate_y : public hittable {
   public:
-    rotate_y(shared_ptr<hittable> p, double angle) : object(p) {
+    rotate_y(shared_ptr<hittable> object, double angle) : object(object) {
         auto radians = degrees_to_radians(angle);
         sin_theta = sin(radians);
         cos_theta = cos(radians);

--- a/src/TheNextWeek/interval.h
+++ b/src/TheNextWeek/interval.h
@@ -15,7 +15,7 @@ class interval {
 
     interval() : min(+infinity), max(-infinity) {} // Default interval is empty
 
-    interval(double _min, double _max) : min(_min), max(_max) {}
+    interval(double min, double max) : min(min), max(max) {}
 
     interval(const interval& a, const interval& b)
       : min(fmin(a.min, b.min)), max(fmax(a.max, b.max)) {}

--- a/src/TheNextWeek/quad.h
+++ b/src/TheNextWeek/quad.h
@@ -16,8 +16,8 @@
 
 class quad : public hittable {
   public:
-    quad(const point3& _Q, const vec3& _u, const vec3& _v, shared_ptr<material> m)
-      : Q(_Q), u(_u), v(_v), mat(m)
+    quad(const point3& Q, const vec3& u, const vec3& v, shared_ptr<material> mat)
+      : Q(Q), u(u), v(v), mat(mat)
     {
         auto n = cross(u, v);
         normal = unit_vector(n);

--- a/src/TheNextWeek/sphere.h
+++ b/src/TheNextWeek/sphere.h
@@ -20,7 +20,7 @@ class sphere : public hittable {
   public:
     // Stationary Sphere
     sphere(const point3& center, double radius, shared_ptr<material> mat)
-      : center1(center), radius(radius), mat(mat), is_moving(false)
+      : center1(center), radius(fmax(0,radius)), mat(mat), is_moving(false)
     {
         auto rvec = vec3(radius, radius, radius);
         bbox = aabb(center1 - rvec, center1 + rvec);
@@ -29,7 +29,7 @@ class sphere : public hittable {
     // Moving Sphere
     sphere(const point3& center1, const point3& center2, double radius,
            shared_ptr<material> mat)
-      : center1(center1), radius(radius), mat(mat), is_moving(true)
+      : center1(center1), radius(fmax(0,radius)), mat(mat), is_moving(true)
     {
         auto rvec = vec3(radius, radius, radius);
         aabb box1(center1 - rvec, center1 + rvec);

--- a/src/TheNextWeek/sphere.h
+++ b/src/TheNextWeek/sphere.h
@@ -19,24 +19,24 @@
 class sphere : public hittable {
   public:
     // Stationary Sphere
-    sphere(const point3& _center, double _radius, shared_ptr<material> _material)
-      : center1(_center), radius(_radius), mat(_material), is_moving(false)
+    sphere(const point3& center, double radius, shared_ptr<material> mat)
+      : center1(center), radius(radius), mat(mat), is_moving(false)
     {
         auto rvec = vec3(radius, radius, radius);
         bbox = aabb(center1 - rvec, center1 + rvec);
     }
 
     // Moving Sphere
-    sphere(const point3& _center1, const point3& _center2, double _radius,
-           shared_ptr<material> _material)
-      : center1(_center1), radius(_radius), mat(_material), is_moving(true)
+    sphere(const point3& center1, const point3& center2, double radius,
+           shared_ptr<material> mat)
+      : center1(center1), radius(radius), mat(mat), is_moving(true)
     {
         auto rvec = vec3(radius, radius, radius);
-        aabb box1(_center1 - rvec, _center1 + rvec);
-        aabb box2(_center2 - rvec, _center2 + rvec);
+        aabb box1(center1 - rvec, center1 + rvec);
+        aabb box2(center2 - rvec, center2 + rvec);
         bbox = aabb(box1, box2);
 
-        center_vec = _center2 - _center1;
+        center_vec = center2 - center1;
     }
 
     bool hit(const ray& r, interval ray_t, hit_record& rec) const override {

--- a/src/TheNextWeek/texture.h
+++ b/src/TheNextWeek/texture.h
@@ -43,11 +43,11 @@ class solid_color : public texture {
 
 class checker_texture : public texture {
   public:
-    checker_texture(double _scale, shared_ptr<texture> _even, shared_ptr<texture> _odd)
-      : inv_scale(1.0 / _scale), even(_even), odd(_odd) {}
+    checker_texture(double scale, shared_ptr<texture> even, shared_ptr<texture> odd)
+      : inv_scale(1.0 / scale), even(even), odd(odd) {}
 
-    checker_texture(double _scale, const color& c1, const color& c2)
-      : inv_scale(1.0 / _scale),
+    checker_texture(double scale, const color& c1, const color& c2)
+      : inv_scale(1.0 / scale),
         even(make_shared<solid_color>(c1)),
         odd(make_shared<solid_color>(c2))
     {}
@@ -73,7 +73,7 @@ class noise_texture : public texture {
   public:
     noise_texture() {}
 
-    noise_texture(double sc) : scale(sc) {}
+    noise_texture(double scale) : scale(scale) {}
 
     color value(double u, double v, const point3& p) const override {
         return color(.5, .5, .5) * (1 + sin(scale * p.z() + 10 * noise.turb(p, 7)));

--- a/src/TheRestOfYourLife/aabb.h
+++ b/src/TheRestOfYourLife/aabb.h
@@ -20,8 +20,8 @@ class aabb {
 
     aabb() {} // The default AABB is empty, since intervals are empty by default.
 
-    aabb(const interval& _x, const interval& _y, const interval& _z)
-      : x(_x), y(_y), z(_z)
+    aabb(const interval& x, const interval& y, const interval& z)
+      : x(x), y(y), z(z)
     {
         pad_to_minimums();
     }

--- a/src/TheRestOfYourLife/constant_medium.h
+++ b/src/TheRestOfYourLife/constant_medium.h
@@ -20,12 +20,14 @@
 
 class constant_medium : public hittable {
   public:
-    constant_medium(shared_ptr<hittable> b, double d, shared_ptr<texture> a)
-      : boundary(b), neg_inv_density(-1/d), phase_function(make_shared<isotropic>(a))
+    constant_medium(shared_ptr<hittable> boundary, double density, shared_ptr<texture> tex)
+      : boundary(boundary), neg_inv_density(-1/density),
+        phase_function(make_shared<isotropic>(tex))
     {}
 
-    constant_medium(shared_ptr<hittable> b, double d, const color& c)
-      : boundary(b), neg_inv_density(-1/d), phase_function(make_shared<isotropic>(c))
+    constant_medium(shared_ptr<hittable> boundary, double density, const color& c)
+      : boundary(boundary), neg_inv_density(-1/density),
+        phase_function(make_shared<isotropic>(c))
     {}
 
     bool hit(const ray& r, interval ray_t, hit_record& rec) const override {

--- a/src/TheRestOfYourLife/hittable.h
+++ b/src/TheRestOfYourLife/hittable.h
@@ -59,8 +59,8 @@ class hittable {
 
 class translate : public hittable {
   public:
-    translate(shared_ptr<hittable> p, const vec3& displacement)
-      : object(p), offset(displacement)
+    translate(shared_ptr<hittable> object, const vec3& offset)
+      : object(object), offset(offset)
     {
         bbox = object->bounding_box() + offset;
     }
@@ -90,7 +90,7 @@ class translate : public hittable {
 
 class rotate_y : public hittable {
   public:
-    rotate_y(shared_ptr<hittable> p, double angle) : object(p) {
+    rotate_y(shared_ptr<hittable> object, double angle) : object(object) {
         auto radians = degrees_to_radians(angle);
         sin_theta = sin(radians);
         cos_theta = cos(radians);

--- a/src/TheRestOfYourLife/interval.h
+++ b/src/TheRestOfYourLife/interval.h
@@ -15,7 +15,7 @@ class interval {
 
     interval() : min(+infinity), max(-infinity) {} // Default interval is empty
 
-    interval(double _min, double _max) : min(_min), max(_max) {}
+    interval(double min, double max) : min(min), max(max) {}
 
     interval(const interval& a, const interval& b)
       : min(fmin(a.min, b.min)), max(fmax(a.max, b.max)) {}

--- a/src/TheRestOfYourLife/pdf.h
+++ b/src/TheRestOfYourLife/pdf.h
@@ -60,8 +60,8 @@ class sphere_pdf : public pdf {
 
 class hittable_pdf : public pdf {
   public:
-    hittable_pdf(const hittable& _objects, const point3& _origin)
-      : objects(_objects), origin(_origin)
+    hittable_pdf(const hittable& objects, const point3& origin)
+      : objects(objects), origin(origin)
     {}
 
     double value(const vec3& direction) const override {

--- a/src/TheRestOfYourLife/quad.h
+++ b/src/TheRestOfYourLife/quad.h
@@ -16,8 +16,8 @@
 
 class quad : public hittable {
   public:
-    quad(const point3& _Q, const vec3& _u, const vec3& _v, shared_ptr<material> m)
-      : Q(_Q), u(_u), v(_v), mat(m)
+    quad(const point3& Q, const vec3& u, const vec3& v, shared_ptr<material> mat)
+      : Q(Q), u(u), v(v), mat(mat)
     {
         auto n = cross(u, v);
         normal = unit_vector(n);

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -20,24 +20,24 @@
 class sphere : public hittable {
   public:
     // Stationary Sphere
-    sphere(const point3& _center, double _radius, shared_ptr<material> _material)
-      : center1(_center), radius(_radius), mat(_material), is_moving(false)
+    sphere(const point3& center, double radius, shared_ptr<material> mat)
+      : center1(center), radius(radius), mat(mat), is_moving(false)
     {
         auto rvec = vec3(radius, radius, radius);
         bbox = aabb(center1 - rvec, center1 + rvec);
     }
 
     // Moving Sphere
-    sphere(const point3& _center1, const point3& _center2, double _radius,
-           shared_ptr<material> _material)
-      : center1(_center1), radius(_radius), mat(_material), is_moving(true)
+    sphere(const point3& center1, const point3& center2, double radius,
+           shared_ptr<material> mat)
+      : center1(center1), radius(radius), mat(mat), is_moving(true)
     {
         auto rvec = vec3(radius, radius, radius);
-        aabb box1(_center1 - rvec, _center1 + rvec);
-        aabb box2(_center2 - rvec, _center2 + rvec);
+        aabb box1(center1 - rvec, center1 + rvec);
+        aabb box2(center2 - rvec, center2 + rvec);
         bbox = aabb(box1, box2);
 
-        center_vec = _center2 - _center1;
+        center_vec = center2 - center1;
     }
 
     bool hit(const ray& r, interval ray_t, hit_record& rec) const override {

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -21,7 +21,7 @@ class sphere : public hittable {
   public:
     // Stationary Sphere
     sphere(const point3& center, double radius, shared_ptr<material> mat)
-      : center1(center), radius(radius), mat(mat), is_moving(false)
+      : center1(center), radius(fmax(0,radius)), mat(mat), is_moving(false)
     {
         auto rvec = vec3(radius, radius, radius);
         bbox = aabb(center1 - rvec, center1 + rvec);
@@ -30,7 +30,7 @@ class sphere : public hittable {
     // Moving Sphere
     sphere(const point3& center1, const point3& center2, double radius,
            shared_ptr<material> mat)
-      : center1(center1), radius(radius), mat(mat), is_moving(true)
+      : center1(center1), radius(fmax(0,radius)), mat(mat), is_moving(true)
     {
         auto rvec = vec3(radius, radius, radius);
         aabb box1(center1 - rvec, center1 + rvec);

--- a/src/TheRestOfYourLife/texture.h
+++ b/src/TheRestOfYourLife/texture.h
@@ -43,11 +43,11 @@ class solid_color : public texture {
 
 class checker_texture : public texture {
   public:
-    checker_texture(double _scale, shared_ptr<texture> _even, shared_ptr<texture> _odd)
-      : inv_scale(1.0 / _scale), even(_even), odd(_odd) {}
+    checker_texture(double scale, shared_ptr<texture> even, shared_ptr<texture> odd)
+      : inv_scale(1.0 / scale), even(even), odd(odd) {}
 
-    checker_texture(double _scale, const color& c1, const color& c2)
-      : inv_scale(1.0 / _scale),
+    checker_texture(double scale, const color& c1, const color& c2)
+      : inv_scale(1.0 / scale),
         even(make_shared<solid_color>(c1)),
         odd(make_shared<solid_color>(c2))
     {}
@@ -73,7 +73,7 @@ class noise_texture : public texture {
   public:
     noise_texture() {}
 
-    noise_texture(double sc) : scale(sc) {}
+    noise_texture(double scale) : scale(scale) {}
 
     color value(double u, double v, const point3& p) const override {
         return color(.5, .5, .5) * (1 + sin(scale * p.z() + 10 * noise.turb(p, 7)));


### PR DESCRIPTION
**[This change is stacked on top of the outstanding PR to normalize constructor parameter names. Ignore that commit, as I'll rebase this onto dev when that PR is merged.]**

Implement bubbles with IOR, not negative radii

We were using negative radii on spheres to invert the sense of front vs
back faces of spheres, and using this to get an inverted index of
refraction (IOR) for bubbles. This method was used to model a hollow
glass sphere.

Over the past couple of years we've encountered a number of bugs induced
by negative radii spheres (see the list in the description for issue
1420).

Instead, this change interprets the dielectric parameter not as an IOR
relative to surrounding air, but instead as the ratio of the IOR of the
object material over the IOR of the surrounding medium. Interpreting the
parameter this way lets you model a sphere of air enclosed in glass --
just what we need to model a hollow glass sphere purely with the proper
IORs, and without resorting to inverted geometry with negative radii
spheres.

We also end up using this method to properly demonstrate total
internal/external reflection in another section.

Resolves #1420