### PR TITLE
[Book2] Add missing word in comment of Listing 53

### DIFF
--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -3038,7 +3038,7 @@ test method from the hit method.
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight
-            // Determine the hit point lies within the planar shape using its plane coordinates.
+            // Determine if the hit point lies within the planar shape using its plane coordinates.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
             auto intersection = r.at(t);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ highlight

--- a/src/TheNextWeek/quad.h
+++ b/src/TheNextWeek/quad.h
@@ -49,7 +49,7 @@ class quad : public hittable {
         if (!ray_t.contains(t))
             return false;
 
-        // Determine the hit point lies within the planar shape using its plane coordinates.
+        // Determine if the hit point lies within the planar shape using its plane coordinates.
         auto intersection = r.at(t);
         vec3 planar_hitpt_vector = intersection - Q;
         auto alpha = dot(w, cross(planar_hitpt_vector, v));

--- a/src/TheRestOfYourLife/quad.h
+++ b/src/TheRestOfYourLife/quad.h
@@ -51,7 +51,7 @@ class quad : public hittable {
         if (!ray_t.contains(t))
             return false;
 
-        // Determine the hit point lies within the planar shape using its plane coordinates.
+        // Determine if the hit point lies within the planar shape using its plane coordinates.
         auto intersection = r.at(t);
         vec3 planar_hitpt_vector = intersection - Q;
         auto alpha = dot(w, cross(planar_hitpt_vector, v));


### PR DESCRIPTION
Fixes a typo in Book 2, Listing 53, by adding a missing `if` in the comment.
Resolves #1560