### PR TITLE
Address HTML parsing bug with '<unsigned char>'

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -1706,6 +1706,7 @@ To help make loading our image files even easier, we provide a helper class to m
 byte values for each pixel. The following listing assumes that you have copied the `stb_image.h`
 header into a folder called `external`. Adjust according to your directory structure.
 
+<script type="preformatted">
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     #ifndef RTW_STB_IMAGE_H
     #define RTW_STB_IMAGE_H
@@ -1807,7 +1808,7 @@ header into a folder called `external`. Adjust according to your directory struc
                 return 0;
             if (1.0 <= value)
                 return 255;
-            return static_cast< unsigned char >(256.0 * value);
+            return static_cast<unsigned char>(256.0 * value);
         }
 
         void convert_to_bytes() {
@@ -1835,6 +1836,7 @@ header into a folder called `external`. Adjust according to your directory struc
     #endif
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     [Listing [rtw_image]: <kbd>[rtw_stb_image.h] The rtw_image helper class]
+</script>
 
 If you are writing your implementation in a language other than C or C++, you'll need to locate (or
 write) an image loading library that provides similar functionality.

--- a/src/TheNextWeek/rtw_stb_image.h
+++ b/src/TheNextWeek/rtw_stb_image.h
@@ -107,7 +107,7 @@ class rtw_image {
             return 0;
         if (1.0 <= value)
             return 255;
-        return static_cast< unsigned char >(256.0 * value);
+        return static_cast<unsigned char>(256.0 * value);
     }
 
     void convert_to_bytes() {

--- a/src/TheRestOfYourLife/rtw_stb_image.h
+++ b/src/TheRestOfYourLife/rtw_stb_image.h
@@ -107,7 +107,7 @@ class rtw_image {
             return 0;
         if (1.0 <= value)
             return 255;
-        return static_cast< unsigned char >(256.0 * value);
+        return static_cast<unsigned char>(256.0 * value);
     }
 
     void convert_to_bytes() {


### PR DESCRIPTION
When listing text contains something like
```
  static_cast<unsigned char>(thing)
```
HTML parses `<unsigned char>` as an HTML tag before Markdeep gets a chance to see it. We had temporarily addressed this by adding spaces inside the angle brackets, and sent an inquiry off to Morgan McGuire, creator of Markdeep. His response was that Markdeep couldn't address this given the parsing order, and to just wrap the entire listing in
```
  <script type="preformatted">
    ...
  </script>
```
Resolves #1463