### PR TITLE
Define albedo prior to first use

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -2829,11 +2829,16 @@ To achieve this, `hit_record` needs to be told the material that is assigned to 
 
 Modeling Light Scatter and Reflectance
 ---------------------------------------
-For the Lambertian (diffuse) case we already have, it can either always scatter and attenuate by its
+Here and throughout these books we will use the term _albedo_ (Latin for "whiteness"). Albedo is a
+precise technical term in some disciplines, but in all cases it is used to define some form of
+_fractional reflectance_. Albedo will vary with material color and (as we will later implement for
+glass materials) can also vary with incident viewing direction (the direction of the incoming ray).
+
+Lambertian (diffuse) reflectance can either always scatter and attenuate light according to its
 reflectance $R$, or it can sometimes scatter (with probabilty $1-R$) with no attenuation (where a
 ray that isn't scattered is just absorbed into the material). It could also be a mixture of both
-those strategies. We will choose to always scatter, so Lambertian materials become this simple
-class:
+those strategies. We will choose to always scatter, so implementing Lambertian materials becomes a
+simple task:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class material {

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -1440,14 +1440,11 @@ Probability of light being scattered: $A$
 
 Probability of light being absorbed: $1-A$
 
-Where here $A$ stands for _albedo_, which is latin for _whiteness_. Albedo is a precise technical
-term in some disciplines, but in all cases it is used to define some form of _fractional
-reflectance_. This _fractional reflectance_ (or albedo) will vary with color and (as we implemented
-for our glass material) can also vary with incident direction (the direction of the incoming ray).
-It can help to stop and remember that when we simulate light propagation, all we're doing is
-simulating the movement of photons through a space. If you remember your high school Physics then
-you should recall that every photon has a unique energy and wavelength associated by the Planck
-constant:
+Where here $A$ stands for _albedo_. As covered in our first book, recall that albedo is a form of
+fractional reflectance. It can help to stop and remember that when we simulate light propagation,
+all we're doing is simulating the movement of photons through a space. If you remember your high
+school Physics then you should recall that every photon has a unique energy and wavelength
+associated by the Planck constant:
 
     $$ E = \frac{hc}{\lambda} $$
 


### PR DESCRIPTION
The term albedo was explained in the middle of book 3, but we use it early in book 1 (for Lambertian materials). Move the explanation to book 1 before we first use it.

Resolves #1430