### PR TITLE
Add default `material::scatter()` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ that, here are the latest changes since our alpha.1 release:
   - Change -- All constructor parameter names now match their member names if assigned directly. C++
               can handle this without ambiguity, and it means we don't have to come up with
               alternate names for everything (#1427)
+  - Change -- `material::scatter()` gets a trivial default implementation (#1455)
   - Fix    -- Fixed section describing total internal reflection. It turns out that spheres with
               refraction index greater than the surrounding atmosphere cannot exhibit total internal
               reflection. Changed example to instead model a bubble of air in water, and updated the

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -2736,7 +2736,10 @@ This suggests the abstract class:
         virtual ~material() = default;
 
         virtual bool scatter(
-            const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered) const = 0;
+            const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
+        ) const {
+            return false;
+        }
     };
 
     #endif

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -3159,11 +3159,6 @@ the ray what color it is and performs no reflection. It’s very simple:
         diffuse_light(shared_ptr<texture> tex) : tex(tex) {}
         diffuse_light(const color& emit) : tex(make_shared<solid_color>(emit)) {}
 
-        bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
-        const override {
-            return false;
-        }
-
         color emitted(double u, double v, const point3& p) const override {
             return tex->value(u, v, p);
         }
@@ -3181,7 +3176,7 @@ class return black:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class material {
       public:
-        ...
+        virtual ~material() = default;
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
@@ -3192,7 +3187,9 @@ class return black:
 
         virtual bool scatter(
             const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-        ) const = 0;
+        ) const {
+            return false;
+        }
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [matl-emit]: <kbd>[material.h]</kbd> New emitted function in class material]

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -3147,13 +3147,12 @@ We can redesign `material` and stuff all the new arguments into a class like we 
       public:
         ...
 
-        virtual bool scatter(
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-            const ray& r_in, const hit_record& rec, scatter_record& srec
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-        ) const {
+        virtual bool scatter(const ray& r_in, const hit_record& rec, scatter_record& srec) const {
             return false;
         }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+
         ...
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/InOneWeekend/material.h
+++ b/src/InOneWeekend/material.h
@@ -22,7 +22,9 @@ class material {
 
     virtual bool scatter(
         const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-    ) const = 0;
+    ) const {
+        return false;
+    }
 };
 
 

--- a/src/TheNextWeek/material.h
+++ b/src/TheNextWeek/material.h
@@ -28,7 +28,9 @@ class material {
 
     virtual bool scatter(
         const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered
-    ) const = 0;
+    ) const {
+        return false;
+    }
 };
 
 
@@ -117,11 +119,6 @@ class diffuse_light : public material {
   public:
     diffuse_light(shared_ptr<texture> tex) : tex(tex) {}
     diffuse_light(const color& emit) : tex(make_shared<solid_color>(emit)) {}
-
-    bool scatter(const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered)
-    const override {
-        return false;
-    }
 
     color emitted(double u, double v, const point3& p) const override {
         return tex->value(u, v, p);


### PR DESCRIPTION
The code mixes up `material::scatter()` with and without a default implementation. This causes problems as the `diffuse_light` (derived from the `material` class) first defines its own no-op implementation, but later the signature of `material::scatter()` changes without associated updates to the `diffuse_light` class.

All of this is fixed by giving `material::scatter()` a no-op default implementation, which `diffuse_light` just uses implicitly. Thus, when the signature is changed, `diffuse_light` requires no updates.

Resolves #1379