### PR TITLE
Wrap listing and figure captions to single line

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -1251,9 +1251,7 @@ know more about the specific geometry.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [front-face-tracking]: <kbd>[hittable.h]</kbd>
-        Adding front-face tracking to hit_record
-    ]
+    [Listing [front-face-tracking]: <kbd>[hittable.h]</kbd> Adding front-face tracking to hit_record]
 
 <div class='together'>
 And then we add the surface side determination to the class:
@@ -1448,9 +1446,7 @@ assumption in mind.
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ delete
     #include "ray.h"
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [assume-rtw-hittable]: <kbd>[hittable.h]</kbd>
-        Assume rtweekend.h inclusion for hittable.h
-    ]
+    [Listing [assume-rtw-hittable]: <kbd>[hittable.h]</kbd> Assume rtweekend.h inclusion for hittable.h]
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ delete
@@ -1463,9 +1459,7 @@ assumption in mind.
     using std::make_shared;
     using std::shared_ptr;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [assume-rtw-hittable-list]: <kbd>[hittable_list.h]</kbd>
-        Assume rtweekend.h inclusion for hittable_list.h
-    ]
+    [Listing [assume-rtw-hittable-list]: <kbd>[hittable_list.h]</kbd> Assume rtweekend.h inclusion for hittable_list.h]
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++ delete
@@ -1692,9 +1686,7 @@ and a maximum. We'll end up using this class quite often as we proceed.
         ...
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [hittable-list-with-interval]: <kbd>[hittable_list.h]</kbd>
-        hittable_list::hit() using interval
-    ]
+    [Listing [hittable-list-with-interval]: <kbd>[hittable_list.h]</kbd> hittable_list::hit() using interval]
 
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -2044,9 +2036,7 @@ want to use this, you can obtain a random number with the conditions we need as 
         return distribution(generator);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [random-double-alt]: <kbd>[rtweekend.h]</kbd>
-        random_double(), alternate implementation
-    ]
+    [Listing [random-double-alt]: <kbd>[rtweekend.h]</kbd> random_double(), alternate implementation]
 
 
 Generating Pixels with Multiple Samples
@@ -2429,9 +2419,7 @@ return 50% of the color from a bounce. We should expect to get a nice gray color
         }
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [ray-color-random-unit]: <kbd>[camera.h]</kbd>
-        ray_color() using a random ray direction
-    ]
+    [Listing [ray-color-random-unit]: <kbd>[camera.h]</kbd> ray_color() using a random ray direction]
 
 <div class='together'>
 ... Indeed we do get rather nice gray spheres:
@@ -2577,9 +2565,7 @@ to address this is just to ignore hits that are very close to the calculated int
         }
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [reflect-tolerance]: <kbd>[camera.h]</kbd>
-        Calculating reflected ray origins with tolerance
-    ]
+    [Listing [reflect-tolerance]: <kbd>[camera.h]</kbd> Calculating reflected ray origins with tolerance]
 
 <div class='together'>
 This gets rid of the shadow acne problem. Yes it is really called that. Here's the result:
@@ -2895,9 +2881,7 @@ To achieve this, `hit_record` needs to be told the material that is assigned to 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [sphere-material]: <kbd>[sphere.h]</kbd>
-        Ray-sphere intersection with added material information
-    ]
+    [Listing [sphere-material]: <kbd>[sphere.h]</kbd> Ray-sphere intersection with added material information]
 
 </div>
 
@@ -3391,9 +3375,7 @@ And the dielectric material that always refracts is:
         double refraction_index;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [dielectric-always-refract]: <kbd>[material.h]</kbd>
-        Dielectric material class that always refracts
-    ]
+    [Listing [dielectric-always-refract]: <kbd>[material.h]</kbd> Dielectric material class that always refracts]
 
 </div>
 
@@ -3521,9 +3503,7 @@ And the dielectric material that always refracts (when possible) is:
         double refraction_index;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [dielectric-with-refraction]: <kbd>[material.h]</kbd>
-        Dielectric material class with reflection
-    ]
+    [Listing [dielectric-with-refraction]: <kbd>[material.h]</kbd> Dielectric material class with reflection]
 
 </div>
 

--- a/books/RayTracingTheNextWeek.html
+++ b/books/RayTracingTheNextWeek.html
@@ -304,9 +304,7 @@ for the time of intersection:
         ...
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [material-time]: <kbd>[material.h]</kbd>
-        Handle ray time in the material::scatter() methods
-    ]
+    [Listing [material-time]: <kbd>[material.h]</kbd> Handle ray time in the material::scatter() methods]
 
 
 Putting Everything Together
@@ -363,9 +361,7 @@ $t=0$ to $\mathbf{C} + (0, r/2, 0)$ at time $t=1$:
         cam.render(world);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [scene-spheres-moving]: <kbd>[main.cc]</kbd>
-        Last book's final scene, but with moving spheres
-    ]
+    [Listing [scene-spheres-moving]: <kbd>[main.cc]</kbd> Last book's final scene, but with moving spheres]
 
 <div class='together'>
 This gives the following result:
@@ -800,9 +796,7 @@ constructor to do this:
         double size() const {
         ...
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [interval-from-intervals]: <kbd>[interval.h]</kbd>
-        Interval constructor from two intervals
-    ]
+    [Listing [interval-from-intervals]: <kbd>[interval.h]</kbd> Interval constructor from two intervals]
 
 </div>
 
@@ -1196,9 +1190,7 @@ Now to implement the empty `aabb` code and the new `aabb::longest_axis()` functi
     const aabb aabb::empty    = aabb(interval::empty,    interval::empty,    interval::empty);
     const aabb aabb::universe = aabb(interval::universe, interval::universe, interval::universe);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [aabb-empty-and-axis]: <kbd>[aabb.h]</kbd>
-        New aabb constants and longest_axis() function
-    ]
+    [Listing [aabb-empty-and-axis]: <kbd>[aabb.h]</kbd> New aabb constants and longest_axis() function]
 
 As before, you should see identical results to [image 1](#image-bouncing-spheres), but rendering a
 little bit faster. On my system, this yields something like an additional 18% render speedup. Not
@@ -3297,9 +3289,7 @@ the new `color_from_emission` value.
         }
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [ray-color-emitted]: <kbd>[camera.h]</kbd>
-        ray_color function with background and emitting materials
-    ]
+    [Listing [ray-color-emitted]: <kbd>[camera.h]</kbd> ray_color function with background and emitting materials]
 
 <div class='together'>
 `main()` is updated to set the background color for the prior scenes:
@@ -3748,9 +3738,7 @@ with an addition operator as well.
         return ival + displacement;
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [interval-plus-displacement]: <kbd>[interval.h]</kbd>
-        The interval + displacement operator
-    ]
+    [Listing [interval-plus-displacement]: <kbd>[interval.h]</kbd> The interval + displacement operator]
 
 
 Instance Rotation

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -1442,9 +1442,7 @@ We can then substitute $1 \cdot \cos \theta$ with $d_z$ giving us:
         std::cout << "I = " << sum / N << '\n';
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [main-sphereimp]: <kbd>[sphere_importance.cc]</kbd>
-        Generating importance-sampled points on the unit sphere
-    ]
+    [Listing [main-sphereimp]: <kbd>[sphere_importance.cc]</kbd> Generating importance-sampled points on the unit sphere]
 
 The analytic answer is $\frac{4}{3} \pi = 4.188790204786391$ -- if you remember enough advanced
 calc, check me! And the code above produces that. The key point here is that all of the integrals
@@ -1718,9 +1716,7 @@ PDF function for Lambertian materials:
         shared_ptr<texture> tex;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [class-lambertian-impsample]: <kbd>[material.h]</kbd>
-        Lambertian material, modified for importance sampling
-    ]
+    [Listing [class-lambertian-impsample]: <kbd>[material.h]</kbd> Lambertian material, modified for importance sampling]
 
 </div>
 
@@ -1763,9 +1759,7 @@ And the `camera::ray_color` function gets a minor modification:
         }
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [ray-color-impsample]: <kbd>[camera.h]</kbd>
-        The ray_color function, modified for importance sampling
-    ]
+    [Listing [ray-color-impsample]: <kbd>[camera.h]</kbd> The ray_color function, modified for importance sampling]
 
 </div>
 
@@ -1818,9 +1812,7 @@ a noisier image:
             return color_from_emission + color_from_scatter;
         }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [ray-color-uniform]: <kbd>[camera.h]</kbd>
-        The ray_color function, now with a uniform PDF in the denominator
-    ]
+    [Listing [ray-color-uniform]: <kbd>[camera.h]</kbd> The ray_color function, now with a uniform PDF in the denominator]
 
 You should get a very similar result to before, only with slightly more noise, it may be hard to
 see.
@@ -2116,9 +2108,7 @@ Here's a function that generates random vectors weighted by this PDF:
         return vec3(x, y, z);
     }
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [random-cosine-direction]: <kbd>[vec3.h]</kbd>
-        Random cosine direction utility function
-    ]
+    [Listing [random-cosine-direction]: <kbd>[vec3.h]</kbd> Random cosine direction utility function]
 
 </div>
 
@@ -2425,9 +2415,7 @@ And here we add the accompanying changes to the camera class:
         ...
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [scatter-ray-color]: <kbd>[camera.h]</kbd>
-        Updated ray_color function with returned PDF value
-    ]
+    [Listing [scatter-ray-color]: <kbd>[camera.h]</kbd> Updated ray_color function with returned PDF value]
 
 <div class='together'>
 Which produces:
@@ -2471,9 +2459,7 @@ But first, let's quickly update the `isotropic` material:
         shared_ptr<texture> tex;
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [class-isotropic-impsample]: <kbd>[material.h]</kbd>
-        Isotropic material, modified for importance sampling
-    ]
+    [Listing [class-isotropic-impsample]: <kbd>[material.h]</kbd> Isotropic material, modified for importance sampling]
 
 </div>
 
@@ -2670,9 +2656,7 @@ that by letting the `hittable::emitted()` function take extra information:
         }
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [emitted-ray-color]: <kbd>[camera.h]</kbd>
-        Material emission, camera::ray_color() changes
-    ]
+    [Listing [emitted-ray-color]: <kbd>[camera.h]</kbd> Material emission, camera::ray_color() changes]
 
 
 <div class='together'>
@@ -3601,9 +3585,7 @@ materials that we're treating specularly.
         }
     };
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    [Listing [ray-color-implicit]: <kbd>[camera.h]</kbd>
-        Ray color function with implicitly-sampled rays
-    ]
+    [Listing [ray-color-implicit]: <kbd>[camera.h]</kbd> Ray color function with implicitly-sampled rays]
 
 </div>
 


### PR DESCRIPTION
The prior version had caption blocks wrapped to maintain the 100-character width source. However, Markdeep suffered a regression at v1.16 (current version v1.17 at this commit) where everything past the first linefeed in the caption block is ignored. To work around this bug, this change converts all caption lines to a single block. Note that figures/images still have an optional linefeed before the closing square bracket and the parenthesized target.

Resolves #1583