### PR TITLE
hittable::emitted() should be material::emitted()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Change Log / Ray Tracing in One Weekend
               without recombining coordinates (#1733)
 
 ### The Rest of Your Life
+  - Fix    -- Typo: hittable::emitted() should be material::emitted() (#1736)
 
 
 ----------------------------------------------------------------------------------------------------

--- a/books/RayTracingTheRestOfYourLife.html
+++ b/books/RayTracingTheRestOfYourLife.html
@@ -2625,7 +2625,7 @@ Switching to Unidirectional Light
 ----------------------------------
 The noisy pops around the light on the ceiling are because the light is two-sided and there is a
 small space between light and ceiling. We probably want to have the light just emit down. We can do
-that by letting the `hittable::emitted()` function take extra information:
+that by letting the `material::emitted()` function take extra information:
 
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class material {


### PR DESCRIPTION
Fixes typo in book 3, chapter 9.3.

Resolves #1736