### PR TITLE
Use delegating ctors + other ctor cleanup

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -75,11 +75,11 @@ time for each ray:
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-        ray(const point3& origin, const vec3& direction)
-          : orig(origin), dir(direction), tm(0) {}
-
         ray(const point3& origin, const vec3& direction, double time)
           : orig(origin), dir(direction), tm(time) {}
+
+        ray(const point3& origin, const vec3& direction)
+          : ray(origin, direction, 0) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 
         const point3& origin() const  { return orig; }
@@ -1323,10 +1323,7 @@ pattern in the scene.
           : inv_scale(1.0 / scale), even(even), odd(odd) {}
 
         checker_texture(double scale, const color& c1, const color& c2)
-          : inv_scale(1.0 / scale),
-            even(make_shared<solid_color>(c1)),
-            odd(make_shared<solid_color>(c2))
-        {}
+          : checker_texture(scale, make_shared<solid_color>(c1), make_shared<solid_color>(c2)) {}
 
         color value(double u, double v, const point3& p) const override {
             auto xInteger = int(std::floor(inv_scale * p.x()));
@@ -2252,9 +2249,6 @@ It is also a bit low frequency. We can scale the input point to make it vary mor
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class noise_texture : public texture {
       public:
-        noise_texture() {}
-
-
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
         noise_texture(double scale) : scale(scale) {}
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2449,8 +2443,6 @@ mitigate this, we'll map the $[-1,+1]$ range of values to $[0,1]$.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class noise_texture : public texture {
       public:
-        noise_texture() {}
-
         noise_texture(double scale) : scale(scale) {}
 
         color value(double u, double v, const point3& p) const override {
@@ -2515,8 +2507,6 @@ turbulence, and is a sum of repeated calls to noise:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class noise_texture : public texture {
       public:
-        noise_texture() {}
-
         noise_texture(double scale) : scale(scale) {}
 
         color value(double u, double v, const point3& p) const override {
@@ -2552,8 +2542,6 @@ effect is:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class noise_texture : public texture {
       public:
-        noise_texture() {}
-
         noise_texture(double scale) : scale(scale) {}
 
         color value(double u, double v, const point3& p) const override {

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -2662,7 +2662,7 @@ create a uniform density over the unit sphere:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class sphere_pdf : public pdf {
       public:
-        sphere_pdf() { }
+        sphere_pdf() {}
 
         double value(const vec3& direction) const override {
             return 1/ (4 * pi);

--- a/src/TheNextWeek/ray.h
+++ b/src/TheNextWeek/ray.h
@@ -18,11 +18,11 @@ class ray {
   public:
     ray() {}
 
-    ray(const point3& origin, const vec3& direction)
-      : orig(origin), dir(direction), tm(0) {}
-
     ray(const point3& origin, const vec3& direction, double time)
       : orig(origin), dir(direction), tm(time) {}
+
+    ray(const point3& origin, const vec3& direction)
+      : ray(origin, direction, 0) {}
 
     const point3& origin() const  { return orig; }
     const vec3& direction() const { return dir; }

--- a/src/TheNextWeek/texture.h
+++ b/src/TheNextWeek/texture.h
@@ -46,10 +46,7 @@ class checker_texture : public texture {
       : inv_scale(1.0 / scale), even(even), odd(odd) {}
 
     checker_texture(double scale, const color& c1, const color& c2)
-      : inv_scale(1.0 / scale),
-        even(make_shared<solid_color>(c1)),
-        odd(make_shared<solid_color>(c2))
-    {}
+      : checker_texture(scale, make_shared<solid_color>(c1), make_shared<solid_color>(c2)) {}
 
     color value(double u, double v, const point3& p) const override {
         auto xInteger = int(std::floor(inv_scale * p.x()));
@@ -95,8 +92,6 @@ class image_texture : public texture {
 
 class noise_texture : public texture {
   public:
-    noise_texture() {}
-
     noise_texture(double scale) : scale(scale) {}
 
     color value(double u, double v, const point3& p) const override {

--- a/src/TheRestOfYourLife/pdf.h
+++ b/src/TheRestOfYourLife/pdf.h
@@ -46,7 +46,7 @@ class cosine_pdf : public pdf {
 
 class sphere_pdf : public pdf {
   public:
-    sphere_pdf() { }
+    sphere_pdf() {}
 
     double value(const vec3& direction) const override {
         return 1/ (4 * pi);

--- a/src/TheRestOfYourLife/ray.h
+++ b/src/TheRestOfYourLife/ray.h
@@ -18,11 +18,11 @@ class ray {
   public:
     ray() {}
 
-    ray(const point3& origin, const vec3& direction)
-      : orig(origin), dir(direction), tm(0) {}
-
     ray(const point3& origin, const vec3& direction, double time)
       : orig(origin), dir(direction), tm(time) {}
+
+    ray(const point3& origin, const vec3& direction)
+      : ray(origin, direction, 0) {}
 
     const point3& origin() const  { return orig; }
     const vec3& direction() const { return dir; }

--- a/src/TheRestOfYourLife/texture.h
+++ b/src/TheRestOfYourLife/texture.h
@@ -46,10 +46,7 @@ class checker_texture : public texture {
       : inv_scale(1.0 / scale), even(even), odd(odd) {}
 
     checker_texture(double scale, const color& c1, const color& c2)
-      : inv_scale(1.0 / scale),
-        even(make_shared<solid_color>(c1)),
-        odd(make_shared<solid_color>(c2))
-    {}
+      : checker_texture(scale, make_shared<solid_color>(c1), make_shared<solid_color>(c2)) {}
 
     color value(double u, double v, const point3& p) const override {
         auto xInteger = int(std::floor(inv_scale * p.x()));
@@ -95,8 +92,6 @@ class image_texture : public texture {
 
 class noise_texture : public texture {
   public:
-    noise_texture() {}
-
     noise_texture(double scale) : scale(scale) {}
 
     color value(double u, double v, const point3& p) const override {


### PR DESCRIPTION
Found two places where delegating constructors helped: ray and checker_texture.

In addition, this includes some minor constructor cleanup.

Resolves #1489