### PR TITLE
Spell out MC and LV abbreviations

### DIFF
--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -61,14 +61,14 @@ Let’s start with one of the simplest Monte Carlo programs. If you're not famil
 programs, then it'll be good to pause and catch you up. There are two kinds of randomized
 algorithms: Monte Carlo and Las Vegas. Randomized algorithms can be found everywhere in computer
 graphics, so getting a decent foundation isn't a bad idea. A randomized algorithm uses some amount
-of randomness in its computation. A Las Vegas (LV) random algorithm always produces the correct
-result, whereas a Monte Carlo (MC) algorithm _may_ produce a correct result--and frequently gets it
-wrong! But for especially complicated problems such as ray tracing, we may not place as huge a
-priority on being perfectly exact as on getting an answer in a reasonable amount of time. LV
-algorithms will eventually arrive at the correct result, but we can't make too many guarantees on
-how long it will take to get there. The classic example of an LV algorithm is the _quicksort_
-sorting algorithm. The quicksort algorithm will always complete with a fully sorted list, but, the
-time it takes to complete is random. Another good example of an LV algorithm is the code that we use
+of randomness in its computation. A Las Vegas random algorithm always produces the correct result,
+whereas a Monte Carlo algorithm _may_ produce a correct result--and frequently gets it wrong! But
+for especially complicated problems such as ray tracing, we may not place as huge a priority on
+being perfectly exact as on getting an answer in a reasonable amount of time. Las Vegas algorithms
+will eventually arrive at the correct result, but we can't make too many guarantees on how long it
+will take to get there. The classic example of a Las Vegas algorithm is the _quicksort_ sorting
+algorithm. The quicksort algorithm will always complete with a fully sorted list, but, the time it
+takes to complete is random. Another good example of a Las Vegas algorithm is the code that we use
 to pick a random point in a unit sphere:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
@@ -84,11 +84,11 @@ to pick a random point in a unit sphere:
 
 This code will always eventually arrive at a random point in the unit sphere, but we can't say
 beforehand how long it'll take. It may take only 1 iteration, it may take 2, 3, 4, or even longer.
-Whereas, an MC program will give a statistical estimate of an answer, and this estimate will get
-more and more accurate the longer you run it. Which means that at a certain point, we can just
+Whereas, a Monte Carlo program will give a statistical estimate of an answer, and this estimate will
+get more and more accurate the longer you run it. Which means that at a certain point, we can just
 decide that the answer is accurate _enough_ and call it quits. This basic characteristic of simple
-programs producing noisy but ever-better answers is what MC is all about, and is especially good for
-applications like graphics where great accuracy is not needed.
+programs producing noisy but ever-better answers is what Monte Carlo is all about, and is especially
+good for applications like graphics where great accuracy is not needed.
 
 
 Estimating Pi


### PR DESCRIPTION
We used MC (Monte Carlo) and LV (Las Vegas) abbreviations in a couple of paragraphs. It's easier to read these out full.