### PR TITLE
Simplify the ONB class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Change Log -- Ray Tracing in One Weekend
 ### The Next Week
 
 ### The Rest of Your Life
-
+  - Change -- Simplified the `onb` class, and renamed or deleted methods (#1080)
 
 
 

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -2257,31 +2257,20 @@ class because it won't really be more complicated than utility functions:
 
     class onb {
       public:
-        onb() {}
-
-        vec3 operator[](int i) const { return axis[i]; }
-        vec3& operator[](int i) { return axis[i]; }
-
-        vec3 u() const { return axis[0]; }
-        vec3 v() const { return axis[1]; }
-        vec3 w() const { return axis[2]; }
-
-        vec3 local(double a, double b, double c) const {
-            return a*u() + b*v() + c*w();
+        onb(const vec3& n) {
+            axis[2] = unit_vector(n);
+            vec3 a = (std::fabs(axis[2].x()) > 0.9) ? vec3(0,1,0) : vec3(1,0,0);
+            axis[1] = unit_vector(cross(axis[2], a));
+            axis[0] = cross(axis[2], axis[1]);
         }
 
-        vec3 local(const vec3& a) const {
-            return a.x()*u() + a.y()*v() + a.z()*w();
-        }
+        const vec3& u() const { return axis[0]; }
+        const vec3& v() const { return axis[1]; }
+        const vec3& w() const { return axis[2]; }
 
-        void build_from_w(const vec3& w) {
-            vec3 unit_w = unit_vector(w);
-            vec3 a = (std::fabs(unit_w.x()) > 0.9) ? vec3(0,1,0) : vec3(1,0,0);
-            vec3 v = unit_vector(cross(unit_w, a));
-            vec3 u = cross(unit_w, v);
-            axis[0] = u;
-            axis[1] = v;
-            axis[2] = unit_w;
+        vec3 transform(const vec3& v) const {
+            // Transform from basis coordinates to local space.
+            return (v[0] * axis[0]) + (v[1] * axis[1]) + (v[2] * axis[2]);
         }
 
       private:
@@ -2332,9 +2321,8 @@ We can rewrite our Lambertian material using this to get:
         bool scatter(
             const ray& r_in, const hit_record& rec, color& attenuation, ray& scattered, double& pdf
         ) const override {
-            onb uvw;
-            uvw.build_from_w(rec.normal);
-            auto scatter_direction = uvw.local(random_cosine_direction());
+            onb uvw(rec.normal);
+            auto scatter_direction = uvw.transform(random_cosine_direction());
 
             scattered = ray(rec.p, unit_vector(scatter_direction), r_in.time());
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2428,7 +2416,7 @@ And here we add the accompanying changes to the camera class:
         ...
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [scatter-onb-ray-color]: <kbd>[camera.h]</kbd>
+    [Listing [scatter-ray-color]: <kbd>[camera.h]</kbd>
         Updated ray_color function with returned PDF value
     ]
 
@@ -2769,7 +2757,7 @@ Next, let’s try a cosine density:
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class cosine_pdf : public pdf {
       public:
-        cosine_pdf(const vec3& w) { uvw.build_from_w(w); }
+        cosine_pdf(const vec3& w) : uvw(w) {}
 
         double value(const vec3& direction) const override {
             auto cosine_theta = dot(unit_vector(direction), uvw.w());
@@ -2777,7 +2765,7 @@ Next, let’s try a cosine density:
         }
 
         vec3 generate() const override {
-            return uvw.local(random_cosine_direction());
+            return uvw.transform(random_cosine_direction());
         }
 
       private:
@@ -3758,9 +3746,8 @@ The sphere class needs the two PDF-related functions:
         vec3 random(const point3& origin) const override {
             vec3 direction = center1 - origin;
             auto distance_squared = direction.length_squared();
-            onb uvw;
-            uvw.build_from_w(direction);
-            return uvw.local(random_to_sphere(radius, distance_squared));
+            onb uvw(direction);
+            return uvw.transform(random_to_sphere(radius, distance_squared));
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
 

--- a/src/TheRestOfYourLife/onb.h
+++ b/src/TheRestOfYourLife/onb.h
@@ -16,31 +16,20 @@
 
 class onb {
   public:
-    onb() {}
-
-    vec3 operator[](int i) const { return axis[i]; }
-    vec3& operator[](int i) { return axis[i]; }
-
-    vec3 u() const { return axis[0]; }
-    vec3 v() const { return axis[1]; }
-    vec3 w() const { return axis[2]; }
-
-    vec3 local(double a, double b, double c) const {
-        return a*u() + b*v() + c*w();
+    onb(const vec3& n) {
+        axis[2] = unit_vector(n);
+        vec3 a = (std::fabs(axis[2].x()) > 0.9) ? vec3(0,1,0) : vec3(1,0,0);
+        axis[1] = unit_vector(cross(axis[2], a));
+        axis[0] = cross(axis[2], axis[1]);
     }
 
-    vec3 local(const vec3& a) const {
-        return a.x()*u() + a.y()*v() + a.z()*w();
-    }
+    const vec3& u() const { return axis[0]; }
+    const vec3& v() const { return axis[1]; }
+    const vec3& w() const { return axis[2]; }
 
-    void build_from_w(const vec3& w) {
-        vec3 unit_w = unit_vector(w);
-        vec3 a = (std::fabs(unit_w.x()) > 0.9) ? vec3(0,1,0) : vec3(1,0,0);
-        vec3 v = unit_vector(cross(unit_w, a));
-        vec3 u = cross(unit_w, v);
-        axis[0] = u;
-        axis[1] = v;
-        axis[2] = unit_w;
+    vec3 transform(const vec3& v) const {
+        // Transform from basis coordinates to local space.
+        return (v[0] * axis[0]) + (v[1] * axis[1]) + (v[2] * axis[2]);
     }
 
   private:

--- a/src/TheRestOfYourLife/pdf.h
+++ b/src/TheRestOfYourLife/pdf.h
@@ -42,7 +42,7 @@ class sphere_pdf : public pdf {
 
 class cosine_pdf : public pdf {
   public:
-    cosine_pdf(const vec3& w) { uvw.build_from_w(w); }
+    cosine_pdf(const vec3& w) : uvw(w) {}
 
     double value(const vec3& direction) const override {
         auto cosine_theta = dot(unit_vector(direction), uvw.w());
@@ -50,7 +50,7 @@ class cosine_pdf : public pdf {
     }
 
     vec3 generate() const override {
-        return uvw.local(random_cosine_direction());
+        return uvw.transform(random_cosine_direction());
     }
 
   private:

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -87,9 +87,8 @@ class sphere : public hittable {
     vec3 random(const point3& origin) const override {
         vec3 direction = center1 - origin;
         auto distance_squared = direction.length_squared();
-        onb uvw;
-        uvw.build_from_w(direction);
-        return uvw.local(random_to_sphere(radius, distance_squared));
+        onb uvw(direction);
+        return uvw.transform(random_to_sphere(radius, distance_squared));
     }
 
   private:


### PR DESCRIPTION
The `onb` class implemented several unused methods, so I've removed them in the interest of simplicity. These include the operator[] methods to retrieve the basis axes, as well as a transform function that took three individual double values. Finally, instead of having an uninitialized form with a `build_from_w()` function, the class now requires a vector at construction time, consistent with our use of the class.

I've renamed `local()` to `transform()` for a bit more clarity, without trying to name either the input space or the result space, as "local" means different things at different times, and to different people.

Resolves #1088