### PR TITLE
Load images in linear gamma

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -1764,7 +1764,10 @@ header into a folder called `external`. Adjust according to your directory struc
 
         bool load(const std::string& filename) {
             // Loads the linear (gamma=1) image data from the given file name. Returns true if the
-            // load succeeded.
+            // load succeeded. The resulting data buffer contains the three [0.0, 1.0]
+            // floating-point values for the first pixel (red, then green, then blue). Pixels are
+            // contiguous, going left to right for the width of the image, followed by the next row
+            // below, for the full height of the image.
 
             auto n = bytes_per_pixel; // Dummy out parameter: original components per pixel
             fdata = stbi_loadf(filename.c_str(), &image_width, &image_height, &n, bytes_per_pixel);
@@ -1779,7 +1782,8 @@ header into a folder called `external`. Adjust according to your directory struc
         int height() const { return (fdata == nullptr) ? 0 : image_height; }
 
         const unsigned char* pixel_data(int x, int y) const {
-            // Return the address of the three bytes of the pixel at x,y (or magenta if no data).
+            // Return the address of the three RGB bytes of the pixel at x,y. If there is no image
+            // data, returns magenta.
             static unsigned char magenta[] = { 255, 0, 255 };
             if (bdata == nullptr) return magenta;
 
@@ -1811,8 +1815,8 @@ header into a folder called `external`. Adjust according to your directory struc
             int total_bytes = image_width * image_height * bytes_per_pixel;
             bdata = new unsigned char[total_bytes];
 
-            // Iterate through all pixel components, converting from linear float values to unsigned
-            // byte values.
+            // Iterate through all pixel components, converting from [0.0, 1.0] float values to
+            // unsigned [0, 255] byte values.
 
             auto *bptr = bdata;
             auto *fptr = fdata;

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -1703,11 +1703,14 @@ This is just a fractional position.
 Accessing Texture Image Data
 -----------------------------
 Now it's time to create a texture class that holds an image. I am going to use my favorite image
-utility, [stb_image][]. It reads image data into a big array of unsigned chars. These are just
-packed RGBs with each component in the range [0,255] (black to full white). To help make loading our
-image files even easier, we provide a helper class to manage all this -- `rtw_image`. The following
-listing assumes that you have copied the `stb_image.h` header into a folder called `external`.
-Adjust according to your directory structure.
+utility, [stb_image][]. It reads image data into an array of 32-bit floating-point values. These are
+just packed RGBs with each component in the range [0,1] (black to full white). In addition, images
+are loaded in linear color space (gamma = 1) -- the color space in which we do all our computations.
+
+To help make loading our image files even easier, we provide a helper class to manage all this:
+`rtw_image`. It provides a helper function -- `pixel_data(int x, int y)` -- to get the 8-bit RGB
+byte values for each pixel. The following listing assumes that you have copied the `stb_image.h`
+header into a folder called `external`. Adjust according to your directory structure.
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #ifndef RTW_STB_IMAGE_H
@@ -1727,7 +1730,7 @@ Adjust according to your directory structure.
 
     class rtw_image {
       public:
-        rtw_image() : data(nullptr) {}
+        rtw_image() {}
 
         rtw_image(const char* image_filename) {
             // Loads image data from the specified file. If the RTW_IMAGES environment variable is
@@ -1754,41 +1757,67 @@ Adjust according to your directory structure.
             std::cerr << "ERROR: Could not load image file '" << image_filename << "'.\n";
         }
 
-        ~rtw_image() { STBI_FREE(data); }
-
-        bool load(const std::string& filename) {
-            // Loads image data from the given file name. Returns true if the load succeeded.
-            auto n = bytes_per_pixel; // Dummy out parameter: original components per pixel
-            data = stbi_load(filename.c_str(), &image_width, &image_height, &n, bytes_per_pixel);
-            bytes_per_scanline = image_width * bytes_per_pixel;
-            return data != nullptr;
+        ~rtw_image() {
+            delete[] bdata;
+            STBI_FREE(fdata);
         }
 
-        int width()  const { return (data == nullptr) ? 0 : image_width; }
-        int height() const { return (data == nullptr) ? 0 : image_height; }
+        bool load(const std::string& filename) {
+            // Loads the linear (gamma=1) image data from the given file name. Returns true if the
+            // load succeeded.
+
+            auto n = bytes_per_pixel; // Dummy out parameter: original components per pixel
+            fdata = stbi_loadf(filename.c_str(), &image_width, &image_height, &n, bytes_per_pixel);
+            if (fdata == nullptr) return false;
+
+            bytes_per_scanline = image_width * bytes_per_pixel;
+            convert_to_bytes();
+            return true;
+        }
+
+        int width()  const { return (fdata == nullptr) ? 0 : image_width; }
+        int height() const { return (fdata == nullptr) ? 0 : image_height; }
 
         const unsigned char* pixel_data(int x, int y) const {
             // Return the address of the three bytes of the pixel at x,y (or magenta if no data).
             static unsigned char magenta[] = { 255, 0, 255 };
-            if (data == nullptr) return magenta;
+            if (bdata == nullptr) return magenta;
 
             x = clamp(x, 0, image_width);
             y = clamp(y, 0, image_height);
 
-            return data + y*bytes_per_scanline + x*bytes_per_pixel;
+            return bdata + y*bytes_per_scanline + x*bytes_per_pixel;
         }
 
       private:
-        const int bytes_per_pixel = 3;
-        unsigned char *data;
-        int image_width, image_height;
-        int bytes_per_scanline;
+        const int      bytes_per_pixel = 3;
+        float         *fdata = nullptr;         // Linear floating point pixel data
+        unsigned char *bdata = nullptr;         // Linear 8-bit pixel data
+        int            image_width = 0;         // Loaded image width
+        int            image_height = 0;        // Loaded image height
+        int            bytes_per_scanline = 0;
 
         static int clamp(int x, int low, int high) {
             // Return the value clamped to the range [low, high).
             if (x < low) return low;
             if (x < high) return x;
             return high - 1;
+        }
+
+        void convert_to_bytes() {
+            // Convert the linear floating point pixel data to bytes, storing the resulting byte
+            // data in the `bdata` member.
+
+            int total_bytes = image_width * image_height * bytes_per_pixel;
+            bdata = new unsigned char[total_bytes];
+
+            // Iterate through all pixel components, converting from linear float values to unsigned
+            // byte values.
+
+            auto *bptr = bdata;
+            auto *fptr = fdata;
+            for (auto i=0; i < total_bytes; i++, fptr++, bptr++)
+                *bptr = static_cast<unsigned char>(*fptr * 256.0);
         }
     };
 

--- a/src/TheNextWeek/rtw_stb_image.h
+++ b/src/TheNextWeek/rtw_stb_image.h
@@ -58,7 +58,10 @@ class rtw_image {
 
     bool load(const std::string& filename) {
         // Loads the linear (gamma=1) image data from the given file name. Returns true if the
-        // load succeeded.
+        // load succeeded. The resulting data buffer contains the three [0.0, 1.0]
+        // floating-point values for the first pixel (red, then green, then blue). Pixels are
+        // contiguous, going left to right for the width of the image, followed by the next row
+        // below, for the full height of the image.
 
         auto n = bytes_per_pixel; // Dummy out parameter: original components per pixel
         fdata = stbi_loadf(filename.c_str(), &image_width, &image_height, &n, bytes_per_pixel);
@@ -73,7 +76,8 @@ class rtw_image {
     int height() const { return (fdata == nullptr) ? 0 : image_height; }
 
     const unsigned char* pixel_data(int x, int y) const {
-        // Return the address of the three bytes of the pixel at x,y (or magenta if no data).
+        // Return the address of the three RGB bytes of the pixel at x,y. If there is no image
+        // data, returns magenta.
         static unsigned char magenta[] = { 255, 0, 255 };
         if (bdata == nullptr) return magenta;
 
@@ -105,8 +109,8 @@ class rtw_image {
         int total_bytes = image_width * image_height * bytes_per_pixel;
         bdata = new unsigned char[total_bytes];
 
-        // Iterate through all pixel components, converting from linear float values to unsigned
-        // byte values.
+        // Iterate through all pixel components, converting from [0.0, 1.0] float values to
+        // unsigned [0, 255] byte values.
 
         auto *bptr = bdata;
         auto *fptr = fdata;

--- a/src/TheRestOfYourLife/rtw_stb_image.h
+++ b/src/TheRestOfYourLife/rtw_stb_image.h
@@ -58,7 +58,10 @@ class rtw_image {
 
     bool load(const std::string& filename) {
         // Loads the linear (gamma=1) image data from the given file name. Returns true if the
-        // load succeeded.
+        // load succeeded. The resulting data buffer contains the three [0.0, 1.0]
+        // floating-point values for the first pixel (red, then green, then blue). Pixels are
+        // contiguous, going left to right for the width of the image, followed by the next row
+        // below, for the full height of the image.
 
         auto n = bytes_per_pixel; // Dummy out parameter: original components per pixel
         fdata = stbi_loadf(filename.c_str(), &image_width, &image_height, &n, bytes_per_pixel);
@@ -73,7 +76,8 @@ class rtw_image {
     int height() const { return (fdata == nullptr) ? 0 : image_height; }
 
     const unsigned char* pixel_data(int x, int y) const {
-        // Return the address of the three bytes of the pixel at x,y (or magenta if no data).
+        // Return the address of the three RGB bytes of the pixel at x,y. If there is no image
+        // data, returns magenta.
         static unsigned char magenta[] = { 255, 0, 255 };
         if (bdata == nullptr) return magenta;
 
@@ -105,8 +109,8 @@ class rtw_image {
         int total_bytes = image_width * image_height * bytes_per_pixel;
         bdata = new unsigned char[total_bytes];
 
-        // Iterate through all pixel components, converting from linear float values to unsigned
-        // byte values.
+        // Iterate through all pixel components, converting from [0.0, 1.0] float values to
+        // unsigned [0, 255] byte values.
 
         auto *bptr = bdata;
         auto *fptr = fdata;


### PR DESCRIPTION
We were using the STBI `stbi_load()` function, which loads gamma-corrected byte data from the given image.

Instead, we want our image data to be in linear space for internal computation, with a final gamma=2 correction applied when we write the rendered result.

Happily, there's an `stbi_loadf()` function that loads linearly-encoded image data as triples of 32-bit floating-point values.

We don't really need to explain all the machinery, as we kind of just plop `rtw_stb_image.h` down for the readers to use. I do add some explanation though that we want loaded images to be in linear color space.

Resolves #842