### PR TITLE
fixed fuzz value for material_right to match reference image

### DIFF
--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -3651,7 +3651,7 @@ Here's the code:
     auto material_left   = make_shared<dielectric>(1.50);
     auto material_bubble = make_shared<dielectric>(1.00 / 1.50);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    auto material_right  = make_shared<metal>(color(0.8, 0.6, 0.2), 0.0);
+    auto material_right  = make_shared<metal>(color(0.8, 0.6, 0.2), 1.0);
 
     world.add(make_shared<sphere>(point3( 0.0, -100.5, -1.0), 100.0, material_ground));
     world.add(make_shared<sphere>(point3( 0.0,    0.0, -1.2),   0.5, material_center));


### PR DESCRIPTION
In chapter **11.5. Modeling a Hollow Glass Sphere** of **Ray Tracing in One Weekend**, there is a typo in the code. 

**Listing 79** highlights the changes to the dielectric material. Not highlighted, is the fuzz value of for the metal material, which has been set to `0.0`. This seems to be a typo considering the line is not highlighted, and, more importantly, the reference **image 18** still shows a rough metal material, indicative of a fuzz value greater than `0.0`.

fixes #1673 