### PR TITLE
Fix green texmap artifacts on earth render

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -1797,6 +1797,14 @@ header into a folder called `external`. Adjust according to your directory struc
             return high - 1;
         }
 
+        static unsigned char float_to_byte(float value) {
+            if (value <= 0.0)
+                return 0;
+            if (1.0 <= value)
+                return 255;
+            return static_cast< unsigned char >(256.0 * value);
+        }
+
         void convert_to_bytes() {
             // Convert the linear floating point pixel data to bytes, storing the resulting byte
             // data in the `bdata` member.
@@ -1810,7 +1818,7 @@ header into a folder called `external`. Adjust according to your directory struc
             auto *bptr = bdata;
             auto *fptr = fdata;
             for (auto i=0; i < total_bytes; i++, fptr++, bptr++)
-                *bptr = static_cast< unsigned char >(*fptr * 256.0);
+                *bptr = float_to_byte(*fptr);
         }
     };
 

--- a/src/TheNextWeek/rtw_stb_image.h
+++ b/src/TheNextWeek/rtw_stb_image.h
@@ -102,6 +102,14 @@ class rtw_image {
         return high - 1;
     }
 
+    static unsigned char float_to_byte(float value) {
+        if (value <= 0.0)
+            return 0;
+        if (1.0 <= value)
+            return 255;
+        return static_cast< unsigned char >(256.0 * value);
+    }
+
     void convert_to_bytes() {
         // Convert the linear floating point pixel data to bytes, storing the resulting byte
         // data in the `bdata` member.
@@ -115,7 +123,7 @@ class rtw_image {
         auto *bptr = bdata;
         auto *fptr = fdata;
         for (auto i=0; i < total_bytes; i++, fptr++, bptr++)
-            *bptr = static_cast<unsigned char>(*fptr * 256.0);
+            *bptr = float_to_byte(*fptr);
     }
 };
 


### PR DESCRIPTION
Turns out the problem has to do with the conversion to gamma-corrected intensities from the [0,1] values read in from the STB image library.

I thought the range would be [0,1), but instead it's [0,1]. Thus, intensity values of 1.0 were mapped to 256, which then converted to 0 for unsigned 8-bit chars. Thankfully, I typo'ed the conversion in the latest book 2 progression, and multiplied intensities by _257_, which made the problem worse, and enough to to hit me.

This fix makes the conversion bullet-proof, and zero or negative intensities are now mapped to 0, and values greater than or equal to 1.0 are now mapped to 255.

Resolves #1485