### PR TITLE
[README] Update optimized build instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,8 @@ include_directories(src)
 # different compiler or want to set different compiler options.
 
 message (STATUS "Compiler ID: " ${CMAKE_CXX_COMPILER_ID})
+message (STATUS "Release flags: " ${CMAKE_CXX_FLAGS_RELEASE})
+message (STATUS "Debug flags: " ${CMAKE_CXX_FLAGS_DEBUG})
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     add_compile_options("/we 4265") # Class has virtual functions, but its non-trivial destructor is not virtual

--- a/README.md
+++ b/README.md
@@ -145,13 +145,34 @@ You can specify the target with the `--target <program>` option, where the progr
 
     $ cmake --build build --target inOneWeekend
 
-You can build either `debug` (the default) or `release` (the optimized version). To specify this,
-use the `--config <debug|release>` option.
+### Optimized Builds
+CMake supports Release and Debug configurations. These require slightly different invocations
+across Windows (MSVC) and Linux/macOS (using GCC or Clang). The following instructions will place
+optimized binaries under `build/Release` and debug binaries (unoptimized and containing debug
+symbols) under `build/Debug`:
 
-    $ cmake --build build --config release
+On Windows:
 
-We recommend building and running the `release` version (especially before the final render) for
-fastest results, unless you need extra debugging information of the (default) debug build.
+```shell
+$ cmake -B build
+$ cmake --build build --config Release  # Create release binaries in `build/Release`
+$ cmake --build build --config Debug    # Create release binaries in `build/Debug`
+```
+
+On Linux / macOS:
+
+```shell
+# Configure and build release binaries under `build/Release`
+$ cmake -B build/Release -DCMAKE_BUILD_TYPE=Release
+$ cmake --build build/Release
+
+# Configure and build debug binaries under `build/Debug`
+$ cmake -B build/Debug -DCMAKE_BUILD_TYPE=Debug
+$ cmake --build build/Debug
+```
+
+We recommend building and running the `Release` version (especially before the final render) for
+the fastest results, unless you need extra debugging information of the (default) debug build.
 
 ### CMake GUI on Windows
 You may choose to use the CMake GUI when building on windows.


### PR DESCRIPTION
* Add instructions for optimized builds that work across Windows (MSVC) and Unix (Linux/macOS, using GCC/Clang).

* Add log messages to CMakeLists.txt that prints out `CMAKE_CXX_FLAGS_DEBUG` and `CMAKE_CXX_FLAGS_RELEASE`. This seems to work on all platforms that I tested and profile useful information about the flags used by the underlying toolchain.

Fixes #1432