### PR TITLE
Remove unused operator<< & const-medium debug code

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -4056,10 +4056,6 @@ The resulting class is:
         {}
 
         bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
-            // Print occasional samples when debugging. To enable, set enableDebug true.
-            const bool enableDebug = false;
-            const bool debugging = enableDebug && random_double() < 0.00001;
-
             hit_record rec1, rec2;
 
             if (!boundary->hit(r, interval::universe, rec1))
@@ -4067,8 +4063,6 @@ The resulting class is:
 
             if (!boundary->hit(r, interval(rec1.t+0.0001, infinity), rec2))
                 return false;
-
-            if (debugging) std::clog << "\nt_min=" << rec1.t << ", t_max=" << rec2.t << '\n';
 
             if (rec1.t < ray_t.min) rec1.t = ray_t.min;
             if (rec2.t > ray_t.max) rec2.t = ray_t.max;
@@ -4088,12 +4082,6 @@ The resulting class is:
 
             rec.t = rec1.t + hit_distance / ray_length;
             rec.p = r.at(rec.t);
-
-            if (debugging) {
-                std::clog << "hit_distance = " <<  hit_distance << '\n'
-                          << "rec.t = " <<  rec.t << '\n'
-                          << "rec.p = " <<  rec.p << '\n';
-            }
 
             rec.normal = vec3(1,0,0);  // arbitrary
             rec.front_face = true;     // also arbitrary

--- a/src/InOneWeekend/vec3.h
+++ b/src/InOneWeekend/vec3.h
@@ -73,10 +73,6 @@ using point3 = vec3;
 
 // Vector Utility Functions
 
-inline std::ostream& operator<<(std::ostream& out, const vec3& v) {
-    return out << v.e[0] << ' ' << v.e[1] << ' ' << v.e[2];
-}
-
 inline vec3 operator+(const vec3& u, const vec3& v) {
     return vec3(u.e[0] + v.e[0], u.e[1] + v.e[1], u.e[2] + v.e[2]);
 }

--- a/src/TheNextWeek/constant_medium.h
+++ b/src/TheNextWeek/constant_medium.h
@@ -31,10 +31,6 @@ class constant_medium : public hittable {
     {}
 
     bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
-        // Print occasional samples when debugging. To enable, set enableDebug true.
-        const bool enableDebug = false;
-        const bool debugging = enableDebug && random_double() < 0.00001;
-
         hit_record rec1, rec2;
 
         if (!boundary->hit(r, interval::universe, rec1))
@@ -42,8 +38,6 @@ class constant_medium : public hittable {
 
         if (!boundary->hit(r, interval(rec1.t+0.0001, infinity), rec2))
             return false;
-
-        if (debugging) std::clog << "\nt_min=" << rec1.t << ", t_max=" << rec2.t << '\n';
 
         if (rec1.t < ray_t.min) rec1.t = ray_t.min;
         if (rec2.t > ray_t.max) rec2.t = ray_t.max;
@@ -63,12 +57,6 @@ class constant_medium : public hittable {
 
         rec.t = rec1.t + hit_distance / ray_length;
         rec.p = r.at(rec.t);
-
-        if (debugging) {
-            std::clog << "hit_distance = " <<  hit_distance << '\n'
-                      << "rec.t = " <<  rec.t << '\n'
-                      << "rec.p = " <<  rec.p << '\n';
-        }
 
         rec.normal = vec3(1,0,0);  // arbitrary
         rec.front_face = true;     // also arbitrary

--- a/src/TheNextWeek/vec3.h
+++ b/src/TheNextWeek/vec3.h
@@ -73,10 +73,6 @@ using point3 = vec3;
 
 // Vector Utility Functions
 
-inline std::ostream& operator<<(std::ostream& out, const vec3& v) {
-    return out << v.e[0] << ' ' << v.e[1] << ' ' << v.e[2];
-}
-
 inline vec3 operator+(const vec3& u, const vec3& v) {
     return vec3(u.e[0] + v.e[0], u.e[1] + v.e[1], u.e[2] + v.e[2]);
 }

--- a/src/TheRestOfYourLife/constant_medium.h
+++ b/src/TheRestOfYourLife/constant_medium.h
@@ -31,10 +31,6 @@ class constant_medium : public hittable {
     {}
 
     bool hit(const ray& r, interval ray_t, hit_record& rec) const override {
-        // Print occasional samples when debugging. To enable, set enableDebug true.
-        const bool enableDebug = false;
-        const bool debugging = enableDebug && random_double() < 0.00001;
-
         hit_record rec1, rec2;
 
         if (!boundary->hit(r, interval::universe, rec1))
@@ -42,8 +38,6 @@ class constant_medium : public hittable {
 
         if (!boundary->hit(r, interval(rec1.t+0.0001, infinity), rec2))
             return false;
-
-        if (debugging) std::clog << "\nt_min=" << rec1.t << ", t_max=" << rec2.t << '\n';
 
         if (rec1.t < ray_t.min) rec1.t = ray_t.min;
         if (rec2.t > ray_t.max) rec2.t = ray_t.max;
@@ -63,12 +57,6 @@ class constant_medium : public hittable {
 
         rec.t = rec1.t + hit_distance / ray_length;
         rec.p = r.at(rec.t);
-
-        if (debugging) {
-            std::clog << "hit_distance = " <<  hit_distance << '\n'
-                      << "rec.t = " <<  rec.t << '\n'
-                      << "rec.p = " <<  rec.p << '\n';
-        }
 
         rec.normal = vec3(1,0,0);  // arbitrary
         rec.front_face = true;     // also arbitrary

--- a/src/TheRestOfYourLife/vec3.h
+++ b/src/TheRestOfYourLife/vec3.h
@@ -73,10 +73,6 @@ using point3 = vec3;
 
 // Vector Utility Functions
 
-inline std::ostream& operator<<(std::ostream& out, const vec3& v) {
-    return out << v.e[0] << ' ' << v.e[1] << ' ' << v.e[2];
-}
-
 inline vec3 operator+(const vec3& u, const vec3& v) {
     return vec3(u.e[0] + v.e[0], u.e[1] + v.e[1], u.e[2] + v.e[2]);
 }


### PR DESCRIPTION
When I created issue #1495, I must have been in the middle of a code progression, because it appeared to me that vec3::operator<< was unused.

Turns out it _is_ used, in debug code for the `constant_medium::hit()` function. This code was created as a clean-up for the original scattered debug statements in this function. On review, however, this appears a bit odd, as the text does not mention the debuggability option (it's off by default), and no other code in the books has debug print code.

Looking at it again, I think it should be removed, and readers are free to add whatever debug code they need at any stage in development.

Resolves #1495