### PR TITLE
True up class hit_record use in material.h

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -2898,6 +2898,7 @@ the vector is very close to zero in all dimensions.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [vec3-near-zero]: <kbd>[vec3.h]</kbd> The vec3::near_zero() method]
 
+
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class lambertian : public material {
       public:

--- a/src/InOneWeekend/material.h
+++ b/src/InOneWeekend/material.h
@@ -13,7 +13,7 @@
 
 #include "rtweekend.h"
 
-#include "hittable_list.h"
+class hit_record;
 
 
 class material {

--- a/src/TheNextWeek/material.h
+++ b/src/TheNextWeek/material.h
@@ -13,8 +13,9 @@
 
 #include "rtweekend.h"
 
-#include "hittable.h"
 #include "texture.h"
+
+class hit_record;
 
 
 class material {

--- a/src/TheRestOfYourLife/material.h
+++ b/src/TheRestOfYourLife/material.h
@@ -16,6 +16,8 @@
 #include "pdf.h"
 #include "texture.h"
 
+class hit_record;
+
 
 class scatter_record {
   public:


### PR DESCRIPTION
Book 1 shows us using "class hit_record" in material.h, but in books 2 and 3 we use "#include "hittable.h" and "hittable_list.h".

The forward declaration is sufficient, and this change makes it consistent throughout the three books.