### PR TITLE
fixed fuzz value for material_right to match reference image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Change Log / Ray Tracing in One Weekend
   - Change -- Improve lifetime of float image data `fdata` in `rtw_image` class (#1723)
 
 ### In One Weekend
+  - Fix    -- Fixed fuzz value for `material_right` to match the reference image
 
 ### The Next Week
   - Fix    -- Remove premature source line for call to `get_sphere_uv` (#1701)

--- a/books/RayTracingInOneWeekend.html
+++ b/books/RayTracingInOneWeekend.html
@@ -3652,7 +3652,7 @@ Here's the code:
     auto material_left   = make_shared<dielectric>(1.50);
     auto material_bubble = make_shared<dielectric>(1.00 / 1.50);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
-    auto material_right  = make_shared<metal>(color(0.8, 0.6, 0.2), 0.0);
+    auto material_right  = make_shared<metal>(color(0.8, 0.6, 0.2), 1.0);
 
     world.add(make_shared<sphere>(point3( 0.0, -100.5, -1.0), 100.0, material_ground));
     world.add(make_shared<sphere>(point3( 0.0,    0.0, -1.2),   0.5, material_center));

--- a/books/acknowledgments.md.html
+++ b/books/acknowledgments.md.html
@@ -52,6 +52,7 @@ Acknowledgments
   - Joey Cho
   - [John Kilpatrick](https://github.com/rjkilpatrick)
   - [Kaan Eraslan](https://github.com/D-K-E)
+  - [Lennart Breede](https://github.com/LBreede)
   - [Lorenzo Mancini](https://github.com/lmancini)
   - [Manas Kale](https://github.com/manas96)
   - Marcus Ottosson


### PR DESCRIPTION
In chapter **11.5. Modeling a Hollow Glass Sphere** of **Ray Tracing in One Weekend**, there is a typo in the code. 

**Listing 79** highlights the changes to the dielectric material. Not highlighted, is the fuzz value of for the metal material, which has been set to `0.0`. This seems to be a typo considering the line is not highlighted, and, more importantly, the reference **image 18** still shows a rough metal material, indicative of a fuzz value greater than `0.0`.

fixes #1673 