### PR TITLE
Add missing space to multiplication

### DIFF
--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -3192,7 +3192,7 @@ direction. The mixture density class is actually pretty straightforward:
         }
 
         double value(const vec3& direction) const override {
-            return 0.5 * p[0]->value(direction) + 0.5 *p[1]->value(direction);
+            return 0.5 * p[0]->value(direction) + 0.5 * p[1]->value(direction);
         }
 
         vec3 generate() const override {

--- a/src/TheRestOfYourLife/pdf.h
+++ b/src/TheRestOfYourLife/pdf.h
@@ -84,7 +84,7 @@ class mixture_pdf : public pdf {
     }
 
     double value(const vec3& direction) const override {
-        return 0.5 * p[0]->value(direction) + 0.5 *p[1]->value(direction);
+        return 0.5 * p[0]->value(direction) + 0.5 * p[1]->value(direction);
     }
 
     vec3 generate() const override {


### PR DESCRIPTION
Adds a space in for the multiplication, for consistency in the code.

Closes: https://github.com/RayTracing/raytracing.github.io/issues/1691