### PR TITLE
CSS reformatting and fixes

### DIFF
--- a/style/book.css
+++ b/style/book.css
@@ -19,7 +19,9 @@ div.indented {
 ** Table of Contents
 ** -----------------------------------------------------------------------------------------------*/
 
-.md .longTOC, .md .mediumTOC, .md .shortTOC {
+.md .longTOC,
+.md .mediumTOC,
+.md .shortTOC {
     font-family: sans-serif;
 }
 
@@ -37,7 +39,9 @@ div.indented {
     border-bottom: solid 4px #777;
 }
 
-.md .longTOC, .md .mediumTOC, .md .shortTOC {
+.md .longTOC,
+.md .mediumTOC,
+.md .shortTOC {
     font-family: sans-serif;
 }
 
@@ -99,9 +103,12 @@ div.indented {
     background: #e4e4e0;
 }
 
-/* Hilight.js Syntax Coloring */
+/* Highlight.js Syntax Coloring */
 
-.hljs-built_in, .hljs-params, .hljs-type, .hljs-literal {
+.hljs-built_in,
+.hljs-params,
+.hljs-type,
+.hljs-literal {
     color: #222;
 }
 
@@ -137,7 +144,7 @@ div.indented {
 
 .md code > .delete {
     text-decoration: line-through;
-    background-color: #;
+    background-color: #fdd;
     color: #a0a0a0;
     background: #e0cfcc;
 }

--- a/style/website.css
+++ b/style/website.css
@@ -23,7 +23,10 @@ div.content {
     margin: 0 auto;
 }
 
-h1, h2, h3, .banner {
+h1,
+h2,
+h3,
+.banner {
     font-family: Copperplate Gothic, Georgia, serif;
 }
 


### PR DESCRIPTION
- Inspired by https://github.com/RayTracing/gpu-tracing/pull/9, I'm adopting the CSS code style of having one selector per line with trailing commas for definitions that apply to multiple selectors.

- Corrected "Hilight.js" to "Highlight.js". There _is_ a hilight.js, but it looks like the syntax highlighting package used by Markdeep is highlight.js (https://highlightjs.org/).

- Fixed background-color syntax bug.