### PR TITLE
now nonskippdf materials can be added to lights hittable list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 build/
 /*.ppm
+
+.vscode/

--- a/src/TheRestOfYourLife/hittable_list.h
+++ b/src/TheRestOfYourLife/hittable_list.h
@@ -59,9 +59,14 @@ class hittable_list : public hittable {
         return sum;
     }
 
-    vec3 random(const point3& origin) const override {
-        auto int_size = int(objects.size());
-        return objects[random_int(0, int_size-1)]->random(origin);
+       vec3 random(const point3& origin) const override {
+        int int_size = int(objects.size());
+        auto vec = objects[random_int(0, int_size-1)]->random(origin);
+        while (vec.is_nan()) {
+            vec = objects[random_int(0, int_size-1)]->random(origin);
+        }
+
+        return vec;
     }
 
   private:

--- a/src/TheRestOfYourLife/main.cc
+++ b/src/TheRestOfYourLife/main.cc
@@ -44,7 +44,8 @@ int main() {
 
     // Glass Sphere
     auto glass = make_shared<dielectric>(1.5);
-    world.add(make_shared<sphere>(point3(190,90,190), 90, glass));
+    auto nonglass = make_shared<lambertian>(color(0.8, 0.2, 0.4));
+    world.add(make_shared<sphere>(point3(190,90,190), 90, nonglass));
 
     // Light Sources
     auto empty_material = shared_ptr<material>();
@@ -56,9 +57,9 @@ int main() {
     camera cam;
 
     cam.aspect_ratio      = 1.0;
-    cam.image_width       = 600;
-    cam.samples_per_pixel = 100;
-    cam.max_depth         = 50;
+    cam.image_width       = 400;
+    cam.samples_per_pixel = 1000;
+    cam.max_depth         = 10;
     cam.background        = color(0,0,0);
 
     cam.vfov     = 40;

--- a/src/TheRestOfYourLife/sphere.h
+++ b/src/TheRestOfYourLife/sphere.h
@@ -76,11 +76,14 @@ class sphere : public hittable {
         if (!this->hit(ray(origin, direction), interval(0.001, infinity), rec))
             return 0;
 
-        auto dist_squared = (center.at(0) - origin).length_squared();
-        auto cos_theta_max = std::sqrt(1 - radius*radius/dist_squared);
+        auto cos_theta_max = sqrt(1 - radius*radius/(center.at(0) - origin).length_squared());
         auto solid_angle = 2*pi*(1-cos_theta_max);
 
-        return  1 / solid_angle;
+        if (std::isnan(solid_angle) || std::fabs(solid_angle) < 1e-3) {
+            return 0;
+        } else {
+            return  1 / solid_angle;
+        }
     }
 
     vec3 random(const point3& origin) const override {

--- a/src/TheRestOfYourLife/vec3.h
+++ b/src/TheRestOfYourLife/vec3.h
@@ -59,6 +59,10 @@ class vec3 {
         return (std::fabs(e[0]) < s) && (std::fabs(e[1]) < s) && (std::fabs(e[2]) < s);
     }
 
+    bool is_nan() const {
+        return std::isnan(e[0]) || std::isnan(e[1]) || std::isnan(e[2]);
+    }
+
     static vec3 random() {
         return vec3(random_double(), random_double(), random_double());
     }


### PR DESCRIPTION
Hello, i' ve modified the pdf_value function for the sphere and the random hittable_list method to include controls for NaNs and zero division, now even materials like a lambertian can be added to the lights hittable list. To see the details and the changes refer to the relative issue [](https://github.com/RayTracing/raytracing.github.io/issues/1668)(https://github.com/RayTracing/raytracing.github.io/issues/1668), i hope this could be usefull.