### PR TITLE
Standardize our use of begin/end iterators

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -989,7 +989,7 @@ we haven't yet defined.
                 left = objects[start];
                 right = objects[start+1];
             } else {
-                std::sort(objects.begin() + start, objects.begin() + end, comparator);
+                std::sort(std::begin(objects) + start, std::begin(objects) + end, comparator);
 
                 auto mid = start + object_span/2;
                 left = make_shared<bvh_node>(objects, start, mid);

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -957,7 +957,7 @@ have an area that is half of the total. From $0$ to $2\pi$ for example:
         }
 
         // Sort the samples by x.
-        std::sort(samples, samples + N, compare_by_x);
+        std::sort(std::begin(samples), std::end(samples), compare_by_x);
 
         // Find out the sample at which we have half of our area.
         double half_sum = sum / 2.0;

--- a/src/TheNextWeek/bvh.h
+++ b/src/TheNextWeek/bvh.h
@@ -49,7 +49,7 @@ class bvh_node : public hittable {
             left = objects[start];
             right = objects[start+1];
         } else {
-            std::sort(objects.begin() + start, objects.begin() + end, comparator);
+            std::sort(std::begin(objects) + start, std::begin(objects) + end, comparator);
 
             auto mid = start + object_span/2;
             left = make_shared<bvh_node>(objects, start, mid);

--- a/src/TheRestOfYourLife/bvh.h
+++ b/src/TheRestOfYourLife/bvh.h
@@ -49,7 +49,7 @@ class bvh_node : public hittable {
             left = objects[start];
             right = objects[start+1];
         } else {
-            std::sort(objects.begin() + start, objects.begin() + end, comparator);
+            std::sort(std::begin(objects) + start, std::begin(objects) + end, comparator);
 
             auto mid = start + object_span/2;
             left = make_shared<bvh_node>(objects, start, mid);

--- a/src/TheRestOfYourLife/estimate_halfway.cc
+++ b/src/TheRestOfYourLife/estimate_halfway.cc
@@ -46,7 +46,7 @@ int main() {
     }
 
     // Sort the samples by x.
-    std::sort(samples, samples + N, compare_by_x);
+    std::sort(std::begin(samples), std::end(samples), compare_by_x);
 
     // Find out the sample at which we have half of our area.
     double half_sum = sum / 2.0;


### PR DESCRIPTION
We try to keep our use of C++ dead simple for non-C++ programmers to read easily, but there are cases where we need to yield a bit. (For example, using shared pointers to keep memory management simple.)

In order to use the std::sort() function, we need to provide or use begin and end iterators. With the recent change to our `estimate_halfway.cc` program, we had different ways of using such iterators.

The BVH code used the member functions `begin()` and `end()`, while the `estimate_halfway` program used argument promotion from an array and the array plus an integer offset.

To standardize both and reduce variance, this change uses the currently-recommended practice of using `std::begin(thing)` and `std::end(thing)`.

For now, I'm avoiding spending any text explaining to the non-C++ reader what these are, in the hopes that the meaning can be easily deduced.